### PR TITLE
Karma: Fix Page Templates Test Failure 

### DIFF
--- a/packages/story-editor/src/karma/fixture/containers/library/pageTemplates.js
+++ b/packages/story-editor/src/karma/fixture/containers/library/pageTemplates.js
@@ -41,7 +41,7 @@ export default class PageTemplates extends Container {
   }
 
   get dropDown() {
-    return this.getByRole('button', { name: 'Select templates type' });
+    return this.queryByRole('button', { name: 'Select templates type' });
   }
 
   dropDownOption(name) {

--- a/packages/story-editor/src/karma/integrationLayerTesting/optionalCallbacks.karma.js
+++ b/packages/story-editor/src/karma/integrationLayerTesting/optionalCallbacks.karma.js
@@ -109,14 +109,6 @@ describe('Integration Layer tests : Optional API Callbacks', () => {
       await fixture.events.click(fixture.editor.library.pageTemplatesTab);
     });
 
-    await fixture.events.click(
-      fixture.editor.library.pageTemplatesPane.dropDown
-    );
-
-    const optionArray = fixture.screen.getAllByRole('option', {
-      name: /templates/,
-    });
-
-    expect(optionArray.length).toBe(1);
+    expect(fixture.editor.library.pageTemplatesPane.dropDown).toBeNull();
   });
 });


### PR DESCRIPTION
## Context

Two branches got merged earlier today that crossed wires on expectations of page templates - #10078 and #10217.  One of them was responsible for not showing the dropdown if there is only one type of page template to view and the other limiting templates shown.

## Summary

Using `queryByRole` for the page templates dropdown so it's allowed to comeback null. 
Updating what is expected with `should not render custom page templates option if getCustomPageTemplates callback is undefined` - new expectation is no dropdown instead of a dropdown with 1 option.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

None

## Testing Instructions

See karma test passing


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10263 
