### PR TITLE
Library: Remove `showTextAndShapesSearchInput` experiment

### DIFF
--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -259,17 +259,6 @@ class Experiments extends Service_Base implements HasRequirements {
 				'group'       => 'dashboard',
 			],
 			/**
-			 * Author: @dmmulroy
-			 * Issue: #2098
-			 * Creation date: 2020-06-04
-			 */
-			[
-				'name'        => 'showTextAndShapesSearchInput',
-				'label'       => __( 'Library search', 'web-stories' ),
-				'description' => __( 'Enable search input on text and shapes tabs', 'web-stories' ),
-				'group'       => 'editor',
-			],
-			/**
 			 * Author: @diegovar
 			 * Issue: #2616
 			 * Creation date: 2020-06-23

--- a/packages/story-editor/src/components/library/panes/shapes/shapesPane.js
+++ b/packages/story-editor/src/components/library/panes/shapes/shapesPane.js
@@ -25,9 +25,8 @@ import STICKERS from '@web-stories-wp/stickers';
 /**
  * Internal dependencies
  */
-import { useFeatures } from 'flagged';
 import { MASKS } from '../../../../masks/constants';
-import { Section, SearchInput } from '../../common';
+import { Section } from '../../common';
 import { Pane } from '../shared';
 import useRovingTabIndex from '../../../../utils/useRovingTabIndex';
 import ShapePreview from './shapePreview';
@@ -54,8 +53,6 @@ const SectionContent = styled.div`
 const STICKER_TYPES = Object.keys(STICKERS);
 
 function ShapesPane(props) {
-  const { showTextAndShapesSearchInput } = useFeatures();
-
   const ref = useRef();
   useRovingTabIndex({ ref });
 
@@ -63,14 +60,6 @@ function ShapesPane(props) {
   useRovingTabIndex({ ref: stickersRef });
   return (
     <Pane id={paneId} {...props} isOverflowScrollable>
-      {showTextAndShapesSearchInput && (
-        <SearchInput
-          initialValue={''}
-          placeholder={__('Search', 'web-stories')}
-          onSearch={() => {}}
-          disabled
-        />
-      )}
       <Section
         data-testid="shapes-library-pane"
         title={__('Shapes', 'web-stories')}

--- a/packages/story-editor/src/components/library/panes/text/textPane.js
+++ b/packages/story-editor/src/components/library/panes/text/textPane.js
@@ -25,7 +25,6 @@ import {
   useCallback,
 } from '@web-stories-wp/react';
 import styled from 'styled-components';
-import { useFeatures } from 'flagged';
 import { __ } from '@web-stories-wp/i18n';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -33,7 +32,6 @@ import { v4 as uuidv4 } from 'uuid';
  * Internal dependencies
  */
 import { Text, THEME_CONSTANTS, Toggle } from '@web-stories-wp/design-system';
-import { SearchInput } from '../../common';
 import { Container as SectionContainer } from '../../common/section';
 import { Pane as SharedPane } from '../shared';
 import usePageAsCanvas from '../../../../utils/usePageAsCanvas';
@@ -72,8 +70,6 @@ function TextPane(props) {
   const paneRef = useRef();
   const [, forceUpdate] = useState();
 
-  const { showTextAndShapesSearchInput } = useFeatures();
-
   const { shouldUseSmartColor, setShouldUseSmartColor } = useLibrary(
     (state) => ({
       shouldUseSmartColor: state.state.shouldUseSmartColor,
@@ -102,14 +98,6 @@ function TextPane(props) {
   const toggleId = useMemo(() => `toggle_auto_color_${uuidv4()}`, []);
   return (
     <Pane id={paneId} {...props} ref={paneRef}>
-      {showTextAndShapesSearchInput && (
-        <SearchInput
-          initialValue={''}
-          placeholder={__('Search', 'web-stories')}
-          onSearch={() => {}}
-          disabled
-        />
-      )}
       <SmartColorToggle>
         <Text
           as="label"


### PR DESCRIPTION
## Context
Searching in text and shapes is an old feature and remains unused even though enabled in experiments.

## Summary
This PR removes `searchInput` in `textPane` and in `shapesPane` and removes the option in experiments page.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Go to experiments page and verify that the option for search in shapes and text is not there.
2. Go to story-editor the `searchBox` for `shapesPane` and `textPane` are not there any more.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10174
