### PR TITLE
Template Details: Chips are divs not buttons

### DIFF
--- a/packages/dashboard/src/app/views/exploreTemplates/modal/templateDetails/content/index.js
+++ b/packages/dashboard/src/app/views/exploreTemplates/modal/templateDetails/content/index.js
@@ -73,7 +73,7 @@ const PaginationContainer = styled.div`
         `}
 `;
 
-const TemplateTag = styled(Chip)`
+const TemplateTag = styled(Chip).attrs({ forwardedAs: 'div' })`
   margin-right: 12px;
   margin-bottom: 12px;
   > span {


### PR DESCRIPTION
## Context

Called out in bug bash, template details chips that hold template tags are rendered as disabled buttons. They aren't clickable with our current implementation so we should not have them be buttons. 

## Summary

Forwards `div` to `Chip` component to override what element it's rendered as. I remember this being there at some earlier point but it got away. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

Chip is a div now not a button. No real changes to notice. 


## Testing Instructions

Verify this: 

Yes: 
<img width="427" alt="Screen Shot 2022-01-19 at 2 50 50 PM" src="https://user-images.githubusercontent.com/10720454/150220234-9270d347-11ff-4b1a-847d-e26d104f0344.png"> 

No: 
![image](https://user-images.githubusercontent.com/10720454/150220617-45cc5a6c-0934-4d2f-baba-c404d934c40e.png)



## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10175 
