### PR TITLE
Explore Templates: Reset image state in modal 

### DIFF
--- a/packages/dashboard/src/app/views/exploreTemplates/modal/templateDetails/content/index.js
+++ b/packages/dashboard/src/app/views/exploreTemplates/modal/templateDetails/content/index.js
@@ -17,7 +17,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useMemo } from '@web-stories-wp/react';
+import { useEffect, useMemo, useState } from '@web-stories-wp/react';
 import { sprintf, __ } from '@web-stories-wp/i18n';
 import styled from 'styled-components';
 import {
@@ -96,13 +96,16 @@ function DetailsContent({
   template,
 }) {
   const { postersByPage, title, description, tags, colors } = template || {};
+  const [galleryPosters, setGalleryPosters] = useState([]);
 
-  const galleryPosters = useMemo(() => {
+  useEffect(() => {
     if (postersByPage) {
-      return Object.values(postersByPage).map((poster, index) => ({
-        id: index,
-        ...poster,
-      }));
+      setGalleryPosters(
+        Object.values(postersByPage).map((poster, index) => ({
+          id: index,
+          ...poster,
+        }))
+      );
     }
     return undefined;
   }, [postersByPage]);
@@ -131,6 +134,7 @@ function DetailsContent({
         aria-label={__('View previous template', 'web-stories')}
         onClick={() => {
           switchToTemplateByOffset(previousIndex);
+          setGalleryPosters([]);
         }}
         disabled={disablePrevious}
       >
@@ -146,6 +150,7 @@ function DetailsContent({
         aria-label={__('View next template', 'web-stories')}
         onClick={() => {
           switchToTemplateByOffset(nextIndex);
+          setGalleryPosters([]);
         }}
         disabled={disableNext}
       >


### PR DESCRIPTION

## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
When navigating the templates details modal, the thumbnail images can experience lag as you move to the next/previous template. This results in the wrong images appearing on newly viewed templates, and is very apparent with slower network speeds. 

## Summary

<!-- A brief description of what this PR does. -->
We reset the images state to nothing when navigating through the templates. Now old images are no longer lingering while we wait for the new images to load. 

## Relevant Technical Choices

<!-- Please describe your changes. -->
Removed the memoization of posterImages, and am now storing them in state. When navigating to next/previous templates we are reseting that state to an empty array. This clears out the old images. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->
### Example with throttled network
|Before|After
|--|--|
|![before](https://user-images.githubusercontent.com/1820266/149403795-d41f2111-633f-4973-b442-ad543fdb1752.gif)|![resetImages](https://user-images.githubusercontent.com/1820266/149403513-98b72c5c-8e32-45e8-b7f6-2d791aee4f5d.gif)|


## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Go to Explore Templates -> See Details
2. Navigate (quickly) through some templates. You should no longer see old images linger on new templates. 


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10178 
