### PR TITLE
Fix Video Poster Not Rendering on Canvas in Safari

### DIFF
--- a/packages/media/src/types.js
+++ b/packages/media/src/types.js
@@ -68,7 +68,7 @@ ResourcePropTypes.videoResource = PropTypes.shape({
   width: PropTypes.number.isRequired,
   height: PropTypes.number.isRequired,
   poster: PropTypes.string,
-  posterId: PropTypes.number,
+  posterId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   tracks: PropTypes.arrayOf(ResourcePropTypes.trackResource),
   alt: PropTypes.string,
   title: PropTypes.string,

--- a/packages/story-editor/src/elements/video/display.js
+++ b/packages/story-editor/src/elements/video/display.js
@@ -112,7 +112,7 @@ function VideoDisplay({ previewMode, box: { width, height }, element }) {
           poster={poster || resource.poster}
           style={style}
           {...videoProps}
-          preload="metadata"
+          preload="all"
           loop={loop}
           muted={muted}
           ref={ref}


### PR DESCRIPTION
## Context

Video posters aren't getting rendered on canvas (have to hit play in order for it to render). 

| Safari | Chrome/Firefox | 
| --- | --- | 
| <img width="271" alt="Screen Shot 2022-01-18 at 3 02 32 PM" src="https://user-images.githubusercontent.com/10720454/150025905-bc0e0de6-57d6-4b46-a6f0-4fe0ca195cb5.png"> | <img width="221" alt="Screen Shot 2022-01-18 at 3 02 49 PM" src="https://user-images.githubusercontent.com/10720454/150025927-eee90c45-3863-48c5-9c50-364171a96b84.png"> |

## Summary

Now when you load a story with video in safari you get to see their poster images. 

## Relevant Technical Choices

The `video` element that's in charge of canvas videos needed to get its `preload` tag updated from `metadata`. Even though specs say Safari can use the preload tag, that browser treats 'metadata' differently from others? We're using `all` as the preload value in the gif `video` implementation so I opted to use that for the video tag here. It's the same as putting down `auto` or `true` or `akldfjlafdjlakdfjlaksf` because it's just the default value. 

## To-do

I remember seeing a ticket for this, I will track it down again, but sometimes the images rendered in the footer on safari will still have the pesky gray rectangle for video. It's a separate issue from this but I wanted to mention it. 

## User-facing changes

Videos will load poster now on canvas in safari. 

## Testing Instructions

Open the editor and add video (local, 3p), see that you don't get a gray rectangle. Now save and refresh and note that the video posters still load (no gray rectangle in canvas). 

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10167 
