### PR TITLE
Explore Templates: fix RTL arrow directions

### DIFF
--- a/packages/dashboard/src/app/views/exploreTemplates/modal/templateDetails/content/index.js
+++ b/packages/dashboard/src/app/views/exploreTemplates/modal/templateDetails/content/index.js
@@ -108,6 +108,21 @@ function DetailsContent({
   }, [postersByPage]);
 
   const { NextButton, PrevButton } = useMemo(() => {
+    const nextIndex = isRTL ? activeTemplateIndex - 1 : activeTemplateIndex + 1;
+    const previousIndex = isRTL
+      ? activeTemplateIndex + 1
+      : activeTemplateIndex - 1;
+
+    const disablePrevious = isRTL
+      ? !filteredTemplatesLength ||
+        activeTemplateIndex === filteredTemplatesLength - 1
+      : !filteredTemplatesLength || activeTemplateIndex === 0;
+
+    const disableNext = isRTL
+      ? !filteredTemplatesLength || activeTemplateIndex === 0
+      : !filteredTemplatesLength ||
+        activeTemplateIndex === filteredTemplatesLength - 1;
+
     const Previous = (
       <Button
         type={BUTTON_TYPES.TERTIARY}
@@ -115,9 +130,9 @@ function DetailsContent({
         variant={BUTTON_VARIANTS.SQUARE}
         aria-label={__('View previous template', 'web-stories')}
         onClick={() => {
-          switchToTemplateByOffset(activeTemplateIndex - 1);
+          switchToTemplateByOffset(previousIndex);
         }}
-        disabled={!filteredTemplatesLength || activeTemplateIndex === 0}
+        disabled={disablePrevious}
       >
         <Icons.ArrowLeftLarge height={32} width={32} />
       </Button>
@@ -130,12 +145,9 @@ function DetailsContent({
         variant={BUTTON_VARIANTS.SQUARE}
         aria-label={__('View next template', 'web-stories')}
         onClick={() => {
-          switchToTemplateByOffset(activeTemplateIndex + 1);
+          switchToTemplateByOffset(nextIndex);
         }}
-        disabled={
-          !filteredTemplatesLength ||
-          activeTemplateIndex === filteredTemplatesLength - 1
-        }
+        disabled={disableNext}
       >
         <Icons.ArrowRightLarge height={32} width={32} />
       </Button>


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
While bug bashing new exploring templates modal we realized the arrows move in the wrong direction in RTL mode. 
## Summary

<!-- A brief description of what this PR does. -->
The right most arrow is the `Previous` when in RTL mode, whereas the left most arrow should be the `Next` button. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do
n/a
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Switch to RTL mode 
2. Go to Explore Templates 
3. One the first template click the See Details button
4. Ensure the arrow buttons move to the Next template, and the Previous button should be disabled when at the beginning of the templates list.


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10177 
