### PR TITLE
Karma: enable test for inline style override

### DIFF
--- a/packages/story-editor/src/components/richText/karma/inlineStyleOverride.karma.js
+++ b/packages/story-editor/src/components/richText/karma/inlineStyleOverride.karma.js
@@ -284,9 +284,7 @@ describe('Inline style override', () => {
     });
   });
 
-  // TODO(#9388): Fix flaky test.
-  // eslint-disable-next-line jasmine/no-disabled-tests
-  xit('should have correct formatting deleting text with one formatting, ending up in different formatting', async () => {
+  it('should have correct formatting deleting text with one formatting, ending up in different formatting', async () => {
     // Toggle bold for entire selection
     await data.fixture.events.keyboard.shortcut('mod+b');
 
@@ -320,7 +318,7 @@ describe('Inline style override', () => {
     const actual = getTextContent();
     const expected = '<span style="font-weight: 700">Full in some text</span>';
     expect(actual).toBe(expected);
-    await data.fixture.snapshot('"Full in some text" in bold');
+    await data.fixture.snapshot('"Fill in some text" in bold');
   });
 
   it('should keep formatting when all text is replaced', async () => {

--- a/packages/story-editor/src/components/richText/karma/inlineStyleOverride.karma.js
+++ b/packages/story-editor/src/components/richText/karma/inlineStyleOverride.karma.js
@@ -284,7 +284,7 @@ describe('Inline style override', () => {
     });
   });
 
-  fit('should have correct formatting deleting text with one formatting, ending up in different formatting', async () => {
+  it('should have correct formatting deleting text with one formatting, ending up in different formatting', async () => {
     // Toggle bold for entire selection
     await data.fixture.events.keyboard.shortcut('mod+b');
 

--- a/packages/story-editor/src/components/richText/karma/inlineStyleOverride.karma.js
+++ b/packages/story-editor/src/components/richText/karma/inlineStyleOverride.karma.js
@@ -284,7 +284,7 @@ describe('Inline style override', () => {
     });
   });
 
-  it('should have correct formatting deleting text with one formatting, ending up in different formatting', async () => {
+  fit('should have correct formatting deleting text with one formatting, ending up in different formatting', async () => {
     // Toggle bold for entire selection
     await data.fixture.events.keyboard.shortcut('mod+b');
 

--- a/packages/story-editor/src/components/richText/karma/inlineStyleOverride.karma.js
+++ b/packages/story-editor/src/components/richText/karma/inlineStyleOverride.karma.js
@@ -318,7 +318,7 @@ describe('Inline style override', () => {
     const actual = getTextContent();
     const expected = '<span style="font-weight: 700">Full in some text</span>';
     expect(actual).toBe(expected);
-    await data.fixture.snapshot('"Fill in some text" in bold');
+    await data.fixture.snapshot('"Full in some text" in bold');
   });
 
   it('should keep formatting when all text is replaced', async () => {


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Looks like this might have gotten fixed within https://github.com/google/web-stories-wp/pull/9726 already, unable to reproduce currently.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
N/A
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9388 
