### PR TITLE
Media Library: don't use item index as `key` prop

### DIFF
--- a/packages/story-editor/src/components/library/panes/media/common/mediaGallery.js
+++ b/packages/story-editor/src/components/library/panes/media/common/mediaGallery.js
@@ -45,6 +45,7 @@ const PHOTO_MARGIN = 4;
  */
 function MediaGallery({ resources, onInsert, providerType, canEditMedia }) {
   const photos = resources.map((resource) => ({
+    id: resource.id,
     src: resource.src,
     width: resource.width,
     height: resource.height,
@@ -53,7 +54,7 @@ function MediaGallery({ resources, onInsert, providerType, canEditMedia }) {
   const imageRenderer = useCallback(
     ({ index, photo }) => (
       <MediaElement
-        key={index}
+        key={photo.id}
         index={index}
         margin={PHOTO_MARGIN + 'px'}
         resource={resources[index]}


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

Miina observed some strange issues with poster images showing up in the media library after trimming a video.

I tracked this down to wrong usage of the `key` prop in the `imageRenderer` within the media library.

Trimming a video means a new item is added to the media list, which of course messes things up when using the array index as the key.

Using indexes for the `key` prop in React is bad practice, see https://reactjs.org/docs/lists-and-keys.html and https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318 for some explanations why.

We do have a lint rule for this, but it's not applied in this section because it's in a render prop and not in a loop.

## Summary

<!-- A brief description of what this PR does. -->

This PR updates the `key` prop to use the photo's ID instead.

The ID is either a temp ID for resources still being uploaded, or a numeric ID from the WP database.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Trim a video in the editor
2. Scroll down the media library list
3. See that there are no stretched poster images suddenly appearing before/after a regular video in the library grid


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
