### PR TITLE
Editor: Remove irrelevant `evt.persist()`

### DIFF
--- a/packages/story-editor/src/app/canvas/canvasProvider.js
+++ b/packages/story-editor/src/app/canvas/canvasProvider.js
@@ -138,7 +138,6 @@ function CanvasProvider({ children }) {
       }
 
       if ('mousedown' === evt.type) {
-        evt.persist();
         setLastSelectionEvent(evt);
 
         // Clear this selection event as soon as mouse is released

--- a/packages/story-editor/src/utils/useDoubleClick.js
+++ b/packages/story-editor/src/utils/useDoubleClick.js
@@ -67,7 +67,6 @@ const useDoubleClick = (onSingleClick, onDoubleClick, ms = null) => {
           onSingleClick(evt, target);
         }
         setTarget(newTarget);
-        evt.persist();
         setLastEvent(evt);
         return;
       }


### PR DESCRIPTION
## Context

While checking something else in the docs, I noticed that `evt.persist()` is irrelevant now, because [events aren't pooled anymore as of React 17](https://reactjs.org/blog/2020/08/10/react-v17-rc.html#no-event-pooling). This PR removes the two instances we had of this method invocation.

## User-facing changes

None!

## Testing Instructions

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #10187
