### PR TITLE
Media Library: Fix video drag & drop and crash upon deletion

### DIFF
--- a/packages/story-editor/src/components/library/panes/media/common/innerElement.js
+++ b/packages/story-editor/src/components/library/panes/media/common/innerElement.js
@@ -240,12 +240,6 @@ function InnerElement({
   }
 
   const dragHandler = (event) => {
-    if (
-      [ContentType.VIDEO, ContentType.GIF].includes(type) &&
-      !mediaElement.current?.paused
-    ) {
-      mediaElement.current?.pause();
-    }
     if (!hasSetResourceTracker.current) {
       // Drop-targets handling.
       resourceList.set(resource.id, {

--- a/packages/story-editor/src/components/library/panes/media/common/mediaElement.js
+++ b/packages/story-editor/src/components/library/panes/media/common/mediaElement.js
@@ -134,12 +134,7 @@ function Element({
         setHoverTimer(null);
       }
     };
-    if (isMenuOpen) {
-      if (mediaElement.current && !mediaElement.current.paused) {
-        // If it's a video, pause the preview while the dropdown menu is open.
-        mediaElement.current.pause();
-      }
-    } else {
+    if (!isMenuOpen) {
       if (active) {
         setShowVideoDetail(false);
         if (mediaElement.current && hoverTimer == null) {


### PR DESCRIPTION
## Context
- This PR fixes mediaElement breaking the story-editor
- This PR also Fixes #10166 
## Summary

Due to recent changes the deletion of a local `video` would lead to breaking the story editor since the node in ref changed from `video` tag to `img` tag.

## Relevant Technical Choices

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
1. You should be able to delete a local video without breaking the editor.
2. You should be able to reset the focus after closing the menu

## Testing Instructions
<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:
For #10161:
1. Go to local media tab
2. Focus on any local video
3. Click on dropdown and click on delete
4. You should be now able to delete without breaking the story-editor.

For #10166 :
1. Pick a shape from the shape tab
2. Use a local video and take it over the shape in canvas.
3. You should be able to see the video in the shape.
4. Use another video and drag it to the edge of canvas
6. You should be able to see the video as a background. 

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->
Fixes #10161 
Fixes #10166 