### PR TITLE
Design System: Switch - allow axe test to pick up background color 

### DIFF
--- a/packages/design-system/src/components/switch/index.js
+++ b/packages/design-system/src/components/switch/index.js
@@ -79,19 +79,6 @@ const SwitchContainer = styled.div`
             background-color: ${theme.colors.interactiveBg.primaryHover};
           }
         `};
-
-          cursor: default;
-          background: ${theme.colors.divider.tertiary};
-
-          ${SlidingButton} {
-            background-color: ${theme.colors.interactiveBg.disable};
-          }
-        `
-      : css`
-          :hover ${SlidingButton} {
-            background-color: ${theme.colors.interactiveBg.primaryHover};
-          }
-        `};
 `;
 
 const HiddenRadioButton = styled.input.attrs({ type: 'radio' })`
@@ -136,15 +123,6 @@ const RadioButtonLabel = styled(Text).attrs({
   ${({ disabled, theme }) =>
     disabled &&
     css`
-      cursor: default;
-      color: ${theme.colors.fg.disable};
-    `}
-
-  /* add focus styling on the slider when the hidden input is focused */
-  :focus-within ~ span {
-    ${themeHelpers.focusCSS};
-  }
-
       cursor: default;
       color: ${theme.colors.fg.disable};
     `}

--- a/packages/design-system/src/components/switch/index.js
+++ b/packages/design-system/src/components/switch/index.js
@@ -45,7 +45,6 @@ const SlidingButton = styled.span`
   width: 50%;
   height: ${SWITCH_HEIGHT}px;
   border-radius: 100px;
-  background-color: ${({ theme }) => theme.colors.interactiveBg.primaryNormal};
   transition: all 0.15s ease-out;
   z-index: 0;
 
@@ -68,6 +67,19 @@ const SwitchContainer = styled.div`
   ${({ disabled, theme }) =>
     disabled
       ? css`
+          cursor: default;
+          background: ${theme.colors.divider.tertiary};
+
+          ${SlidingButton} {
+            background-color: ${theme.colors.interactiveBg.disable};
+          }
+        `
+      : css`
+          :hover ${SlidingButton} {
+            background-color: ${theme.colors.interactiveBg.primaryHover};
+          }
+        `};
+
           cursor: default;
           background: ${theme.colors.divider.tertiary};
 
@@ -111,16 +123,28 @@ const RadioButtonLabel = styled(Text).attrs({
   z-index: 1;
   color: ${({ isActive, theme }) =>
     isActive ? theme.colors.inverted.fg.primary : theme.colors.fg.secondary};
+  background-color: ${({ isActive, theme }) =>
+    isActive && theme.colors.interactiveBg.primaryNormal};
+  border-radius: 100px;
   cursor: pointer;
   overflow: hidden;
   text-align: center;
   text-overflow: ellipsis;
   white-space: nowrap;
-  transition: color 0.15s ease-out;
+  transition: all 0.15s ease-out;
 
   ${({ disabled, theme }) =>
     disabled &&
     css`
+      cursor: default;
+      color: ${theme.colors.fg.disable};
+    `}
+
+  /* add focus styling on the slider when the hidden input is focused */
+  :focus-within ~ span {
+    ${themeHelpers.focusCSS};
+  }
+
       cursor: default;
       color: ${theme.colors.fg.disable};
     `}

--- a/packages/story-editor/src/components/inspector/karma/inspectorTabs.karma.js
+++ b/packages/story-editor/src/components/inspector/karma/inspectorTabs.karma.js
@@ -37,10 +37,7 @@ describe('Inspector Tabs integration', () => {
     fixture.restore();
   });
 
-  // Disable reason: false positive for aXe violation
-  // TODO: https://github.com/google/web-stories-wp/issues/9943
-  // eslint-disable-next-line jasmine/no-disabled-tests
-  xdescribe('Inspector Tabs aXe tests', () => {
+  describe('Inspector Tabs aXe tests', () => {
     it('should have no aXe violations', async () => {
       const { documentTab } = fixture.editor.inspector;
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
The axe test coverage is failing in the Design System's Switch component. This is due to background-color being set on an absolutely positioned span which is flagging as color contrast of 1.59 (foreground color: #131516, background color: #373a3b, the real contrast is 7.02. 

## Summary

<!-- A brief description of what this PR does. -->
Allows the axe test coverage to grab the correct background color from the Switch component. 

## Relevant Technical Choices

<!-- Please describe your changes. -->
Changing the background color on the `RadioButtonLabel` when the button `isActive`. Added the radius here as to keep the rounded edges. Also, changed the `RadioButtonLabel` to have `all` on the transition in order to maintain the nice little slidey animation. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->
### Before
![before](https://user-images.githubusercontent.com/1820266/147130778-0d262566-d2e4-4678-b652-dfdc2f5bcc17.gif)

### After
![after](https://user-images.githubusercontent.com/1820266/147130764-5a879b2e-0226-4cce-a43c-f2d6edba1fe2.gif)

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9943 
