### PR TITLE
Mock blur hash in story editor karma tests

### DIFF
--- a/packages/story-editor/src/karma/fixture/fixture.js
+++ b/packages/story-editor/src/karma/fixture/fixture.js
@@ -42,6 +42,7 @@ import { createPage } from '../../elements';
 import { TEXT_ELEMENT_DEFAULT_FONT } from '../../app/font/defaultFonts';
 import formattedTemplatesArray from '../../dataUtils/formattedTemplatesArray';
 import { PRESET_TYPES } from '../../constants';
+import * as BlurHash from '../../app/media/utils/useDetectBlurhash.js';
 import getMediaResponse from './db/getMediaResponse';
 import { Editor as EditorContainer } from './containers';
 import taxonomiesResponse from './db/getTaxonomiesResponse';
@@ -182,6 +183,11 @@ export class Fixture {
       }
       return origCreateElement(type, props, ...children);
     });
+
+    //eslint-disable-next-line jasmine/no-unsafe-spy
+    spyOn(BlurHash, 'default').and.callFake(() => ({
+      updateBlurHash: Promise.resolve,
+    }));
 
     this.apiProviderFixture_ = new APIProviderFixture({ mocks });
     this.stubComponent(APIProvider).callFake(

--- a/packages/story-editor/src/karma/fixture/fixture.js
+++ b/packages/story-editor/src/karma/fixture/fixture.js
@@ -186,7 +186,7 @@ export class Fixture {
 
     //eslint-disable-next-line jasmine/no-unsafe-spy
     spyOn(BlurHash, 'default').and.callFake(() => ({
-      updateBlurHash: Promise.resolve,
+      updateBlurHash: () => {},
     }));
 
     this.apiProviderFixture_ = new APIProviderFixture({ mocks });


### PR DESCRIPTION
## Context

Karma tests are failing due to long timeouts. @spacedmonkey identified #9953 as the possible culprit. This is an attempt to mock the blur hash functionality.

## Summary

Mocks the `useDetectBlurHash` hook. This hook now returns a function that is a `no-op`.

Mocking this seems to make the tests pass.

## Relevant Technical Choices

A naive first approach that may need some more work. Not sure if we need to be implementing new blur hash behavior in the karma tests as well.

## To-do

n/a

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10052 
