### PR TITLE
Embeds: Use native `<img>` instead of `<amp-img>`

### DIFF
--- a/includes/Renderer/Stories/Renderer.php
+++ b/includes/Renderer/Stories/Renderer.php
@@ -591,26 +591,14 @@ abstract class Renderer implements RenderingInterface, Iterator {
 			?>
 			<div class="web-stories-list__story-poster">
 				<a href="<?php echo esc_url( $story->get_url() ); ?>">
-					<?php
-					if ( $this->context->is_amp() ) {
-						// Set the dimensions to '0' so that we can handle image ratio/size by CSS per view type.
-						?>
-						<amp-img
-							src="<?php echo esc_url( $poster_url ); ?>"
-							layout="responsive"
-							width="0"
-							height="0"
-							alt="<?php echo esc_attr( $story->get_title() ); ?>"
-						>
-						</amp-img>
-	<?php } else { ?>
-						<img
-							src="<?php echo esc_url( $poster_url ); ?>"
-							alt="<?php echo esc_attr( $story->get_title() ); ?>"
-							width="<?php echo absint( $this->width ); ?>"
-							height="<?php echo absint( $this->height ); ?>"
-						>
-					<?php } ?>
+					<img
+						src="<?php echo esc_url( $poster_url ); ?>"
+						alt="<?php echo esc_attr( $story->get_title() ); ?>"
+						width="<?php echo absint( $this->width ); ?>"
+						height="<?php echo absint( $this->height ); ?>"
+						loading="lazy"
+						decoding="async"
+					>
 				</a>
 			</div>
 			<?php

--- a/packages/stories-block/src/css/common.css
+++ b/packages/stories-block/src/css/common.css
@@ -83,11 +83,6 @@
   box-sizing: border-box;
 }
 
-.web-stories-list__story-poster amp-img img {
-  object-fit: cover;
-  box-sizing: border-box;
-}
-
 .web-stories-list__story-poster::before {
   content: '';
   display: block;

--- a/packages/stories-block/src/css/views/circles.css
+++ b/packages/stories-block/src/css/views/circles.css
@@ -30,11 +30,7 @@
   .web-stories-list__story-poster
   .web-stories-list__story-poster-placeholder,
 .web-stories-list.is-view-type-circles .web-stories-list__story-poster > img,
-.web-stories-list.is-view-type-circles .web-stories-list__story-poster a > img,
-.web-stories-list.is-view-type-circles
-  .web-stories-list__story-poster
-  a
-  > amp-img {
+.web-stories-list.is-view-type-circles .web-stories-list__story-poster a > img {
   position: absolute;
   top: 0;
   left: 0;


### PR DESCRIPTION
## Context
- With the introduction of sandboxing levels (check https://github.com/ampproject/amp-wp/pull/6546) in [AMP 2.2.0 release](https://github.com/ampproject/amp-wp/releases/tag/2.2.0), it was noticed that the Web Stories' poster images weren't rendering properly.

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
- The PR removes the `<amp-img/>` element from the markup so the native `<img/>` HTML element will be used on both AMP & Non-AMP pages.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
- The issue of Poster images not rendering properly happened in the first place because the `amp-img` tag had some missing styles which were only given for the `img` tag (non-AMP page), and since there's no CSS processing happening on the `Loose` sandboxing level, the AMP plugin wasn't adding in the styles for `amp-img`.
- adding the missing styles could've also fixed the issue but since `amp-img` is going to be deprecated soon, it makes sense to remove the markup entirely.

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
- Install latest (2.2.0) [AMP Plugin](https://wordpress.org/plugins/amp/) from the Plugins directory.
- Install latest (1.15.1) [Web Stories plugin](https://wordpress.org/plugins/web-stories/) from the Plugins directory.
- Enable the `Loose` experimental sandboxing level. You'll have to have the AMP running on `Standard` mode for this option to be visible.
![Screenshot 2022-01-17 at 7 42 12 PM](https://user-images.githubusercontent.com/59014930/149785342-c5cff5a1-5f69-469f-9463-5e69b970c0d8.png)
- Add the `Web Stories` block on a post or a page. By default, if there's no AMP-invalid markup on a page, the AMP plugin will switch to higher/stricter sandboxing levels automatically, if that's the case, you can add a `Custom HTML` core block with some invalid AMP content (`<script></script>` will do the job).
- Visit the page/post on front-end and check the Poster images of the Web Stories block aren't being rendered properly.
- Make sure on the admin-bar, you see the sandboxing level is set to `Loose/1`.
![Screenshot 2022-01-17 at 7 46 38 PM](https://user-images.githubusercontent.com/59014930/149786040-b84a6b9e-6e47-458c-92c2-c2d583ed56e0.png)

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->


<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Checkout the branch and you can follow instructions mentioned above.


## Reviews

### Does this PR have a security-related impact?
No
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
No
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

## Screenshots
- Before
![Screenshot 2022-01-14 at 11 21 26 PM](https://user-images.githubusercontent.com/59014930/149800373-d9548de2-c1e8-4637-bf0a-4574e62f462d.png)

- After
![Screenshot 2022-01-14 at 11 23 53 PM](https://user-images.githubusercontent.com/59014930/149800404-1c0c9fe6-c579-4709-b677-3b575b72a649.png)


<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->
Fixes #10213
