### PR TITLE
Unit Tests: Fix proptype error in StoryMenu unit tests

### DIFF
--- a/packages/dashboard/src/components/storyMenu/test/storyMenu.js
+++ b/packages/dashboard/src/components/storyMenu/test/storyMenu.js
@@ -40,7 +40,7 @@ describe('StoryMenu', () => {
         onMoreButtonSelected={jest.fn}
         contextMenuId={1}
         menuItems={menuItems}
-        story={{ id: 1, status: 'publish', title: 'Sample Story' }}
+        storyId={1}
       />
     );
 
@@ -56,7 +56,7 @@ describe('StoryMenu', () => {
         onMoreButtonSelected={mockOnMoreButtonSelected}
         contextMenuId={1}
         menuItems={menuItems}
-        story={{ id: 1, status: 'publish', title: 'Sample Story' }}
+        storyId={1}
       />
     );
 


### PR DESCRIPTION
## Context

#9960 Added a prop type error in the js unit tests.

## Summary

Fix props in unit tests to remove prop type error from logs.

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10201
