### PR TITLE
Checklist: Offer page reload option when toggling Video Optimization setting

### DIFF
--- a/packages/wp-story-editor/src/components/checklist/accessibility/index.js
+++ b/packages/wp-story-editor/src/components/checklist/accessibility/index.js
@@ -46,7 +46,7 @@ function Accessibility() {
       <ElementLinkTappableRegionTooSmall />
       <ElementLinkTappableRegionTooBig />
       <ImageElementMissingAlt />
-      {hasUploadMediaAction && <VideoOptimizationCheckbox />}
+      <VideoOptimizationCheckbox />
     </>
   );
 }

--- a/packages/wp-story-editor/src/components/checklist/accessibility/index.js
+++ b/packages/wp-story-editor/src/components/checklist/accessibility/index.js
@@ -46,7 +46,7 @@ function Accessibility() {
       <ElementLinkTappableRegionTooSmall />
       <ElementLinkTappableRegionTooBig />
       <ImageElementMissingAlt />
-      <VideoOptimizationCheckbox />
+      {hasUploadMediaAction && <VideoOptimizationCheckbox />}
     </>
   );
 }

--- a/packages/wp-story-editor/src/components/checklist/accessibility/videoOptimizationCheckbox/index.js
+++ b/packages/wp-story-editor/src/components/checklist/accessibility/videoOptimizationCheckbox/index.js
@@ -49,6 +49,11 @@ const ButtonContainer = styled.div`
   justify-content: center;
 `;
 
+const BoldText = styled.span`
+  color: ${({ theme }) => theme.colors.standard.white};
+  font-weight: ${({ theme }) => theme.typography.weight.bold};
+`;
+
 const DescriptionText = styled(Text).attrs({
   size: THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL,
 })`
@@ -101,17 +106,31 @@ function VideoOptimizationCheckbox() {
       )}
       footer={
         hasOptedIn ? (
-          <ButtonContainer>
-            <Button
-              variant={BUTTON_VARIANTS.RECTANGLE}
-              type={BUTTON_TYPES.PRIMARY}
-              size={BUTTON_SIZES.SMALL}
-              onClick={handleSave}
-              disabled={isSaving}
-            >
-              {__('Save and Reload', 'web-stories')}
-            </Button>
-          </ButtonContainer>
+          <>
+            <p>
+              <TranslateWithMarkup
+                mapping={{
+                  b: <BoldText />,
+                }}
+              >
+                {__(
+                  'Automatic video optimization enabled. <b>Reload the page</b> to apply changes.',
+                  'web-stories'
+                )}
+              </TranslateWithMarkup>
+            </p>
+            <ButtonContainer>
+              <Button
+                variant={BUTTON_VARIANTS.RECTANGLE}
+                type={BUTTON_TYPES.PRIMARY}
+                size={BUTTON_SIZES.SMALL}
+                onClick={handleSave}
+                disabled={isSaving}
+              >
+                {__('Save and Reload', 'web-stories')}
+              </Button>
+            </ButtonContainer>
+          </>
         ) : (
           <CheckboxContainer>
             <Checkbox

--- a/packages/wp-story-editor/src/components/checklist/accessibility/videoOptimizationCheckbox/index.js
+++ b/packages/wp-story-editor/src/components/checklist/accessibility/videoOptimizationCheckbox/index.js
@@ -34,6 +34,7 @@ import {
   useConfig,
   useCurrentUser,
   useIsChecklistMounted,
+  useStory,
   ChecklistCard,
 } from '@web-stories-wp/story-editor';
 
@@ -83,6 +84,15 @@ function VideoOptimizationCheckbox() {
     toggleWebStoriesMediaOptimization();
   }, [toggleWebStoriesMediaOptimization]);
 
+  const { isSaving, saveStory } = useStory(({ state, actions }) => ({
+    isSaving: state.meta.isSaving,
+    saveStory: actions.saveStory,
+  }));
+  const handleSave = async () => {
+    await saveStory();
+    window.location.reload(true);
+  };
+
   return (showCheckbox || hasOptedIn) && isChecklistMounted ? (
     <ChecklistCard
       title={__(
@@ -96,8 +106,8 @@ function VideoOptimizationCheckbox() {
               variant={BUTTON_VARIANTS.RECTANGLE}
               type={BUTTON_TYPES.PRIMARY}
               size={BUTTON_SIZES.SMALL}
-              // onClick={handleSaveButton}
-              // disabled={isSaving}
+              onClick={handleSave}
+              disabled={isSaving}
             >
               {__('Save and Reload', 'web-stories')}
             </Button>

--- a/packages/wp-story-editor/src/components/checklist/accessibility/videoOptimizationCheckbox/index.js
+++ b/packages/wp-story-editor/src/components/checklist/accessibility/videoOptimizationCheckbox/index.js
@@ -38,6 +38,7 @@ import {
   useConfig,
   useCurrentUser,
   useIsChecklistMounted,
+  useRegisterCheck,
   useStory,
   ChecklistCard,
   DefaultFooterText,
@@ -77,8 +78,7 @@ function VideoOptimizationCheckbox() {
   const isChecklistMounted = useIsChecklistMounted();
   const [hasOptedIn, setHasOptedIn] = useState(false);
   const saveButtonRef = useRef();
-  const { capabilities: { hasUploadMediaAction } = {}, dashboardSettingsLink } =
-    useConfig();
+  const { dashboardSettingsLink } = useConfig();
   const { currentUser, toggleWebStoriesMediaOptimization } = useCurrentUser(
     ({ state, actions }) => ({
       currentUser: state.currentUser,
@@ -88,7 +88,7 @@ function VideoOptimizationCheckbox() {
   );
 
   const checked = currentUser?.meta?.web_stories_media_optimization;
-  const showCheckbox = !checked && hasUploadMediaAction;
+  useRegisterCheck('VideoOptimizationCheckbox', isChecklistMounted && !checked);
 
   const handleToggle = useCallback(() => {
     setHasOptedIn(true);
@@ -108,7 +108,7 @@ function VideoOptimizationCheckbox() {
     hasOptedIn && saveButtonRef.current.focus();
   }, [hasOptedIn]);
 
-  return (showCheckbox || hasOptedIn) && isChecklistMounted ? (
+  return (!checked || hasOptedIn) && isChecklistMounted ? (
     <ChecklistCard
       title={__(
         'Optimize all videos in the Story to ensure smooth playback.',

--- a/packages/wp-story-editor/src/components/checklist/accessibility/videoOptimizationCheckbox/index.js
+++ b/packages/wp-story-editor/src/components/checklist/accessibility/videoOptimizationCheckbox/index.js
@@ -75,9 +75,10 @@ const CheckboxLabel = styled(DescriptionText)`
 
 function VideoOptimizationCheckbox() {
   const isChecklistMounted = useIsChecklistMounted();
+  const { capabilities: { hasUploadMediaAction } = {}, dashboardSettingsLink } =
+    useConfig();
   const [hasOptedIn, setHasOptedIn] = useState(false);
   const saveButtonRef = useRef();
-  const { dashboardSettingsLink } = useConfig();
   const { currentUser, toggleWebStoriesMediaOptimization } = useCurrentUser(
     ({ state, actions }) => ({
       currentUser: state.currentUser,
@@ -87,6 +88,7 @@ function VideoOptimizationCheckbox() {
   );
 
   const checked = currentUser?.meta?.web_stories_media_optimization;
+  const showCheckbox = !checked && hasUploadMediaAction;
 
   const handleToggle = useCallback(() => {
     setHasOptedIn(true);
@@ -106,7 +108,7 @@ function VideoOptimizationCheckbox() {
     hasOptedIn && saveButtonRef.current.focus();
   }, [hasOptedIn]);
 
-  return (!checked || hasOptedIn) && isChecklistMounted ? (
+  return (showCheckbox || hasOptedIn) && isChecklistMounted ? (
     <ChecklistCard
       title={__(
         'Optimize all videos in the Story to ensure smooth playback.',

--- a/packages/wp-story-editor/src/components/checklist/accessibility/videoOptimizationCheckbox/index.js
+++ b/packages/wp-story-editor/src/components/checklist/accessibility/videoOptimizationCheckbox/index.js
@@ -122,12 +122,12 @@ function VideoOptimizationCheckbox() {
             <ButtonContainer>
               <Button
                 variant={BUTTON_VARIANTS.RECTANGLE}
-                type={BUTTON_TYPES.PRIMARY}
+                type={BUTTON_TYPES.SECONDARY}
                 size={BUTTON_SIZES.SMALL}
                 onClick={handleSave}
                 disabled={isSaving}
               >
-                {__('Save and Reload', 'web-stories')}
+                {__('Save & Reload', 'web-stories')}
               </Button>
             </ButtonContainer>
           </>

--- a/packages/wp-story-editor/src/components/checklist/accessibility/videoOptimizationCheckbox/index.js
+++ b/packages/wp-story-editor/src/components/checklist/accessibility/videoOptimizationCheckbox/index.js
@@ -16,7 +16,12 @@
 /**
  * External dependencies
  */
+import { useCallback, useState } from '@web-stories-wp/react';
 import {
+  Button,
+  BUTTON_SIZES,
+  BUTTON_TYPES,
+  BUTTON_VARIANTS,
   Checkbox,
   Link,
   Text,
@@ -37,6 +42,12 @@ const CheckboxContainer = styled.div`
   align-items: flex-start;
 `;
 
+const ButtonContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
 const DescriptionText = styled(Text).attrs({
   size: THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL,
 })`
@@ -53,6 +64,7 @@ const CheckboxLabel = styled(DescriptionText)`
 
 function VideoOptimizationCheckbox() {
   const isChecklistMounted = useIsChecklistMounted();
+  const [hasOptedIn, setHasOptedIn] = useState(false);
   const { capabilities: { hasUploadMediaAction } = {}, dashboardSettingsLink } =
     useConfig();
   const { currentUser, toggleWebStoriesMediaOptimization } = useCurrentUser(
@@ -66,44 +78,63 @@ function VideoOptimizationCheckbox() {
   const checked = currentUser?.meta?.web_stories_media_optimization;
   const showCheckbox = !checked && hasUploadMediaAction;
 
-  return showCheckbox && isChecklistMounted ? (
+  const handleToggle = useCallback(() => {
+    setHasOptedIn(true);
+    toggleWebStoriesMediaOptimization();
+  }, [toggleWebStoriesMediaOptimization]);
+
+  return (showCheckbox || hasOptedIn) && isChecklistMounted ? (
     <ChecklistCard
       title={__(
         'Optimize all videos in the Story to ensure smooth playback.',
         'web-stories'
       )}
       footer={
-        <CheckboxContainer>
-          <Checkbox
-            id="automatic-video-optimization-toggle"
-            checked={currentUser?.meta?.web_stories_media_optimization}
-            onChange={toggleWebStoriesMediaOptimization}
-          />
-          <CheckboxLabel
-            forwardedAs="label"
-            htmlFor="automatic-video-optimization-toggle"
-          >
-            <TranslateWithMarkup
-              mapping={{
-                a: (
-                  <Link
-                    size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}
-                    onClick={(evt) =>
-                      trackClick(evt, 'click_video_optimization_settings')
-                    }
-                    href={dashboardSettingsLink}
-                    isBold
-                  />
-                ),
-              }}
+        hasOptedIn ? (
+          <ButtonContainer>
+            <Button
+              variant={BUTTON_VARIANTS.RECTANGLE}
+              type={BUTTON_TYPES.PRIMARY}
+              size={BUTTON_SIZES.SMALL}
+              // onClick={handleSaveButton}
+              // disabled={isSaving}
             >
-              {__(
-                'Enable automatic optimization. Change this any time in <a>Settings</a>.',
-                'web-stories'
-              )}
-            </TranslateWithMarkup>
-          </CheckboxLabel>
-        </CheckboxContainer>
+              {__('Save and Reload', 'web-stories')}
+            </Button>
+          </ButtonContainer>
+        ) : (
+          <CheckboxContainer>
+            <Checkbox
+              id="automatic-video-optimization-toggle"
+              checked={currentUser?.meta?.web_stories_media_optimization}
+              onChange={handleToggle}
+            />
+            <CheckboxLabel
+              forwardedAs="label"
+              htmlFor="automatic-video-optimization-toggle"
+            >
+              <TranslateWithMarkup
+                mapping={{
+                  a: (
+                    <Link
+                      size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}
+                      onClick={(evt) =>
+                        trackClick(evt, 'click_video_optimization_settings')
+                      }
+                      href={dashboardSettingsLink}
+                      isBold
+                    />
+                  ),
+                }}
+              >
+                {__(
+                  'Enable automatic optimization. Change this any time in <a>Settings</a>.',
+                  'web-stories'
+                )}
+              </TranslateWithMarkup>
+            </CheckboxLabel>
+          </CheckboxContainer>
+        )
       }
     />
   ) : null;

--- a/packages/wp-story-editor/src/components/checklist/accessibility/videoOptimizationCheckbox/index.js
+++ b/packages/wp-story-editor/src/components/checklist/accessibility/videoOptimizationCheckbox/index.js
@@ -38,7 +38,6 @@ import {
   useConfig,
   useCurrentUser,
   useIsChecklistMounted,
-  useRegisterCheck,
   useStory,
   ChecklistCard,
   DefaultFooterText,
@@ -88,7 +87,6 @@ function VideoOptimizationCheckbox() {
   );
 
   const checked = currentUser?.meta?.web_stories_media_optimization;
-  useRegisterCheck('VideoOptimizationCheckbox', isChecklistMounted && !checked);
 
   const handleToggle = useCallback(() => {
     setHasOptedIn(true);

--- a/packages/wp-story-editor/src/components/checklist/accessibility/videoOptimizationCheckbox/index.js
+++ b/packages/wp-story-editor/src/components/checklist/accessibility/videoOptimizationCheckbox/index.js
@@ -16,12 +16,16 @@
 /**
  * External dependencies
  */
-import { useCallback, useState } from '@web-stories-wp/react';
+import {
+  useCallback,
+  useState,
+  useRef,
+  useEffect,
+} from '@web-stories-wp/react';
 import {
   Button,
   BUTTON_SIZES,
   BUTTON_TYPES,
-  BUTTON_VARIANTS,
   Checkbox,
   Link,
   Text,
@@ -36,6 +40,7 @@ import {
   useIsChecklistMounted,
   useStory,
   ChecklistCard,
+  DefaultFooterText,
 } from '@web-stories-wp/story-editor';
 
 const CheckboxContainer = styled.div`
@@ -47,11 +52,11 @@ const ButtonContainer = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
+  margin-top: 16px;
 `;
 
-const BoldText = styled.span`
+const BoldText = styled(Text).attrs({ as: 'span', isBold: true })`
   color: ${({ theme }) => theme.colors.standard.white};
-  font-weight: ${({ theme }) => theme.typography.weight.bold};
 `;
 
 const DescriptionText = styled(Text).attrs({
@@ -71,6 +76,7 @@ const CheckboxLabel = styled(DescriptionText)`
 function VideoOptimizationCheckbox() {
   const isChecklistMounted = useIsChecklistMounted();
   const [hasOptedIn, setHasOptedIn] = useState(false);
+  const saveButtonRef = useRef();
   const { capabilities: { hasUploadMediaAction } = {}, dashboardSettingsLink } =
     useConfig();
   const { currentUser, toggleWebStoriesMediaOptimization } = useCurrentUser(
@@ -98,6 +104,10 @@ function VideoOptimizationCheckbox() {
     window.location.reload(true);
   };
 
+  useEffect(() => {
+    hasOptedIn && saveButtonRef.current.focus();
+  }, [hasOptedIn]);
+
   return (showCheckbox || hasOptedIn) && isChecklistMounted ? (
     <ChecklistCard
       title={__(
@@ -107,7 +117,7 @@ function VideoOptimizationCheckbox() {
       footer={
         hasOptedIn ? (
           <>
-            <p>
+            <DefaultFooterText>
               <TranslateWithMarkup
                 mapping={{
                   b: <BoldText />,
@@ -118,14 +128,14 @@ function VideoOptimizationCheckbox() {
                   'web-stories'
                 )}
               </TranslateWithMarkup>
-            </p>
+            </DefaultFooterText>
             <ButtonContainer>
               <Button
-                variant={BUTTON_VARIANTS.RECTANGLE}
                 type={BUTTON_TYPES.SECONDARY}
                 size={BUTTON_SIZES.SMALL}
                 onClick={handleSave}
                 disabled={isSaving}
+                ref={saveButtonRef}
               >
                 {__('Save & Reload', 'web-stories')}
               </Button>

--- a/packages/wp-story-editor/src/components/checklist/accessibility/videoOptimizationCheckbox/test/index.js
+++ b/packages/wp-story-editor/src/components/checklist/accessibility/videoOptimizationCheckbox/test/index.js
@@ -19,7 +19,11 @@
 import { render, screen } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 import { theme } from '@web-stories-wp/design-system';
-import { useConfig, useCurrentUser } from '@web-stories-wp/story-editor';
+import {
+  useConfig,
+  useCurrentUser,
+  useStory,
+} from '@web-stories-wp/story-editor';
 
 /**
  * Internal dependencies
@@ -30,15 +34,28 @@ jest.mock('@web-stories-wp/story-editor', () => ({
   ...jest.requireActual('@web-stories-wp/story-editor'),
   useConfig: jest.fn(),
   useCurrentUser: jest.fn(),
+  useStory: jest.fn(),
   useIsChecklistMounted: jest.fn(() => true),
 }));
 
 const mockUseConfig = useConfig;
 const mockUseCurrentUser = useCurrentUser;
+const mockUseStory = useStory;
 const mockToggleWebStoriesMediaOptimization = jest.fn();
 const mockUser = {
   meta: {
     web_stories_media_optimization: false,
+  },
+};
+
+const mockStory = {
+  state: {
+    meta: {
+      isSaving: false,
+    },
+  },
+  actions: {
+    saveStory: jest.fn(),
   },
 };
 
@@ -54,6 +71,7 @@ describe('VideoOptimizationCheckbox', () => {
       currentUser: mockUser,
       toggleWebStoriesMediaOptimization: mockToggleWebStoriesMediaOptimization,
     });
+    mockUseStory.mockReturnValue(mockStory);
   });
 
   it('should render `null` if auto video optimization is enabled', () => {


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
If a user has opted out of the video optimization, then in the pre-publish checklist, there is an option to re-enable it. However, once you toggle it 'on' you must save and reload your story before it will apply the change. 

## Summary

<!-- A brief description of what this PR does. -->
We are adding a button to the pre-publish checklist video optimization item that allows the user to save their progress and reload the editor. The reload is necessary for the optimization to take affect. 

## Relevant Technical Choices

<!-- Please describe your changes. -->
Added a `hasOptedIn` state that gets updated to `true` if the user toggles the video optimization on. This is used to determine which `footer` to render in the checklist's card for video optimization. 
When they have opted in,  a `Save & Reload` button will now appear as the footer. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

![save](https://user-images.githubusercontent.com/1820266/147507189-54f3f021-e189-4eff-86fb-a778ff448fe7.gif)

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Go to settings in the editor, and turn off video optimization. 
2. Back in the story editor, add a new video that has not had the optimization. 
3. Open the checklist
4. You should see a checklist item under `Accessibility` that mentions the video optimization.
5. Click the checkbox to re-enable video optimization.
6. You should now see a `Save & Reload` button. 
7. Your progress should now be saved, then the page will reload.  


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7473 
