### PR TITLE
Telemetry: Remove trackEvent call on mount

### DIFF
--- a/packages/dashboard/src/utils/useStoryView.js
+++ b/packages/dashboard/src/utils/useStoryView.js
@@ -124,15 +124,17 @@ export default function useStoryView({
   }, []);
 
   useEffect(() => {
-    trackEvent('search', {
-      search_type: 'dashboard_stories',
-      search_term: searchKeyword,
-      search_filter: filter,
-      search_author_filter: authorFilterId,
-      search_order: sortDirection,
-      search_orderby: sort,
-      search_view: viewStyle,
-    });
+    if (searchKeyword.length) {
+      trackEvent('search', {
+        search_type: 'dashboard_stories',
+        search_term: searchKeyword,
+        search_filter: filter,
+        search_author_filter: authorFilterId,
+        search_order: sortDirection,
+        search_orderby: sort,
+        search_view: viewStyle,
+      });
+    }
   }, [searchKeyword, filter, sortDirection, sort, viewStyle, authorFilterId]);
 
   useEffect(() => {

--- a/packages/story-editor/src/components/library/panes/media/media3p/media3pPane.js
+++ b/packages/story-editor/src/components/library/panes/media/media3p/media3pPane.js
@@ -89,13 +89,16 @@ function Media3pPane(props) {
 
   const selectedCategoryId =
     media3p[selectedProvider]?.state?.categories?.selectedCategoryId;
+
   useEffect(() => {
-    trackEvent('search', {
-      search_type: 'media3p',
-      search_term: searchTerm,
-      search_filter: selectedProvider,
-      search_category: selectedCategoryId,
-    });
+    if (searchTerm.length) {
+      trackEvent('search', {
+        search_type: 'media3p',
+        search_term: searchTerm,
+        search_filter: selectedProvider,
+        search_category: selectedCategoryId,
+      });
+    }
   }, [selectedProvider, searchTerm, selectedCategoryId]);
 
   const onSearch = useCallback(

--- a/packages/story-editor/src/components/library/panes/text/textSets/textSetsPane.js
+++ b/packages/story-editor/src/components/library/panes/text/textSets/textSetsPane.js
@@ -22,6 +22,7 @@ import {
   useMemo,
   useCallback,
   useEffect,
+  useRef,
 } from '@web-stories-wp/react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
@@ -89,6 +90,7 @@ function TextSetsPane({ paneRef }) {
     })
   );
   const [showInUse, setShowInUse] = useState(false);
+  const trackChange = useRef(false);
 
   const allTextSets = useMemo(() => Object.values(textSets).flat(), [textSets]);
   const storyPages = useStory(({ state: { pages } }) => pages);
@@ -172,22 +174,25 @@ function TextSetsPane({ paneRef }) {
       localStore.setItemByKey(`${LOCAL_STORAGE_PREFIX.TEXT_SET_SETTINGS}`, {
         selectedCategory,
       });
+      trackChange.current = true;
     },
     [speak]
   );
 
-  const onChangeShowInUse = useCallback(
-    () => requestAnimationFrame(() => setShowInUse((prevVal) => !prevVal)),
-    [setShowInUse]
-  );
+  const onChangeShowInUse = useCallback(() => {
+    requestAnimationFrame(() => setShowInUse((prevVal) => !prevVal));
+    trackChange.current = true;
+  }, [setShowInUse]);
 
   useEffect(() => {
-    trackEvent('search', {
-      search_type: 'textsets',
-      search_term: '',
-      search_category: selectedCat,
-      search_filter: showInUse ? 'show_in_use' : undefined,
-    });
+    if (selectedCat || showInUse || trackChange.current) {
+      trackEvent('search', {
+        search_type: 'textsets',
+        search_term: '',
+        search_category: selectedCat,
+        search_filter: showInUse ? 'show_in_use' : undefined,
+      });
+    }
   }, [selectedCat, showInUse]);
 
   const sectionId = useMemo(() => `section-${uuidv4()}`, []);

--- a/packages/story-editor/src/components/library/panes/text/textSets/textSetsPane.js
+++ b/packages/story-editor/src/components/library/panes/text/textSets/textSetsPane.js
@@ -185,7 +185,7 @@ function TextSetsPane({ paneRef }) {
   }, [setShowInUse]);
 
   useEffect(() => {
-    if (selectedCat || showInUse || trackChange.current) {
+    if (trackChange.current) {
       trackEvent('search', {
         search_type: 'textsets',
         search_term: '',


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
In some instances we were calling `trackEvent` in an `useEffect`. Most of these cases included a check as to whether the event should be track due to some triggering event. However, in a couple places there wasn't a preventative check which was leading to the `trackEvent` getting called on mount, or during each re-render. We only want to call trackEvent when those events are truly triggered. 

## Summary

<!-- A brief description of what this PR does. -->

Add a check before calling `trackEvent` when trackEvent is called in a `useEffect` to avoid calling them when the component mounts. 

## Relevant Technical Choices

<!-- Please describe your changes. -->
Check for searchTerm length before calling trackEvent. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. You can turn on tracking via the tracking package shared config file.  (There might be another way to change this setting, but this worked for me)
2. Go to package -> tracking -> src -> shared 
3. change `trackingAllowed: true, trackingEnabled: true`
4. Tracking changed in 3 place. `TextSets` `Media3p` and the `Dashboard`
5. Go to text set tab and open console. 
6. In the console type `window.webStoriesTrackingDataLayer` and hit enter. 
7. You will see a list of all the tracking events
8. Filter text set by either `Match fonts from story` or selecting one of the pills ie. `COVER` , `STEPS` etc.
9.  In the console type `window.webStoriesTrackingDataLayer` and hit enter again. You should see the new `search` event in `window.webStoriesTrackingDataLayer` TWICE. Each one is sent to two different places. Not sure why. 
10. Repeat for Media3p search and Dashboard search


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
Yes!
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7738 
