### PR TITLE
Collapse Footer Popups When Element is Trimming or Cropping

### DIFF
--- a/packages/story-editor/src/components/footer/secondaryMenu.js
+++ b/packages/story-editor/src/components/footer/secondaryMenu.js
@@ -26,7 +26,7 @@ import PropTypes from 'prop-types';
  */
 import KeyboardShortcutsMenu from '../keyboardShortcutsMenu';
 import { HelpCenter } from '../helpCenter';
-import { useHelpCenter } from '../../app';
+import { useCanvas, useHelpCenter } from '../../app';
 import {
   Checklist,
   ChecklistCountProvider,
@@ -102,6 +102,15 @@ function SecondaryMenu({ menu }) {
     })
   );
 
+  const isActiveTrimOrEdit = useCanvas(
+    ({
+      state: {
+        editingElementState: { isTrimMode },
+        isEditing,
+      },
+    }) => isTrimMode || isEditing
+  );
+
   const setPopupRef = useCallback((newPopup = '') => {
     expandedPopupRef.current = newPopup;
   }, []);
@@ -162,6 +171,16 @@ function SecondaryMenu({ menu }) {
     openChecklist,
     setPopupRef,
   ]);
+
+  // The checklist and help center will stay open as user interacts with canvas
+  // we want to collapse either of these if expanded when the trim or cropping mode is selected.
+  useEffect(() => {
+    if (isActiveTrimOrEdit && expandedPopupRef.current) {
+      setPopupRef();
+      closeChecklist();
+      closeHelpCenter();
+    }
+  }, [closeChecklist, closeHelpCenter, isActiveTrimOrEdit, setPopupRef]);
 
   return (
     <Wrapper>


### PR DESCRIPTION
## Context

Jonny flagged the overlay in trim when the checklist is expanded as a bug. 

## Summary

When canvas has true value for isTrimMode or isEditing we should close any open popups on the secondary footer menu (help center or checklist) because they interfere with trimming or editing ux.

## Relevant Technical Choices

Hook into `useCanvas` on the `SecondaryMenu` to keep track of `isTrimMode` and `isEditing` - trim mode will be true when in, yup, trim mode, and is editing is true when you double click into it to crop the element. Use these in tandem with checking for an active popup in a useEffect hook to then collapse the popups and reset the active one to none when one of these modes is triggered. 

Keyboard Shortcut popup always closes when you click outside of it so it's a nonfactor here. 

## To-do

Noticed that video trim has no tests added to it in quick menus, we should add some.


## User-facing changes

Old functionality: 

https://user-images.githubusercontent.com/10720454/147514137-c2c9e1b1-aeb1-48e8-b1c6-a6daf57c9cd3.mp4

New when `isEditing` is true:

https://user-images.githubusercontent.com/10720454/147514148-d27f61f5-2c9e-4cce-87ef-d34228dae675.mp4

New when `isTrimMode` is true: 

https://user-images.githubusercontent.com/10720454/147514154-829ff6a2-73ea-47d1-80fb-4f2a0776193a.mp4


## Testing Instructions

Try opening popups (checklist and helpcenter) and then entering trim or edit of an element, see that popups collapse. 

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9908 
