### PR TITLE
Remove cs2pr from PHPStan's output

### DIFF
--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -58,7 +58,7 @@ jobs:
         run: vendor/bin/phpcs -q --report=checkstyle --severity=1 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 | cs2pr --graceful-warnings
 
       - name: Static Analysis (PHPStan)
-        run: composer phpstan -- --error-format=checkstyle | cs2pr
+        run: composer phpstan
 
       - name: Static Analysis (PHPMD)
         run: composer phpmd


### PR DESCRIPTION
## Context

CI job errors.

## Summary

Modern PHPStan can speak GHA! Outputs annotations when ran in GHA.

