### PR TITLE
Performance: Remove Extraneous Re-Renders in Frames Layer

### DIFF
--- a/packages/story-editor/src/app/canvas/canvasProvider.js
+++ b/packages/story-editor/src/app/canvas/canvasProvider.js
@@ -96,7 +96,8 @@ function CanvasProvider({ children }) {
   } = useEditingElement();
 
   const {
-    currentPage,
+    elements,
+    backgroundElementId,
     selectedElementIds,
     toggleElementInSelection,
     setSelectedElementsById,
@@ -105,8 +106,10 @@ function CanvasProvider({ children }) {
       state: { currentPage, selectedElementIds },
       actions: { toggleElementInSelection, setSelectedElementsById },
     }) => {
+      const elements = currentPage?.elements || [];
       return {
-        currentPage,
+        elements,
+        backgroundElementId: elements[0]?.id,
         selectedElementIds,
         toggleElementInSelection,
         setSelectedElementsById,
@@ -133,7 +136,7 @@ function CanvasProvider({ children }) {
         setSelectedElementsById({ elementIds: [elId] });
       }
       evt.currentTarget.focus({ preventScroll: true });
-      if (currentPage?.elements[0].id !== elId) {
+      if (backgroundElementId !== elId) {
         evt.stopPropagation();
       }
 
@@ -151,7 +154,7 @@ function CanvasProvider({ children }) {
     },
     [
       editingElement,
-      currentPage?.elements,
+      backgroundElementId,
       clearEditing,
       toggleElementInSelection,
       setSelectedElementsById,
@@ -161,7 +164,7 @@ function CanvasProvider({ children }) {
   const selectIntersection = useCallback(
     ({ x: lx, y: ly, width: lw, height: lh }) => {
       const lassoP = createPolygon(0, lx, ly, lw, lh);
-      const newSelectedElementIds = currentPage.elements
+      const newSelectedElementIds = elements
         .filter(({ isBackground }) => !isBackground)
         .map(({ id, rotationAngle, x, y, width, height }) => {
           const elementP = createPolygon(rotationAngle, x, y, width, height);
@@ -170,7 +173,7 @@ function CanvasProvider({ children }) {
         .filter((id) => id);
       setSelectedElementsById({ elementIds: newSelectedElementIds });
     },
-    [currentPage, setSelectedElementsById]
+    [elements, setSelectedElementsById]
   );
 
   // Reset editing mode when selection changes.

--- a/packages/story-editor/src/components/canvas/frameElement.js
+++ b/packages/story-editor/src/components/canvas/frameElement.js
@@ -23,13 +23,14 @@ import {
   useLayoutEffect,
   useRef,
   useState,
+  memo,
 } from '@googleforcreators/react';
 import { useUnits } from '@googleforcreators/units';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
-import StoryPropTypes from '../../types';
 import { getDefinitionForType } from '../../elements';
 import { useStory, useTransform, useCanvas } from '../../app';
 import {
@@ -78,33 +79,34 @@ const EmptyFrame = styled.div`
 
 const NOOP = () => {};
 
-function FrameElement({ element }) {
+function FrameElement({ id }) {
+  const { isSelected, isSingleElement, isBackground, element } = useStory(
+    ({ state }) => ({
+      isSelected: state.selectedElementIds.includes(id),
+      isSingleElement: state.selectedElementIds.length === 1,
+      isBackground: state.currentPage?.elements[0].id === id,
+      element: state.currentPage?.elements.find((el) => el.id === id),
+    })
+  );
   const setEditingElement = useCanvas(
     ({ actions }) => actions.setEditingElement
   );
-  const { id, type, flip } = element;
+  const { type, flip } = element;
   const { Frame, isMaskable, Controls } = getDefinitionForType(type);
   const elementRef = useRef();
   const [hovering, setHovering] = useState(false);
-  const isAnythingTransforming = useTransform(
-    ({ state }) => state.isAnythingTransforming
-  );
 
   const onPointerEnter = () => setHovering(true);
   const onPointerLeave = () => setHovering(false);
 
+  const isLinkActive = useTransform(
+    ({ state }) => !isSelected && hovering && !state.isAnythingTransforming
+  );
   const { setNodeForElement, handleSelectElement, isEditing } = useCanvas(
     ({ state, actions }) => ({
       setNodeForElement: actions.setNodeForElement,
       handleSelectElement: actions.handleSelectElement,
       isEditing: state.isEditing,
-    })
-  );
-  const { isSelected, isSingleElement, isBackground } = useStory(
-    ({ state }) => ({
-      isSelected: state.selectedElementIds.includes(id),
-      isSingleElement: state.selectedElementIds.length === 1,
-      isBackground: state.currentPage?.elements[0].id === id,
     })
   );
   const getBox = useUnits(({ actions }) => actions.getBox);
@@ -171,11 +173,7 @@ function FrameElement({ element }) {
   });
 
   return (
-    <WithLink
-      element={element}
-      active={!isSelected && hovering && !isAnythingTransforming}
-      anchorRef={elementRef}
-    >
+    <WithLink element={element} active={isLinkActive} anchorRef={elementRef}>
       {Controls && (
         <Controls
           isTransforming={isTransforming}
@@ -218,7 +216,7 @@ function FrameElement({ element }) {
 }
 
 FrameElement.propTypes = {
-  element: StoryPropTypes.element.isRequired,
+  id: PropTypes.string.isRequired,
 };
 
-export default FrameElement;
+export default memo(FrameElement);

--- a/packages/story-editor/src/components/canvas/framesLayer.js
+++ b/packages/story-editor/src/components/canvas/framesLayer.js
@@ -58,7 +58,7 @@ const DesignSpaceGuidelineBorder = styled.div`
   visibility: ${({ isVisible }) => (isVisible ? 'visible' : 'hidden')};
 `;
 
-const DesignSpaceGuideline = function DesignSpaceGuidline() {
+function DesignSpaceGuideline() {
   const setDesignSpaceGuideline = useCanvas(
     ({ actions }) => actions.setDesignSpaceGuideline
   );
@@ -72,7 +72,7 @@ const DesignSpaceGuideline = function DesignSpaceGuidline() {
       isVisible={isAnythingTransforming}
     />
   );
-};
+}
 
 function FramesLayer() {
   // were returning this directly because we want the elementIds array to be shallowly
@@ -89,7 +89,8 @@ function FramesLayer() {
   );
 
   const framesLayerRef = useRef(null);
-  // TODO: refactor `useCanvasKeys`. This is the last hook causing extraneous re-renders in this component.
+  // TODO: https://github.com/google/web-stories-wp/issues/10266
+  // refactor `useCanvasKeys`. This is the last hook causing extraneous re-renders in this component.
   // - pulls most of state from useStory and only creates actions and attaches them to hot keys
   // - extraneous re-renders in this component contribute only ~1ms to total re-render time,
   //   so this is a high hanging fruit with little reward.

--- a/packages/story-editor/src/components/canvas/framesLayer.js
+++ b/packages/story-editor/src/components/canvas/framesLayer.js
@@ -75,7 +75,7 @@ function DesignSpaceGuideline() {
 }
 
 function FramesLayer() {
-  // were returning this directly because we want the elementIds array to be shallowly
+  // We are returning this directly because we want the elementIds array to be shallowly
   // compared between re-renders. This allows element properties to update without re-rendering
   // this top level component.
   const elementIds = useStory(

--- a/packages/story-editor/src/components/canvas/framesLayer.js
+++ b/packages/story-editor/src/components/canvas/framesLayer.js
@@ -27,7 +27,7 @@ import { STORY_ANIMATION_STATE } from '@googleforcreators/animation';
  * Internal dependencies
  */
 import { useKeyDownEffect } from '@googleforcreators/design-system';
-import { DESIGN_SPACE_MARGIN } from '../../constants';
+import { DESIGN_SPACE_MARGIN, STABLE_ARRAY } from '../../constants';
 import {
   useStory,
   useCanvas,
@@ -45,7 +45,8 @@ const FramesPageArea = styled(PageArea)`
   pointer-events: initial;
 `;
 const marginRatio = 100 * (DESIGN_SPACE_MARGIN / PAGE_WIDTH);
-const DesignSpaceGuideline = styled.div`
+
+const DesignSpaceGuidelineBorder = styled.div`
   border: 1px solid ${({ theme }) => theme.colors.border.negativePress};
   left: ${marginRatio}%;
   right: ${marginRatio}%;
@@ -57,28 +58,44 @@ const DesignSpaceGuideline = styled.div`
   visibility: ${({ isVisible }) => (isVisible ? 'visible' : 'hidden')};
 `;
 
-function FramesLayer() {
-  const { currentPage, isAnimating } = useStory((state) => ({
-    currentPage: state.state.currentPage,
-    isAnimating: [
-      STORY_ANIMATION_STATE.PLAYING,
-      STORY_ANIMATION_STATE.SCRUBBING,
-    ].includes(state.state.animationState),
+const DesignSpaceGuideline = function DesignSpaceGuidline() {
+  const setDesignSpaceGuideline = useCanvas(
+    ({ actions }) => actions.setDesignSpaceGuideline
+  );
+  const { isAnythingTransforming } = useTransform(({ state }) => ({
+    isAnythingTransforming: state.isAnythingTransforming,
   }));
-  const { setDesignSpaceGuideline } = useCanvas(
-    ({ actions: { setDesignSpaceGuideline } }) => ({
-      setDesignSpaceGuideline,
-    })
+
+  return (
+    <DesignSpaceGuidelineBorder
+      ref={setDesignSpaceGuideline}
+      isVisible={isAnythingTransforming}
+    />
+  );
+};
+
+function FramesLayer() {
+  // were returning this directly because we want the elementIds array to be shallowly
+  // compared between re-renders. This allows element properties to update without re-rendering
+  // this top level component.
+  const elementIds = useStory(
+    ({ state }) =>
+      state.currentPage?.elements?.map((el) => el.id) || STABLE_ARRAY
+  );
+  const isAnimating = useStory(({ state }) =>
+    [STORY_ANIMATION_STATE.PLAYING, STORY_ANIMATION_STATE.SCRUBBING].includes(
+      state.animationState
+    )
   );
 
-  const { isAnythingTransforming } = useTransform((state) => ({
-    isAnythingTransforming: state.state.isAnythingTransforming,
-  }));
-
   const framesLayerRef = useRef(null);
+  // TODO: refactor `useCanvasKeys`. This is the last hook causing extraneous re-renders in this component.
+  // - pulls most of state from useStory and only creates actions and attaches them to hot keys
+  // - extraneous re-renders in this component contribute only ~1ms to total re-render time,
+  //   so this is a high hanging fruit with little reward.
   useCanvasKeys(framesLayerRef);
 
-  const { onOpenMenu } = useRightClickMenu();
+  const onOpenMenu = useRightClickMenu((state) => state.onOpenMenu);
 
   const { setScrollOffset } = useLayout(({ actions: { setScrollOffset } }) => ({
     setScrollOffset,
@@ -114,14 +131,10 @@ function FramesLayer() {
           onContextMenu={onOpenMenu}
           onScroll={onScroll}
         >
-          {currentPage &&
-            currentPage.elements.map((element) => {
-              return <FrameElement key={element.id} element={element} />;
-            })}
-          <DesignSpaceGuideline
-            ref={setDesignSpaceGuideline}
-            isVisible={isAnythingTransforming}
-          />
+          {elementIds.map((id) => {
+            return <FrameElement key={id} id={id} />;
+          })}
+          <DesignSpaceGuideline />
         </FramesPageArea>
       )}
       <NavPrevArea>

--- a/packages/story-editor/src/components/canvas/test/_utils.js
+++ b/packages/story-editor/src/components/canvas/test/_utils.js
@@ -65,6 +65,13 @@ export function TestFrameElement({
       selectedElements: [],
       selectedElementIds: [],
       ...(inputStoryContext && inputStoryContext.state),
+      currentPage: {
+        ...(inputStoryContext.state?.currentPage || {}),
+        elements: [
+          element,
+          ...(inputStoryContext.state?.currentPage?.elements || []),
+        ],
+      },
     },
     actions: {
       toggleElementInSelection: () => {},
@@ -87,7 +94,7 @@ export function TestFrameElement({
             <CanvasProvider>
               <TransformProvider>
                 <WithRefs refs={refs}>
-                  <FrameElement element={element} />
+                  <FrameElement id={element.id} />
                 </WithRefs>
               </TransformProvider>
             </CanvasProvider>

--- a/packages/story-editor/src/components/transform/useTransformHandler.js
+++ b/packages/story-editor/src/components/transform/useTransformHandler.js
@@ -36,9 +36,9 @@ import useTransform from './useTransform';
  * @param {Array} [deps] The effect's dependencies.
  */
 function useTransformHandler(id, handler, deps = undefined) {
-  const {
-    actions: { registerTransformHandler },
-  } = useTransform();
+  const registerTransformHandler = useTransform(
+    ({ actions }) => actions.registerTransformHandler
+  );
 
   useEffect(
     () => registerTransformHandler(id, handler),


### PR DESCRIPTION
## Context
Part of ongoing performance work.

## Summary
Removes empty re-renders of frame elements.

Running against these tests:
https://github.com/google/web-stories-wp/issues/10158

**Element Selection**
| Before | After |
| ----- | -----|
| React | React |
| Longest Commit | Longest Commit |
| ~92ms | ~56ms |
| Frames Layer | Frames Layer |
| ~45ms | ~1.7ms |
| <img width="630" alt="Screen Shot 2022-01-19 at 10 16 24 AM" src="https://user-images.githubusercontent.com/35983235/150170978-2882431f-f13c-4642-b82f-6c18a23ca415.png"> |  <img width="559" alt="Screen Shot 2022-01-19 at 10 16 09 AM" src="https://user-images.githubusercontent.com/35983235/150171006-5936ee78-929a-4196-8ace-39566a75232b.png"> |
| Total JS | Total JS |
| ~167ms | ~120ms |
| <img width="631" alt="Screen Shot 2022-01-19 at 10 28 02 AM" src="https://user-images.githubusercontent.com/35983235/150173019-b22d7ce1-6c74-46a9-b666-bb7e18300063.png"> |  <img width="500" alt="Screen Shot 2022-01-19 at 10 23 37 AM" src="https://user-images.githubusercontent.com/35983235/150173335-7acffd33-497d-4da8-a994-c9005ad2ddcb.png"> |






**Starting the drag of element to update position**
| Before | After |
| ----- | -----|
| React | React |
| Longest Commit | Longest Commit |
| ~80ms | ~2ms |
| Frames Layer | Frames Layer |
| ~44ms | ~1.6ms |
| <img width="686" alt="Screen Shot 2022-01-19 at 10 07 55 AM" src="https://user-images.githubusercontent.com/35983235/150170207-f43067f9-1695-4f3a-b130-152882468aa0.png"> |  <img width="679" alt="Screen Shot 2022-01-19 at 10 11 59 AM" src="https://user-images.githubusercontent.com/35983235/150170234-562b95b6-1af4-4ffd-85ab-79e3d6ee9222.png"> |
| Total JS | Total JS |
| ~182ms | ~36ms |
| <img width="687" alt="Screen Shot 2022-01-19 at 10 04 24 AM" src="https://user-images.githubusercontent.com/35983235/150169030-a1e895b2-323f-4dee-956f-2eb7ac43be81.png"> |  <img width="675" alt="Screen Shot 2022-01-19 at 10 05 04 AM" src="https://user-images.githubusercontent.com/35983235/150169055-410a50a5-904e-4a83-ac54-8bb641f86201.png"> |




**Ending the drag of element to update position**
| Before | After |
| ----- | -----|
| React | React |
| Longest Commit | Longest Commit |
| ~92ms | ~60ms |
| Frames Layer | Frames Layer |
| ~44ms | ~7.5ms |
| <img width="688" alt="Screen Shot 2022-01-19 at 9 54 59 AM" src="https://user-images.githubusercontent.com/35983235/150167370-8555e638-e44a-479b-86bc-0a9ba68f17c7.png"> | <img width="675" alt="Screen Shot 2022-01-19 at 9 51 20 AM" src="https://user-images.githubusercontent.com/35983235/150167401-89fc37dd-92ee-4989-8299-e404ea59801b.png"> |
| Total JS | Total JS |
| ~382ms | ~204ms |
| <img width="689" alt="Screen Shot 2022-01-19 at 10 01 13 AM" src="https://user-images.githubusercontent.com/35983235/150168485-dcfbbed6-c7c0-4110-bf68-5bcd0978f125.png"> |  <img width="678" alt="Screen Shot 2022-01-19 at 10 01 40 AM" src="https://user-images.githubusercontent.com/35983235/150168535-1d49b8ea-5b14-4082-ba9d-38c29eeab2ae.png"> |

**Changing Layer Order**
_Screenshots of flame graphs are similar to above, so going to omit for brevity here_
| Before | After |
| ----- | ----- |
| React | React |
| Longest Commit | Longest Commit |
| ~92ms | ~55ms |
| Frames Layer | Frames Layer |
| ~42ms | ~3.6ms |
| Total JS | Total JS|
| ~182ms | ~127ms |




## Relevant Technical Choices
Better context selector usage and memoization.

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
NA
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
NA
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10079 
