### PR TITLE
Performance: Limit Renders in the Layers Panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32059,11 +32059,6 @@
         "react": "^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0"
       }
     },
-    "node_modules/react-pure-render": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/react-pure-render/-/react-pure-render-1.0.2.tgz",
-      "integrity": "sha1-nYqSjH8sN1E8LQZOV7Pjw1bp+rs="
-    },
     "node_modules/react-refresh": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
@@ -34034,6 +34029,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/shallow-equal": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
+      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
     },
     "node_modules/shallowequal": {
       "version": "1.1.0",
@@ -39593,8 +39593,8 @@
         "prop-types": "^15.8.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-pure-render": "^1.0.2",
         "resize-observer-polyfill": "^1.5.1",
+        "shallow-equal": "^1.2.1",
         "use-context-selector": "^1.2.11",
         "use-debounce": "^7.0.1"
       },
@@ -47495,8 +47495,8 @@
         "prop-types": "^15.8.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-pure-render": "^1.0.2",
         "resize-observer-polyfill": "^1.5.1",
+        "shallow-equal": "^1.2.1",
         "use-context-selector": "^1.2.11",
         "use-debounce": "^7.0.1"
       },
@@ -64912,11 +64912,6 @@
         "prop-types": "^15.5.8"
       }
     },
-    "react-pure-render": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/react-pure-render/-/react-pure-render-1.0.2.tgz",
-      "integrity": "sha1-nYqSjH8sN1E8LQZOV7Pjw1bp+rs="
-    },
     "react-refresh": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
@@ -66493,6 +66488,11 @@
       "requires": {
         "kind-of": "^6.0.2"
       }
+    },
+    "shallow-equal": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
+      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
     },
     "shallowequal": {
       "version": "1.1.0",

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,0 +1,877 @@
+{
+  "name": "@web-stories-wp/react",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@web-stories-wp/react",
+      "dependencies": {
+        "prop-types": "^15.7.2",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2",
+        "resize-observer-polyfill": "^1.5.1",
+        "shallow-equal": "^1.2.1",
+        "use-context-selector": "^1.2.11",
+        "use-debounce": "^7.0.1"
+      },
+      "devDependencies": {
+        "@testing-library/react": "^12.1.2"
+      },
+      "engines": {
+        "node": ">= 16",
+        "npm": ">= 7.3"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.16.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.7.tgz",
+      "integrity": "sha512-aKpPMfLvGO3Q97V0qhw/V2SWNWlwfJknuwAunU7wZLSfrM4xTBvg7E5opUVi1kJTBKihE38CPg4nBiqX83PWYw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "node_modules/@babel/highlight/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
+      "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+      "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.11.1.tgz",
+      "integrity": "sha512-3KQDyx9r0RKYailW2MiYrSSKEfH0GTkI51UGEvJenvcoDoeRYs0PZpi2SXqtnMClQvCqdtTTpOfFETDTVADpAg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^5.0.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.4.4",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.2.tgz",
+      "integrity": "sha512-ihQiEOklNyHIpo2Y8FREkyD1QAea054U0MVbwH1m8N9TxeFz+KoJ9LkqoKqJlzx2JDm56DVwaJ1r36JYxZM05g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
+      "dev": true
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
+      "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
+      "dev": true
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
+      "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
+      "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg==",
+      "dev": true
+    },
+    "node_modules/@types/yargs": {
+      "version": "16.0.4",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+      "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
+      "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
+      "dev": true
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
+      "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.10.tgz",
+      "integrity": "sha512-Xu9mD0UjrJisTmv7lmVSDMagQcU9R5hwAbxsaAE/35XPnPLJobbuREfV/rraiSaEj/UOvgrzQs66zyTWTlyd+g==",
+      "dev": true
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "dev": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.2.tgz",
+      "integrity": "sha512-p0wNtJ9oLuvgOQDEIZ9zQjZffK7KtyR6Si0jnXULIDwrlNF8Cuir3AZP0hHv0jmKuNN/edOnbMjnzd4uTcmWiw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^27.4.2",
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.0.tgz",
+      "integrity": "sha512-fDGekdaHh65eI3lMi5OnErU6a8Ighg2KjcjQxO7m8VHyWjcPyj5kiOgV1LQDOOOgVy3+5FgjXvdSSX7B8/5/4g==",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "scheduler": "^0.20.2"
+      },
+      "peerDependencies": {
+        "react": "17.0.2"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "dev": true
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+    },
+    "node_modules/scheduler": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "node_modules/shallow-equal": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
+      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/use-context-selector": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/use-context-selector/-/use-context-selector-1.3.9.tgz",
+      "integrity": "sha512-YgzRyeFjoJXwFn2qLVAuIbV6EQ8DOuzu3SS/eiCxyAyvBhcn02jYSz8c5v22QQU3LW6Ez/Iyo62kKvS7Kdqt3A==",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": "*",
+        "react-native": "*",
+        "scheduler": ">=0.19.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-debounce": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-7.0.1.tgz",
+      "integrity": "sha512-fOrzIw2wstbAJuv8PC9Vg4XgwyTLEOdq4y/Z3IhVl8DAE4svRcgyEUvrEXu+BMNgMoc3YND6qLT61kkgEKXh7Q==",
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    }
+  },
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.16.7"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.7.tgz",
+      "integrity": "sha512-aKpPMfLvGO3Q97V0qhw/V2SWNWlwfJknuwAunU7wZLSfrM4xTBvg7E5opUVi1kJTBKihE38CPg4nBiqX83PWYw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
+      "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "@jest/types": {
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+      "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      }
+    },
+    "@testing-library/dom": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.11.1.tgz",
+      "integrity": "sha512-3KQDyx9r0RKYailW2MiYrSSKEfH0GTkI51UGEvJenvcoDoeRYs0PZpi2SXqtnMClQvCqdtTTpOfFETDTVADpAg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^5.0.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.4.4",
+        "pretty-format": "^27.0.2"
+      }
+    },
+    "@testing-library/react": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.2.tgz",
+      "integrity": "sha512-ihQiEOklNyHIpo2Y8FREkyD1QAea054U0MVbwH1m8N9TxeFz+KoJ9LkqoKqJlzx2JDm56DVwaJ1r36JYxZM05g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^8.0.0"
+      }
+    },
+    "@types/aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
+      "dev": true
+    },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
+      "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
+      "dev": true
+    },
+    "@types/istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
+      "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/node": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
+      "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg==",
+      "dev": true
+    },
+    "@types/yargs": {
+      "version": "16.0.4",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+      "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+      "dev": true,
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
+      "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "aria-query": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
+      "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "dom-accessibility-api": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.10.tgz",
+      "integrity": "sha512-Xu9mD0UjrJisTmv7lmVSDMagQcU9R5hwAbxsaAE/35XPnPLJobbuREfV/rraiSaEj/UOvgrzQs66zyTWTlyd+g==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "pretty-format": {
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.2.tgz",
+      "integrity": "sha512-p0wNtJ9oLuvgOQDEIZ9zQjZffK7KtyR6Si0jnXULIDwrlNF8Cuir3AZP0hHv0jmKuNN/edOnbMjnzd4uTcmWiw==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^27.4.2",
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        }
+      }
+    },
+    "prop-types": {
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.0.tgz",
+      "integrity": "sha512-fDGekdaHh65eI3lMi5OnErU6a8Ighg2KjcjQxO7m8VHyWjcPyj5kiOgV1LQDOOOgVy3+5FgjXvdSSX7B8/5/4g==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
+    },
+    "react": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "react-dom": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "scheduler": "^0.20.2"
+      }
+    },
+    "react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
+    },
+    "regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "dev": true
+    },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+    },
+    "scheduler": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "shallow-equal": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
+      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "use-context-selector": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/use-context-selector/-/use-context-selector-1.3.9.tgz",
+      "integrity": "sha512-YgzRyeFjoJXwFn2qLVAuIbV6EQ8DOuzu3SS/eiCxyAyvBhcn02jYSz8c5v22QQU3LW6Ez/Iyo62kKvS7Kdqt3A==",
+      "requires": {}
+    },
+    "use-debounce": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-7.0.1.tgz",
+      "integrity": "sha512-fOrzIw2wstbAJuv8PC9Vg4XgwyTLEOdq4y/Z3IhVl8DAE4svRcgyEUvrEXu+BMNgMoc3YND6qLT61kkgEKXh7Q==",
+      "requires": {}
+    }
+  }
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -14,8 +14,8 @@
     "prop-types": "^15.8.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-pure-render": "^1.0.2",
     "resize-observer-polyfill": "^1.5.1",
+    "shallow-equal": "^1.2.1",
     "use-context-selector": "^1.2.11",
     "use-debounce": "^7.0.1"
   },

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -30,3 +30,4 @@ export { default as useResizeEffect } from './useResizeEffect';
 export { default as renderToStaticMarkup } from './renderToStaticMarkup';
 export { default as useUnmount } from './useUnmount';
 export { default as useWhyDidYouUpdate } from './useWhyDidYouUpdate';
+export { default as shallowEqual } from './shallowEqual';

--- a/packages/react/src/shallowEqual.js
+++ b/packages/react/src/shallowEqual.js
@@ -13,24 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  forwardRef,
-  lazy,
-  memo,
-  useLayoutEffect,
-  useReducer,
-  createRef,
-  Fragment,
-  Component,
-  StrictMode,
-  Suspense,
-  cloneElement,
-  createElement,
-  useImperativeHandle,
-  useContext as useContextReact,
-} from 'react';
+/**
+ * External dependencies
+ */
+import { shallowEqualArrays, shallowEqualObjects } from 'shallow-equal';
+
+function shallowEqual(a, b) {
+  if (a === b) {
+    return true;
+  }
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return shallowEqualArrays(a, b);
+  }
+
+  if (typeof a === 'object' && typeof b === 'object') {
+    return shallowEqualObjects(a, b);
+  }
+
+  return false;
+}
+
+export default shallowEqual;

--- a/packages/react/src/test/shallowEqual.js
+++ b/packages/react/src/test/shallowEqual.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import * as _shallowEqual from 'shallow-equal';
+/**
+ * Internal dependencies
+ */
+import shallowEqual from '../shallowEqual';
+
+describe('shallowEqual', () => {
+  let shallowEqualArraysSpy, shallowEqualObjectsSpy;
+
+  beforeEach(() => {
+    shallowEqualArraysSpy = jest.spyOn(_shallowEqual, 'shallowEqualArrays');
+    shallowEqualObjectsSpy = jest.spyOn(_shallowEqual, 'shallowEqualObjects');
+  });
+
+  afterEach(() => {
+    shallowEqualArraysSpy.mockRestore();
+    shallowEqualObjectsSpy.mockRestore();
+  });
+
+  it('calls shallowEqualArrays for arrays', () => {
+    shallowEqual([1], [2]);
+
+    expect(shallowEqualObjectsSpy).not.toHaveBeenCalled();
+    expect(shallowEqualArraysSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls shallowEqualObjects for object', () => {
+    shallowEqual({ a: 1 }, { a: 1 });
+
+    expect(shallowEqualArraysSpy).not.toHaveBeenCalled();
+    expect(shallowEqualObjectsSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls neither shallowEqualObjects nor shallowEqualArrays for primitives', () => {
+    shallowEqual(1, 'foo');
+
+    expect(shallowEqualArraysSpy).not.toHaveBeenCalled();
+    expect(shallowEqualObjectsSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/useContextSelector.js
+++ b/packages/react/src/useContextSelector.js
@@ -22,7 +22,8 @@ import { useContextSelector as useContextSelectorOrig } from 'use-context-select
 /**
  * Internal dependencies
  */
-import { useRef, shallowEqual } from './react';
+import { useRef } from './react';
+import shallowEqual from './shallowEqual';
 
 /**
  * This hook returns a part of the context value by selector.

--- a/packages/story-editor/src/app/index.js
+++ b/packages/story-editor/src/app/index.js
@@ -26,10 +26,12 @@ import { useFont } from './font';
 import { useLocalMedia, useMedia } from './media';
 import {
   useStory,
+  useCurrentPageElementIds,
   useStoryTriggers,
   useStoryTriggerListener,
   useStoryTriggersDispatch,
   STORY_EVENTS,
+  storyReducers,
 } from './story';
 
 import { useCanvas } from './canvas';
@@ -50,6 +52,7 @@ export {
   useStoryTriggersDispatch,
   STORY_EVENTS,
   useConfig,
+  useCurrentPageElementIds,
   useFont,
   useLocalMedia,
   useMedia,
@@ -59,4 +62,5 @@ export {
   useHelpCenter,
   useUserOnboarding,
   useRightClickMenu,
+  storyReducers,
 };

--- a/packages/story-editor/src/app/index.js
+++ b/packages/story-editor/src/app/index.js
@@ -26,7 +26,6 @@ import { useFont } from './font';
 import { useLocalMedia, useMedia } from './media';
 import {
   useStory,
-  useCurrentPageElementIds,
   useStoryTriggers,
   useStoryTriggerListener,
   useStoryTriggersDispatch,
@@ -52,7 +51,6 @@ export {
   useStoryTriggersDispatch,
   STORY_EVENTS,
   useConfig,
-  useCurrentPageElementIds,
   useFont,
   useLocalMedia,
   useMedia,

--- a/packages/story-editor/src/app/story/index.js
+++ b/packages/story-editor/src/app/story/index.js
@@ -19,7 +19,7 @@
 import * as storyReducers from './useStoryReducer/reducers';
 export { default as StoryProvider } from './storyProvider';
 export { default as StoryContext } from './context';
-export { default as useStory, useCurrentPageElementIds } from './useStory';
+export { default as useStory } from './useStory';
 export {
   useStoryTriggers,
   useStoryTriggerListener,

--- a/packages/story-editor/src/app/story/index.js
+++ b/packages/story-editor/src/app/story/index.js
@@ -13,13 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+/**
+ * Internal dependencies
+ */
+import * as storyReducers from './useStoryReducer/reducers';
 export { default as StoryProvider } from './storyProvider';
 export { default as StoryContext } from './context';
-export { default as useStory } from './useStory';
+export { default as useStory, useCurrentPageElementIds } from './useStory';
 export {
   useStoryTriggers,
   useStoryTriggerListener,
   useStoryTriggersDispatch,
   STORY_EVENTS,
 } from './storyTriggers';
+
+export { storyReducers };

--- a/packages/story-editor/src/app/story/useStory.js
+++ b/packages/story-editor/src/app/story/useStory.js
@@ -35,8 +35,8 @@ const DELIMITER = ':::';
  * @return {Array} array of current pages story element ids in order
  */
 export function useCurrentPageElementIds() {
-  const elementIds = useStory((v) => {
-    const elements = v.state.currentPage?.elements || [];
+  const elementIds = useStory((value) => {
+    const elements = value.state.currentPage?.elements || [];
     return elements.map((element) => element.id).join(DELIMITER);
   });
   return elementIds.split(DELIMITER);

--- a/packages/story-editor/src/app/story/useStory.js
+++ b/packages/story-editor/src/app/story/useStory.js
@@ -27,4 +27,19 @@ function useStory(selector) {
   return useContextSelector(Context, selector ?? identity);
 }
 
+const DELIMITER = ':::';
+/**
+ * Returns an array of current page's story element ids. Only rerenders when there are
+ * element reorders, deletions or additions
+ *
+ * @return {Array} array of current pages story element ids in order
+ */
+export function useCurrentPageElementIds() {
+  const elementIds = useStory((v) => {
+    const elements = v.state.currentPage?.elements || [];
+    return elements.map((element) => element.id).join(DELIMITER);
+  });
+  return elementIds.split(DELIMITER);
+}
+
 export default useStory;

--- a/packages/story-editor/src/app/story/useStory.js
+++ b/packages/story-editor/src/app/story/useStory.js
@@ -27,23 +27,4 @@ function useStory(selector) {
   return useContextSelector(Context, selector ?? identity);
 }
 
-const DELIMITER = ':::';
-/**
- * Returns an array of current page's story element ids. Only rerenders when there are
- * element reorders, deletions or additions
- *
- * @return {Array} array of current pages story element ids in order
- */
-export function useCurrentPageElementIds() {
-  // Joining and splitting with delimiter so that selector returns
-  // a strictly equal result when we have a new id array instance that
-  // is shallowly equal. This prevents empty forced re-renders from
-  // useContextSelector
-  const elementIds = useStory((value) => {
-    const elements = value.state.currentPage?.elements || [];
-    return elements.map((element) => element.id).join(DELIMITER);
-  });
-  return elementIds.split(DELIMITER);
-}
-
 export default useStory;

--- a/packages/story-editor/src/app/story/useStory.js
+++ b/packages/story-editor/src/app/story/useStory.js
@@ -35,6 +35,10 @@ const DELIMITER = ':::';
  * @return {Array} array of current pages story element ids in order
  */
 export function useCurrentPageElementIds() {
+  // Joining and splitting with delimiter so that selector returns
+  // a shallow equal result when we have a new id array instance that
+  // is deeply equal. This prevents empty forced re-renders from
+  // useContextSelector
   const elementIds = useStory((value) => {
     const elements = value.state.currentPage?.elements || [];
     return elements.map((element) => element.id).join(DELIMITER);

--- a/packages/story-editor/src/app/story/useStory.js
+++ b/packages/story-editor/src/app/story/useStory.js
@@ -36,8 +36,8 @@ const DELIMITER = ':::';
  */
 export function useCurrentPageElementIds() {
   // Joining and splitting with delimiter so that selector returns
-  // a shallow equal result when we have a new id array instance that
-  // is deeply equal. This prevents empty forced re-renders from
+  // a strictly equal result when we have a new id array instance that
+  // is shallowly equal. This prevents empty forced re-renders from
   // useContextSelector
   const elementIds = useStory((value) => {
     const elements = value.state.currentPage?.elements || [];

--- a/packages/story-editor/src/app/story/useStoryReducer/actions.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/actions.js
@@ -211,10 +211,13 @@ const addAnimations =
   ({ animations }) =>
     dispatch({ type: types.ADD_ANIMATIONS, payload: { animations } });
 
-const updateStateWithReducer =
+const toggleLayer =
   (dispatch) =>
-  ({ reducer }) =>
-    dispatch({ type: types.UPDATE_STATE_WITH_REDUCER, payload: { reducer } });
+  ({ metaKey, shiftKey, elementId }) =>
+    dispatch({
+      type: types.TOGGLE_LAYER,
+      payload: { metaKey, shiftKey, elementId },
+    });
 
 export const exposedActions = {
   addPage,
@@ -249,7 +252,7 @@ export const exposedActions = {
   updateAnimationState,
   addAnimations,
   updateStory,
-  updateStateWithReducer,
+  toggleLayer,
 };
 
 // Internal actions

--- a/packages/story-editor/src/app/story/useStoryReducer/actions.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/actions.js
@@ -211,6 +211,11 @@ const addAnimations =
   ({ animations }) =>
     dispatch({ type: types.ADD_ANIMATIONS, payload: { animations } });
 
+const updateStateWithReducer =
+  (dispatch) =>
+  ({ reducer }) =>
+    dispatch({ type: types.UPDATE_STATE_WITH_REDUCER, payload: { reducer } });
+
 export const exposedActions = {
   addPage,
   addPageAt,
@@ -244,6 +249,7 @@ export const exposedActions = {
   updateAnimationState,
   addAnimations,
   updateStory,
+  updateStateWithReducer,
 };
 
 // Internal actions

--- a/packages/story-editor/src/app/story/useStoryReducer/reducer.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/reducer.js
@@ -91,6 +91,10 @@ function reducer(state, { type, payload }) {
       return reducers.toggleElement(state, payload);
     }
 
+    case types.TOGGLE_LAYER: {
+      return reducers.toggleLayer(state, payload);
+    }
+
     case types.DUPLICATE_ELEMENT_BY_ID: {
       return reducers.duplicateElementById(state, payload);
     }

--- a/packages/story-editor/src/app/story/useStoryReducer/reducers/index.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/reducers/index.js
@@ -39,6 +39,7 @@ export { default as setSelectedElements } from './setSelectedElements';
 export { default as selectElement } from './selectElement';
 export { default as unselectElement } from './unselectElement';
 export { default as toggleElement } from './toggleElement';
+export { default as toggleLayer } from './toggleLayer';
 
 // Manipulate animation state
 export { default as updateAnimationState } from './updateAnimationState';

--- a/packages/story-editor/src/app/story/useStoryReducer/reducers/setSelectedElements.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/reducers/setSelectedElements.js
@@ -41,11 +41,14 @@ import { intersect } from './utils';
  * @return {Object} New state
  */
 function setSelectedElements(state, { elementIds }) {
-  if (!Array.isArray(elementIds)) {
+  const newElementIds =
+    typeof elementIds === 'function' ? elementIds(state.selection) : elementIds;
+
+  if (!Array.isArray(newElementIds)) {
     return state;
   }
 
-  const uniqueElementIds = [...new Set(elementIds)];
+  const uniqueElementIds = [...new Set(newElementIds)];
 
   // They can only be similar if they have the same length
   if (state.selection.length === uniqueElementIds.length) {

--- a/packages/story-editor/src/app/story/useStoryReducer/reducers/toggleLayer.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/reducers/toggleLayer.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import toggleElement from './toggleElement';
+import setSelectedElements from './setSelectedElements';
+
+function toggleLayer(state, { elementId, metaKey, shiftKey }) {
+  // Meta pressed. Toggle this layer in the selection.
+  if (metaKey) {
+    return toggleElement(state, { elementId });
+  }
+
+  // No special key pressed - just selected this layer and nothing else.
+  if (state.selection.length <= 0 || !shiftKey) {
+    return setSelectedElements(state, {
+      elementIds: [elementId],
+    });
+  }
+
+  // Shift key pressed with any element selected:
+  // select everything between this layer and the first selected layer
+  const firstId = state.selection[0];
+  const currentPage = state.pages.find(({ id }) => id === state.current);
+  const pageElementIds = currentPage.elements.map((el) => el.id);
+  const firstIndex = pageElementIds.findIndex((id) => id === firstId);
+  const clickedIndex = pageElementIds.findIndex((id) => id === elementId);
+  const lowerIndex = Math.min(firstIndex, clickedIndex);
+  const higherIndex = Math.max(firstIndex, clickedIndex);
+  const elementIds = pageElementIds.slice(lowerIndex, higherIndex + 1);
+  // reverse selection if firstId isn't first anymore
+  if (firstId !== elementIds[0]) {
+    elementIds.reverse();
+  }
+
+  return setSelectedElements(state, {
+    elementIds,
+  });
+}
+
+export default toggleLayer;

--- a/packages/story-editor/src/app/story/useStoryReducer/reducers/updateStateWithReducer.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/reducers/updateStateWithReducer.js
@@ -15,19 +15,20 @@
  */
 
 /**
- * Internal dependencies
+ * Update story properties.
+ *
+ * No validation is performed and existing values are overwritten.
+ *
+ * @param {Object} state Current state
+ * @param {Object} payload Action payload
+ * @param {Object | Function} payload.reducer reducer to apply to state
+ * @return {Object} New state
  */
-import { useCurrentPageElementIds } from '../../../../app';
-
-function useLayers() {
-  const elementIds = useCurrentPageElementIds();
-
-  const layers = elementIds.map((id, index) => ({
-    id,
-    position: index,
-  }));
-  layers.reverse();
-  return layers;
+function updateStateWithReducer(state, { reducer }) {
+  if (typeof reducer !== 'function') {
+    return state;
+  }
+  return reducer(state);
 }
 
-export default useLayers;
+export default updateStateWithReducer;

--- a/packages/story-editor/src/app/story/useStoryReducer/test/toggleLayer.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/test/toggleLayer.js
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { setupReducer } from './_utils';
+
+describe('toggleLayer', () => {
+  it('adds an element to selection if meta key is pressed', () => {
+    const { restore, toggleLayer } = setupReducer();
+
+    // Set an initial state with a current page and some elements selected.
+    const initialState = restore({
+      pages: [
+        {
+          id: '111',
+          elements: [
+            { id: '1', isBackground: true },
+            { id: '2' },
+            { id: '3' },
+            { id: '4' },
+            { id: '5' },
+            { id: '6' },
+          ],
+        },
+      ],
+      current: '111',
+      selection: ['2', '5', '4', '6'],
+    });
+
+    const result = toggleLayer({ elementId: '3', metaKey: true });
+
+    expect(result).toStrictEqual({
+      ...initialState,
+      selection: ['2', '5', '4', '6', '3'],
+    });
+  });
+
+  it('removes an element from selection if meta key is pressed', () => {
+    const { restore, toggleLayer } = setupReducer();
+
+    // Set an initial state with a current page and some elements selected.
+    const initialState = restore({
+      pages: [
+        {
+          id: '111',
+          elements: [
+            { id: '1', isBackground: true },
+            { id: '2' },
+            { id: '3' },
+            { id: '4' },
+            { id: '5' },
+            { id: '6' },
+          ],
+        },
+      ],
+      current: '111',
+      selection: ['2', '5', '4', '6'],
+    });
+
+    const result = toggleLayer({ elementId: '4', metaKey: true });
+
+    expect(result).toStrictEqual({
+      ...initialState,
+      selection: ['2', '5', '6'],
+    });
+  });
+
+  it('selects a single element if no special keys are pressed', () => {
+    const { restore, toggleLayer } = setupReducer();
+
+    // Set an initial state with a current page and some elements selected.
+    const initialState = restore({
+      pages: [
+        {
+          id: '111',
+          elements: [
+            { id: '1', isBackground: true },
+            { id: '2' },
+            { id: '3' },
+            { id: '4' },
+            { id: '5' },
+            { id: '6' },
+          ],
+        },
+      ],
+      current: '111',
+      selection: ['2', '5', '4', '6'],
+    });
+
+    const result = toggleLayer({ elementId: '3' });
+
+    expect(result).toStrictEqual({
+      ...initialState,
+      selection: ['3'],
+    });
+  });
+
+  it('selects everything between the element and the first element in the current selection', () => {
+    const { restore, toggleLayer } = setupReducer();
+
+    // Set an initial state with a current page and some elements selected.
+    const initialState = restore({
+      pages: [
+        {
+          id: '111',
+          elements: [
+            { id: '1', isBackground: true },
+            { id: '2' },
+            { id: '3' },
+            { id: '4' },
+            { id: '5' },
+            { id: '6' },
+          ],
+        },
+      ],
+      current: '111',
+      selection: ['3', '5'],
+    });
+
+    const result = toggleLayer({ elementId: '6', shiftKey: true });
+
+    expect(result).toStrictEqual({
+      ...initialState,
+      selection: ['3', '4', '5', '6'],
+    });
+  });
+
+  it('reverses selection if the new element is before the first one', () => {
+    const { restore, toggleLayer } = setupReducer();
+
+    // Set an initial state with a current page and some elements selected.
+    const initialState = restore({
+      pages: [
+        {
+          id: '111',
+          elements: [
+            { id: '1', isBackground: true },
+            { id: '2' },
+            { id: '3' },
+            { id: '4' },
+            { id: '5' },
+            { id: '6' },
+          ],
+        },
+      ],
+      current: '111',
+      selection: ['4', '6'],
+    });
+
+    const result = toggleLayer({ elementId: '2', shiftKey: true });
+
+    expect(result).toStrictEqual({
+      ...initialState,
+      selection: ['4', '3', '2'],
+    });
+  });
+});

--- a/packages/story-editor/src/app/story/useStoryReducer/types.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/types.js
@@ -39,6 +39,7 @@ export const SET_SELECTED_ELEMENTS = 'SET_SELECTED_ELEMENTS';
 export const SELECT_ELEMENT = 'SELECT_ELEMENT';
 export const UNSELECT_ELEMENT = 'UNSELECT_ELEMENT';
 export const TOGGLE_ELEMENT_IN_SELECTION = 'TOGGLE_ELEMENT_IN_SELECTION';
+export const TOGGLE_LAYER = 'TOGGLE_LAYER';
 
 // Manipulate story-global state.
 export const UPDATE_STORY = 'UPDATE_STORY';
@@ -46,9 +47,6 @@ export const UPDATE_STORY = 'UPDATE_STORY';
 // Manipulate animation state.
 export const UPDATE_ANIMATION_STATE = 'UPDATE_ANIMATION_STATE';
 export const ADD_ANIMATIONS = 'ADD_ANIMATIONS';
-
-// Allows to opt out of root reducer and compose reducers manually
-export const UPDATE_STATE_WITH_REDUCER = 'UPDATE_STATE_WITH_REDUCER';
 
 // Manipulate entire internal state.
 export const RESTORE = 'RESTORE';

--- a/packages/story-editor/src/app/story/useStoryReducer/types.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/types.js
@@ -47,6 +47,9 @@ export const UPDATE_STORY = 'UPDATE_STORY';
 export const UPDATE_ANIMATION_STATE = 'UPDATE_ANIMATION_STATE';
 export const ADD_ANIMATIONS = 'ADD_ANIMATIONS';
 
+// Allows to opt out of root reducer and compose reducers manually
+export const UPDATE_STATE_WITH_REDUCER = 'UPDATE_STATE_WITH_REDUCER';
+
 // Manipulate entire internal state.
 export const RESTORE = 'RESTORE';
 

--- a/packages/story-editor/src/components/panels/design/layer/layer.js
+++ b/packages/story-editor/src/components/panels/design/layer/layer.js
@@ -142,37 +142,6 @@ const LayerButton = styled(Button).attrs({
     --background-color-opaque: ${({ theme }) =>
       rgba(theme.colors.interactiveBg.secondaryPress, 0)};
   }
-
-      background: ${theme.colors.interactiveBg.secondaryPress};
-      + * {
-        --background-color: ${theme.colors.interactiveBg.secondaryPress};
-        --background-color-opaque: ${rgba(
-          theme.colors.interactiveBg.secondaryPress,
-          0
-        )};
-        --selected-hover-color: ${theme.colors.interactiveBg.tertiaryHover};
-      }
-    `}
-
-  :hover {
-    background: ${({ theme }) => theme.colors.interactiveBg.secondaryHover};
-  }
-  :hover + * {
-    --background-color: ${({ theme }) =>
-      theme.colors.interactiveBg.secondaryHover};
-    --background-color-opaque: ${({ theme }) =>
-      rgba(theme.colors.interactiveBg.secondaryHover, 0)};
-  }
-
-  :active {
-    background: ${({ theme }) => theme.colors.interactiveBg.secondaryPress};
-  }
-  :active + * {
-    --background-color: ${({ theme }) =>
-      theme.colors.interactiveBg.secondaryPress};
-    --background-color-opaque: ${({ theme }) =>
-      rgba(theme.colors.interactiveBg.secondaryPress, 0)};
-  }
 `;
 
 const LayerIconWrapper = styled.div`

--- a/packages/story-editor/src/components/panels/design/layer/layer.js
+++ b/packages/story-editor/src/components/panels/design/layer/layer.js
@@ -27,7 +27,7 @@ import {
   themeHelpers,
   Tooltip,
 } from '@web-stories-wp/design-system';
-import { useRef } from '@web-stories-wp/react';
+import { useRef, memo } from '@web-stories-wp/react';
 
 /**
  * Internal dependencies
@@ -252,31 +252,25 @@ function preventReorder(e) {
   e.preventDefault();
 }
 
-function Layer({ layer }) {
-  const { LayerIcon, LayerContent } = getDefinitionForType(layer.type);
-  const { isSelected, handleClick } = useLayerSelection(layer);
-  const { currentPage, deleteElementById, duplicateElementById } = useStory(
-    (state) => ({
-      currentPage: state.state.currentPage,
-      deleteElementById: state.actions.deleteElementById,
-      duplicateElementById: state.actions.duplicateElementById,
-    })
-  );
+function Layer({ element }) {
+  const { LayerIcon, LayerContent } = getDefinitionForType(element.type);
+  const { isSelected, handleClick } = useLayerSelection(element);
+  const duplicateElementById = useStory((v) => v.actions.duplicateElementById);
+  const deleteElementById = useStory((v) => v.actions.deleteElementById);
 
   const layerRef = useRef(null);
   usePerformanceTracking({
     node: layerRef.current,
-    eventData: { ...TRACKING_EVENTS.SELECT_ELEMENT, label: layer.type },
+    eventData: { ...TRACKING_EVENTS.SELECT_ELEMENT, label: element.type },
   });
 
   const deleteButtonRef = useRef(null);
   usePerformanceTracking({
     node: deleteButtonRef.current,
-    eventData: { ...TRACKING_EVENTS.DELETE_ELEMENT, label: layer.type },
+    eventData: { ...TRACKING_EVENTS.DELETE_ELEMENT, label: element.type },
   });
 
-  const isBackground = currentPage.elements[0].id === layer.id;
-  const layerId = `layer-${layer.id}`;
+  const layerId = `layer-${element.id}`;
 
   return (
     <LayerContainer>
@@ -287,17 +281,17 @@ function Layer({ layer }) {
         isSelected={isSelected}
       >
         <LayerIconWrapper>
-          <LayerIcon element={layer} currentPage={currentPage} />
+          <LayerIcon element={element} />
         </LayerIconWrapper>
         <LayerDescription>
           <LayerContentContainer>
-            {isBackground ? (
+            {element.isBackground ? (
               <LayerText>{__('Background', 'web-stories')}</LayerText>
             ) : (
-              <LayerContent element={layer} />
+              <LayerContent element={element} />
             )}
           </LayerContentContainer>
-          {isBackground && (
+          {element.isBackground && (
             <IconWrapper>
               <Icons.LockClosed />
             </IconWrapper>
@@ -305,7 +299,7 @@ function Layer({ layer }) {
         </LayerDescription>
       </LayerButton>
       <ActionsContainer>
-        {isBackground ? (
+        {element.isBackground ? (
           <LayerAction
             aria-label={__('Locked', 'web-stories')}
             aria-describedby={layerId}
@@ -325,7 +319,7 @@ function Layer({ layer }) {
                 aria-label={__('Delete', 'web-stories')}
                 aria-describedby={layerId}
                 onPointerDown={preventReorder}
-                onClick={() => deleteElementById({ elementId: layer.id })}
+                onClick={() => deleteElementById({ elementId: element.id })}
               >
                 <Icons.Trash />
               </LayerAction>
@@ -339,7 +333,7 @@ function Layer({ layer }) {
                 aria-label={__('Duplicate', 'web-stories')}
                 aria-describedby={layerId}
                 onPointerDown={preventReorder}
-                onClick={() => duplicateElementById({ elementId: layer.id })}
+                onClick={() => duplicateElementById({ elementId: element.id })}
               >
                 <Icons.PagePlus />
               </LayerAction>
@@ -352,7 +346,7 @@ function Layer({ layer }) {
 }
 
 Layer.propTypes = {
-  layer: StoryPropTypes.layer.isRequired,
+  element: StoryPropTypes.element.isRequired,
 };
 
-export default Layer;
+export default memo(Layer);

--- a/packages/story-editor/src/components/panels/design/layer/layer.js
+++ b/packages/story-editor/src/components/panels/design/layer/layer.js
@@ -142,6 +142,37 @@ const LayerButton = styled(Button).attrs({
     --background-color-opaque: ${({ theme }) =>
       rgba(theme.colors.interactiveBg.secondaryPress, 0)};
   }
+
+      background: ${theme.colors.interactiveBg.secondaryPress};
+      + * {
+        --background-color: ${theme.colors.interactiveBg.secondaryPress};
+        --background-color-opaque: ${rgba(
+          theme.colors.interactiveBg.secondaryPress,
+          0
+        )};
+        --selected-hover-color: ${theme.colors.interactiveBg.tertiaryHover};
+      }
+    `}
+
+  :hover {
+    background: ${({ theme }) => theme.colors.interactiveBg.secondaryHover};
+  }
+  :hover + * {
+    --background-color: ${({ theme }) =>
+      theme.colors.interactiveBg.secondaryHover};
+    --background-color-opaque: ${({ theme }) =>
+      rgba(theme.colors.interactiveBg.secondaryHover, 0)};
+  }
+
+  :active {
+    background: ${({ theme }) => theme.colors.interactiveBg.secondaryPress};
+  }
+  :active + * {
+    --background-color: ${({ theme }) =>
+      theme.colors.interactiveBg.secondaryPress};
+    --background-color-opaque: ${({ theme }) =>
+      rgba(theme.colors.interactiveBg.secondaryPress, 0)};
+  }
 `;
 
 const LayerIconWrapper = styled.div`
@@ -255,11 +286,11 @@ function preventReorder(e) {
 function Layer({ element }) {
   const { LayerIcon, LayerContent } = getDefinitionForType(element.type);
   const { isSelected, handleClick } = useLayerSelection(element);
-  const duplicateElementById = useStory(
-    (value) => value.actions.duplicateElementById
-  );
-  const deleteElementById = useStory(
-    (value) => value.actions.deleteElementById
+  const { duplicateElementById, deleteElementById } = useStory(
+    ({ actions }) => ({
+      duplicateElementById: actions.duplicateElementById,
+      deleteElementById: actions.deleteElementById,
+    })
   );
 
   const layerRef = useRef(null);

--- a/packages/story-editor/src/components/panels/design/layer/layer.js
+++ b/packages/story-editor/src/components/panels/design/layer/layer.js
@@ -142,6 +142,37 @@ const LayerButton = styled(Button).attrs({
     --background-color-opaque: ${({ theme }) =>
       rgba(theme.colors.interactiveBg.secondaryPress, 0)};
   }
+
+      background: ${theme.colors.interactiveBg.secondaryPress};
+      + * {
+        --background-color: ${theme.colors.interactiveBg.secondaryPress};
+        --background-color-opaque: ${rgba(
+          theme.colors.interactiveBg.secondaryPress,
+          0
+        )};
+        --selected-hover-color: ${theme.colors.interactiveBg.tertiaryHover};
+      }
+    `}
+
+  :hover {
+    background: ${({ theme }) => theme.colors.interactiveBg.secondaryHover};
+  }
+  :hover + * {
+    --background-color: ${({ theme }) =>
+      theme.colors.interactiveBg.secondaryHover};
+    --background-color-opaque: ${({ theme }) =>
+      rgba(theme.colors.interactiveBg.secondaryHover, 0)};
+  }
+
+  :active {
+    background: ${({ theme }) => theme.colors.interactiveBg.secondaryPress};
+  }
+  :active + * {
+    --background-color: ${({ theme }) =>
+      theme.colors.interactiveBg.secondaryPress};
+    --background-color-opaque: ${({ theme }) =>
+      rgba(theme.colors.interactiveBg.secondaryPress, 0)};
+  }
 `;
 
 const LayerIconWrapper = styled.div`
@@ -255,8 +286,12 @@ function preventReorder(e) {
 function Layer({ element }) {
   const { LayerIcon, LayerContent } = getDefinitionForType(element.type);
   const { isSelected, handleClick } = useLayerSelection(element);
-  const duplicateElementById = useStory((v) => v.actions.duplicateElementById);
-  const deleteElementById = useStory((v) => v.actions.deleteElementById);
+  const duplicateElementById = useStory(
+    (value) => value.actions.duplicateElementById
+  );
+  const deleteElementById = useStory(
+    (value) => value.actions.deleteElementById
+  );
 
   const layerRef = useRef(null);
   usePerformanceTracking({

--- a/packages/story-editor/src/components/panels/design/layer/layerList.js
+++ b/packages/story-editor/src/components/panels/design/layer/layerList.js
@@ -58,8 +58,8 @@ const ReorderableLayer = memo(function ReorderableLayer({
   position,
   handleStartReordering,
 }) {
-  const element = useStory((v) =>
-    v.state.currentPage?.elements.find((el) => el.id === id)
+  const element = useStory(({ state }) =>
+    state.currentPage?.elements.find((el) => el.id === id)
   );
   return element ? (
     <Fragment key={id}>

--- a/packages/story-editor/src/components/panels/design/layer/layerList.js
+++ b/packages/story-editor/src/components/panels/design/layer/layerList.js
@@ -82,12 +82,12 @@ ReorderableLayer.propTypes = {
 };
 
 function LayerPanel({ layers }) {
-  const arrangeElement = useStory((v) => v.actions.arrangeElement);
+  const arrangeElement = useStory((value) => value.actions.arrangeElement);
   const setSelectedElementsById = useStory(
-    (v) => v.actions.setSelectedElementsById
+    (value) => value.actions.setSelectedElementsById
   );
 
-  const onOpenMenu = useRightClickMenu((v) => v.onOpenMenu);
+  const onOpenMenu = useRightClickMenu((value) => value.onOpenMenu);
 
   const numLayers = layers.length;
 

--- a/packages/story-editor/src/components/panels/design/layer/layerList.js
+++ b/packages/story-editor/src/components/panels/design/layer/layerList.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import styled from 'styled-components';
-import { Fragment, useCallback } from '@web-stories-wp/react';
+import { Fragment, useCallback, memo } from '@web-stories-wp/react';
 import PropTypes from 'prop-types';
 import { __ } from '@web-stories-wp/i18n';
 
@@ -53,15 +53,43 @@ const LayerSeparator = styled(ReorderableSeparator)`
   padding: ${LAYER_HEIGHT / 2}px 0;
 `;
 
+const ReorderableLayer = memo(function ReorderableLayer({
+  id,
+  position,
+  handleStartReordering,
+}) {
+  const element = useStory((v) =>
+    v.state.currentPage?.elements.find((el) => el.id === id)
+  );
+  return element ? (
+    <Fragment key={id}>
+      <LayerSeparator position={position + 1} />
+      <ReorderableItem
+        position={position}
+        onStartReordering={handleStartReordering(id)}
+        disabled={element.isBackground}
+      >
+        <Layer element={element} />
+      </ReorderableItem>
+    </Fragment>
+  ) : null;
+});
+
+ReorderableLayer.propTypes = {
+  id: PropTypes.string.isRequired,
+  position: PropTypes.number.isRequired,
+  handleStartReordering: PropTypes.func.isRequired,
+};
+
 function LayerPanel({ layers }) {
-  const { arrangeElement, setSelectedElementsById } = useStory((state) => ({
-    arrangeElement: state.actions.arrangeElement,
-    setSelectedElementsById: state.actions.setSelectedElementsById,
-  }));
+  const arrangeElement = useStory((v) => v.actions.arrangeElement);
+  const setSelectedElementsById = useStory(
+    (v) => v.actions.setSelectedElementsById
+  );
 
-  const { onOpenMenu } = useRightClickMenu();
+  const onOpenMenu = useRightClickMenu((v) => v.onOpenMenu);
 
-  const numLayers = layers && layers.length;
+  const numLayers = layers.length;
 
   const focusCanvas = useFocusCanvas();
   const handleStartReordering = useCallback(
@@ -89,16 +117,12 @@ function LayerPanel({ layers }) {
       getItemSize={() => LAYER_HEIGHT}
     >
       {layers.map((layer) => (
-        <Fragment key={layer.id}>
-          <LayerSeparator position={layer.position + 1} />
-          <ReorderableItem
-            position={layer.position}
-            onStartReordering={handleStartReordering(layer.id)}
-            disabled={layer.isBackground}
-          >
-            <Layer layer={layer} />
-          </ReorderableItem>
-        </Fragment>
+        <ReorderableLayer
+          key={layer.id}
+          id={layer.id}
+          position={layer.position}
+          handleStartReordering={handleStartReordering}
+        />
       ))}
     </LayerList>
   );

--- a/packages/story-editor/src/components/panels/design/layer/layerList.js
+++ b/packages/story-editor/src/components/panels/design/layer/layerList.js
@@ -82,9 +82,11 @@ ReorderableLayer.propTypes = {
 };
 
 function LayerPanel({ layers }) {
-  const arrangeElement = useStory((value) => value.actions.arrangeElement);
-  const setSelectedElementsById = useStory(
-    (value) => value.actions.setSelectedElementsById
+  const { arrangeElement, setSelectedElementsById } = useStory(
+    ({ actions }) => ({
+      arrangeElement: actions.arrangeElement,
+      setSelectedElementsById: actions.setSelectedElementsById,
+    })
   );
 
   const onOpenMenu = useRightClickMenu((value) => value.onOpenMenu);

--- a/packages/story-editor/src/components/panels/design/layer/layerPanel.js
+++ b/packages/story-editor/src/components/panels/design/layer/layerPanel.js
@@ -54,7 +54,7 @@ function LayerPanel() {
   const layers = useLayers();
 
   const inspectorContentHeight = useInspector(
-    (v) => v.state.inspectorContentHeight
+    (value) => value.state.inspectorContentHeight
   );
 
   // We want the max height to fill the space underneath the document/design tab bar.

--- a/packages/story-editor/src/components/panels/design/layer/layerPanel.js
+++ b/packages/story-editor/src/components/panels/design/layer/layerPanel.js
@@ -54,7 +54,7 @@ function LayerPanel() {
   const layers = useLayers();
 
   const inspectorContentHeight = useInspector(
-    (value) => value.state.inspectorContentHeight
+    ({ state }) => state.inspectorContentHeight
   );
 
   // We want the max height to fill the space underneath the document/design tab bar.

--- a/packages/story-editor/src/components/panels/design/layer/layerPanel.js
+++ b/packages/story-editor/src/components/panels/design/layer/layerPanel.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import { __ } from '@web-stories-wp/i18n';
-import { useMemo } from '@web-stories-wp/react';
+import { useMemo, memo } from '@web-stories-wp/react';
 import styled from 'styled-components';
 
 /**
@@ -53,9 +53,9 @@ const Divider = styled.div`
 function LayerPanel() {
   const layers = useLayers();
 
-  const {
-    state: { inspectorContentHeight },
-  } = useInspector();
+  const inspectorContentHeight = useInspector(
+    (v) => v.state.inspectorContentHeight
+  );
 
   // We want the max height to fill the space underneath the document/design tab bar.
   // Since the document/design tab bar has top and bottom margin in addition to a static
@@ -97,4 +97,4 @@ function LayerPanel() {
   );
 }
 
-export default LayerPanel;
+export default memo(LayerPanel);

--- a/packages/story-editor/src/components/panels/design/layer/useLayerSelection.js
+++ b/packages/story-editor/src/components/panels/design/layer/useLayerSelection.js
@@ -27,11 +27,11 @@ import useFocusCanvas from '../../../canvas/useFocusCanvas';
 
 function useLayerSelection(layer) {
   const { id: elementId } = layer;
-  const isSelected = useStory((value) =>
-    value.state.selectedElementIds.includes(elementId)
-  );
-  const updateStateWithReducer = useStory(
-    (value) => value.actions.updateStateWithReducer
+  const { isSelected, updateStateWithReducer } = useStory(
+    ({ state, actions }) => ({
+      isSelected: state.selectedElementIds.includes(elementId),
+      updateStateWithReducer: actions.updateStateWithReducer,
+    })
   );
 
   const focusCanvas = useFocusCanvas();

--- a/packages/story-editor/src/components/panels/design/layer/useLayerSelection.js
+++ b/packages/story-editor/src/components/panels/design/layer/useLayerSelection.js
@@ -27,11 +27,11 @@ import useFocusCanvas from '../../../canvas/useFocusCanvas';
 
 function useLayerSelection(layer) {
   const { id: elementId } = layer;
-  const isSelected = useStory((v) =>
-    v.state.selectedElementIds.includes(elementId)
+  const isSelected = useStory((value) =>
+    value.state.selectedElementIds.includes(elementId)
   );
   const updateStateWithReducer = useStory(
-    (v) => v.actions.updateStateWithReducer
+    (value) => value.actions.updateStateWithReducer
   );
 
   const focusCanvas = useFocusCanvas();

--- a/packages/story-editor/src/components/panels/design/layer/useLayers.js
+++ b/packages/story-editor/src/components/panels/design/layer/useLayers.js
@@ -17,10 +17,14 @@
 /**
  * Internal dependencies
  */
-import { useCurrentPageElementIds } from '../../../../app';
+import { useStory } from '../../../../app';
+import { STABLE_ARRAY } from '../../../../constants';
 
 function useLayers() {
-  const elementIds = useCurrentPageElementIds();
+  const elementIds = useStory(
+    ({ state }) =>
+      state.currentPage?.elements?.map((el) => el.id) || STABLE_ARRAY
+  );
 
   const layers = elementIds.map((id, index) => ({
     id,

--- a/packages/story-editor/src/components/panels/panel/shared/title.js
+++ b/packages/story-editor/src/components/panels/panel/shared/title.js
@@ -88,6 +88,7 @@ const IconWrapper = styled.div`
   position: relative;
   width: 32px;
   height: 32px;
+
   svg {
     position: relative;
     z-index: 1;
@@ -110,11 +111,14 @@ const Collapse = styled.button`
   cursor: pointer;
   margin-left: -12px;
   transition: ${BUTTON_TRANSITION_TIMING};
+
   &:hover,
   &.${ThemeGlobals.FOCUS_VISIBLE_SELECTOR}, &[${ThemeGlobals.FOCUS_VISIBLE_DATA_ATTRIBUTE}] {
     color: ${({ theme }) => theme.colors.fg.primary};
   }
+
   ${focusStyle};
+
   svg {
     width: 32px;
     height: 32px;
@@ -125,6 +129,24 @@ const Collapse = styled.button`
         transform: rotate(-90deg);
       `};
   }
+
+  :hover ${IconWrapper}:after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    height: 16px;
+    width: 16px;
+    border-radius: ${({ theme }) => theme.borders.radius.round};
+    background: ${({ theme }) => theme.colors.bg.quaternary};
+  }
+
+        color: ${theme.colors.fg.secondary};
+        transform: rotate(-90deg);
+      `};
+  }
+
   :hover ${IconWrapper}:after {
     content: '';
     position: absolute;

--- a/packages/story-editor/src/components/panels/panel/shared/title.js
+++ b/packages/story-editor/src/components/panels/panel/shared/title.js
@@ -88,7 +88,6 @@ const IconWrapper = styled.div`
   position: relative;
   width: 32px;
   height: 32px;
-
   svg {
     position: relative;
     z-index: 1;
@@ -111,9 +110,8 @@ const Collapse = styled.button`
   cursor: pointer;
   margin-left: -12px;
   transition: ${BUTTON_TRANSITION_TIMING};
-
   &:hover,
-  &.${ThemeGlobals.FOCUS_VISIBLE_SELECTOR}, &[${ThemeGlobals.FOCUS_VISIBLE_DATA_ATTRIBUTE}] {
+   &.${ThemeGlobals.FOCUS_VISIBLE_SELECTOR}, &[${ThemeGlobals.FOCUS_VISIBLE_DATA_ATTRIBUTE}] {
     color: ${({ theme }) => theme.colors.fg.primary};
   }
 
@@ -125,23 +123,6 @@ const Collapse = styled.button`
     ${({ $isCollapsed, theme }) =>
       $isCollapsed &&
       css`
-        color: ${theme.colors.fg.secondary};
-        transform: rotate(-90deg);
-      `};
-  }
-
-  :hover ${IconWrapper}:after {
-    content: '';
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    height: 16px;
-    width: 16px;
-    border-radius: ${({ theme }) => theme.borders.radius.round};
-    background: ${({ theme }) => theme.colors.bg.quaternary};
-  }
-
         color: ${theme.colors.fg.secondary};
         transform: rotate(-90deg);
       `};

--- a/packages/story-editor/src/components/panels/panel/shared/title.js
+++ b/packages/story-editor/src/components/panels/panel/shared/title.js
@@ -139,23 +139,6 @@ const Collapse = styled.button`
     border-radius: ${({ theme }) => theme.borders.radius.round};
     background: ${({ theme }) => theme.colors.bg.quaternary};
   }
-
-        color: ${theme.colors.fg.secondary};
-        transform: rotate(-90deg);
-      `};
-  }
-
-  :hover ${IconWrapper}:after {
-    content: '';
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    height: 16px;
-    width: 16px;
-    border-radius: ${({ theme }) => theme.borders.radius.round};
-    background: ${({ theme }) => theme.colors.bg.quaternary};
-  }
 `;
 
 function Toggle({ children, isCollapsed, toggle, ...rest }) {

--- a/packages/story-editor/src/components/panels/panel/shared/title.js
+++ b/packages/story-editor/src/components/panels/panel/shared/title.js
@@ -111,7 +111,7 @@ const Collapse = styled.button`
   margin-left: -12px;
   transition: ${BUTTON_TRANSITION_TIMING};
   &:hover,
-   &.${ThemeGlobals.FOCUS_VISIBLE_SELECTOR}, &[${ThemeGlobals.FOCUS_VISIBLE_DATA_ATTRIBUTE}] {
+  &.${ThemeGlobals.FOCUS_VISIBLE_SELECTOR}, &[${ThemeGlobals.FOCUS_VISIBLE_DATA_ATTRIBUTE}] {
     color: ${({ theme }) => theme.colors.fg.primary};
   }
 
@@ -123,6 +123,23 @@ const Collapse = styled.button`
     ${({ $isCollapsed, theme }) =>
       $isCollapsed &&
       css`
+        color: ${theme.colors.fg.secondary};
+        transform: rotate(-90deg);
+      `};
+  }
+
+  :hover ${IconWrapper}:after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    height: 16px;
+    width: 16px;
+    border-radius: ${({ theme }) => theme.borders.radius.round};
+    background: ${({ theme }) => theme.colors.bg.quaternary};
+  }
+
         color: ${theme.colors.fg.secondary};
         transform: rotate(-90deg);
       `};

--- a/packages/story-editor/src/components/panels/panel/shared/title.js
+++ b/packages/story-editor/src/components/panels/panel/shared/title.js
@@ -88,7 +88,6 @@ const IconWrapper = styled.div`
   position: relative;
   width: 32px;
   height: 32px;
-
   svg {
     position: relative;
     z-index: 1;
@@ -111,17 +110,14 @@ const Collapse = styled.button`
   cursor: pointer;
   margin-left: -12px;
   transition: ${BUTTON_TRANSITION_TIMING};
-
   &:hover,
   &.${ThemeGlobals.FOCUS_VISIBLE_SELECTOR}, &[${ThemeGlobals.FOCUS_VISIBLE_DATA_ATTRIBUTE}] {
     color: ${({ theme }) => theme.colors.fg.primary};
   }
   ${focusStyle};
-
   svg {
     width: 32px;
     height: 32px;
-
     ${({ $isCollapsed, theme }) =>
       $isCollapsed &&
       css`
@@ -129,7 +125,6 @@ const Collapse = styled.button`
         transform: rotate(-90deg);
       `};
   }
-
   :hover ${IconWrapper}:after {
     content: '';
     position: absolute;

--- a/packages/story-editor/src/components/reorderable/reorderableItem.js
+++ b/packages/story-editor/src/components/reorderable/reorderableItem.js
@@ -37,7 +37,7 @@ function ReorderableItem({
   ...props
 }) {
   const handleStartReordering = useReorderable(
-    (value) => value.actions.handleStartReordering
+    ({ actions }) => actions.handleStartReordering
   );
 
   return (

--- a/packages/story-editor/src/components/reorderable/reorderableItem.js
+++ b/packages/story-editor/src/components/reorderable/reorderableItem.js
@@ -37,7 +37,7 @@ function ReorderableItem({
   ...props
 }) {
   const handleStartReordering = useReorderable(
-    (v) => v.actions.handleStartReordering
+    (value) => value.actions.handleStartReordering
   );
 
   return (

--- a/packages/story-editor/src/components/reorderable/reorderableItem.js
+++ b/packages/story-editor/src/components/reorderable/reorderableItem.js
@@ -36,9 +36,9 @@ function ReorderableItem({
   disabled,
   ...props
 }) {
-  const {
-    actions: { handleStartReordering },
-  } = useReorderable();
+  const handleStartReordering = useReorderable(
+    (v) => v.actions.handleStartReordering
+  );
 
   return (
     <Container

--- a/packages/story-editor/src/components/reorderable/reorderableSeparator.js
+++ b/packages/story-editor/src/components/reorderable/reorderableSeparator.js
@@ -46,9 +46,11 @@ const Line = styled.div`
 function ReorderableSeparator({ position, children = <Line />, ...props }) {
   const separatorRef = useRef(null);
 
-  const isReordering = useReorderable((value) => value.state.isReordering);
-  const setCurrentSeparator = useReorderable(
-    (value) => value.actions.setCurrentSeparator
+  const { isReordering, setCurrentSeparator } = useReorderable(
+    ({ state, actions }) => ({
+      isReordering: state.isReordering,
+      setCurrentSeparator: actions.setCurrentSeparator,
+    })
   );
   const handlePointerEnter = useCallback(() => {
     if (!isReordering) {

--- a/packages/story-editor/src/components/reorderable/reorderableSeparator.js
+++ b/packages/story-editor/src/components/reorderable/reorderableSeparator.js
@@ -46,9 +46,9 @@ const Line = styled.div`
 function ReorderableSeparator({ position, children = <Line />, ...props }) {
   const separatorRef = useRef(null);
 
-  const isReordering = useReorderable((v) => v.state.isReordering);
+  const isReordering = useReorderable((value) => value.state.isReordering);
   const setCurrentSeparator = useReorderable(
-    (v) => v.actions.setCurrentSeparator
+    (value) => value.actions.setCurrentSeparator
   );
   const handlePointerEnter = useCallback(() => {
     if (!isReordering) {

--- a/packages/story-editor/src/components/reorderable/reorderableSeparator.js
+++ b/packages/story-editor/src/components/reorderable/reorderableSeparator.js
@@ -46,10 +46,10 @@ const Line = styled.div`
 function ReorderableSeparator({ position, children = <Line />, ...props }) {
   const separatorRef = useRef(null);
 
-  const {
-    actions: { setCurrentSeparator },
-    state: { isReordering },
-  } = useReorderable();
+  const isReordering = useReorderable((v) => v.state.isReordering);
+  const setCurrentSeparator = useReorderable(
+    (v) => v.actions.setCurrentSeparator
+  );
   const handlePointerEnter = useCallback(() => {
     if (!isReordering) {
       return;

--- a/packages/story-editor/src/constants/index.js
+++ b/packages/story-editor/src/constants/index.js
@@ -98,3 +98,5 @@ export const PRESET_TYPES = {
   STYLE: 'style',
   COLOR: 'colors',
 };
+
+export const STABLE_ARRAY = [];

--- a/packages/story-editor/src/elements/shape/icon.js
+++ b/packages/story-editor/src/elements/shape/icon.js
@@ -25,6 +25,7 @@ import styled from 'styled-components';
 import { getMaskByType } from '../../masks';
 import { elementWithBackgroundColor } from '../shared';
 import StoryPropTypes from '../../types';
+import { useStory } from '../../app';
 
 const Container = styled.div`
   display: flex;
@@ -57,13 +58,15 @@ https://caniuse.com/css-clip-path
 
 function ShapeLayerIcon({
   element: { id, mask, backgroundColor, isDefaultBackground },
-  currentPage,
 }) {
   const maskDef = getMaskByType(mask.type);
+  const currentPageBackgroundColor = useStory(
+    (v) => !isDefaultBackground || v.state.currentPage?.backgroundColor
+  );
 
   const maskId = `mask-${maskDef.type}-${id}-layer-preview`;
   if (isDefaultBackground) {
-    backgroundColor = currentPage.backgroundColor;
+    backgroundColor = currentPageBackgroundColor;
   }
 
   return (
@@ -90,7 +93,6 @@ function ShapeLayerIcon({
 
 ShapeLayerIcon.propTypes = {
   element: StoryPropTypes.element.isRequired,
-  currentPage: StoryPropTypes.page,
 };
 
 export default ShapeLayerIcon;


### PR DESCRIPTION
## Context
Performance optimization & documentation around several key interactions in the Layers Panel. Makes key actions only render relevant components in the Layers Panel. Basically now `O(updated layers)` vs `O(all layers)` for these interactions

## Summary
Improving rendering performance of the layers panel with 3 interactions. 

Tested on a page with 50 square shape elements (51 including the background element) with the Layers panel open:
<img width="1440" alt="Screen Shot 2021-12-22 at 1 55 36 PM" src="https://user-images.githubusercontent.com/35983235/147141603-77df3d34-db93-4ac2-bea7-bcc38644f492.png">

*Tested on a fully specced 2018 Macbook Pro with no CPU Throttling*


### Element Selection
Test: Changing the selected element in the editor by clicking a different layer in the layers panel. 
Result: **~49.14x faster** 

| Before | After |
| --- | --- |
| ~68.8ms | ~1.4ms |
|  <img width="648" alt="Screen Shot 2021-12-22 at 1 28 19 PM" src="https://user-images.githubusercontent.com/35983235/147138712-dbc7872c-15cb-4d97-b404-41ed0cd51a5d.png"> |  <img width="684" alt="Screen Shot 2021-12-22 at 1 28 29 PM" src="https://user-images.githubusercontent.com/35983235/147138731-9ba24179-7f32-4998-9885-642f42c4c01c.png"> |


### Reordering Layers
Test: Drag the selected layer in the layers panel to a new position. 
Result: **~45.48x faster** 

| Before | After |
| --- | --- |
| ~104.6ms | ~2.3ms |
| <img width="600" alt="Screen Shot 2021-12-22 at 1 42 27 PM" src="https://user-images.githubusercontent.com/35983235/147141054-88360c27-e4cf-46bb-ba38-f223036d1cfa.png"> |  <img width="567" alt="Screen Shot 2021-12-22 at 1 42 38 PM" src="https://user-images.githubusercontent.com/35983235/147141071-62a10d1c-0790-4dd3-a03c-829f992bb2ea.png"> |



### Updating an elements style properties
Test: Drag the previously selected element on the canvas to update its x & y coordinates
Result: **~42.75x faster** 

| Before | After |
| --- | --- |
| <img width="599" alt="Screen Shot 2021-12-22 at 2 01 56 PM" src="https://user-images.githubusercontent.com/35983235/147142358-c0b27c89-896b-4917-ae74-54e5e7e85fc8.png"> |  <img width="600" alt="Screen Shot 2021-12-22 at 2 13 26 PM" src="https://user-images.githubusercontent.com/35983235/147143682-ad3d5d85-71ac-4bd5-8386-5544bffcf31b.png"> |




## Relevant Technical Choices
Introduces better (more sensitive to referential equality) patterns around `useContextSelector` more inline with the library's recommended usage:
https://github.com/dai-shi/use-context-selector#usage

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10051 
