### PR TITLE
Karma: Fix Drop Target Handle Image Dragged from Library 

### DIFF
--- a/packages/story-editor/src/components/dropTargets/karma/dropTarget.karma.js
+++ b/packages/story-editor/src/components/dropTargets/karma/dropTarget.karma.js
@@ -24,6 +24,7 @@ import { waitFor } from '@testing-library/react';
  */
 import { Fixture } from '../../../karma';
 import { useStory } from '../../../app/story';
+import { useLocalMedia } from '../../../app/media';
 
 describe('Drop-Target integration', () => {
   let fixture;
@@ -107,9 +108,7 @@ describe('Drop-Target integration', () => {
       expect(bgElement.resource.baseColor).toEqual('#734727');
     });
 
-    // TODO: https://github.com/google/web-stories-wp/issues/10145
-    // eslint-disable-next-line jasmine/no-disabled-tests
-    xit('should correctly handle image dragged from library straight to edge (no cached base color)', async () => {
+    it('should correctly handle image dragged from library straight to edge (no cached base color)', async () => {
       const backgroundId = (await getElements(fixture))[0].id;
 
       // Verify that bg replacement is empty
@@ -118,7 +117,13 @@ describe('Drop-Target integration', () => {
       expect(rep1).toBeEmpty();
 
       // Get library element reference
-      const libraryElement = fixture.editor.library.media.item(4);
+      const mediaIndex = 4;
+      const { mediaResource } = await fixture.renderHook(() =>
+        useLocalMedia(({ state }) => ({
+          mediaResource: state.media[mediaIndex],
+        }))
+      );
+      const libraryElement = fixture.editor.library.media.item(mediaIndex);
 
       // Drag the element to the background
       await dragToDropTarget(fixture, libraryElement, backgroundId);
@@ -158,8 +163,12 @@ describe('Drop-Target integration', () => {
 
       // Verify the background base color is handled as expected.
       await waitFor(() => {
-        expect(bgElement.resource.baseColor).toEqual('#a38d7f');
+        if (bgElement.resource.baseColor === mediaResource.baseColor) {
+          return;
+        }
+        throw new Error('Background element image loading');
       });
+      expect(bgElement.resource.baseColor).toEqual(mediaResource.baseColor);
     });
   });
 


### PR DESCRIPTION
## Context
Found this test was consistently failing when working we were trouble shooting the broken karma tests.
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
This test was testing against a hardcoded color. This made the assumption that the local media library images would never change in the lifetime of this app. I just updated this to be dynamic since the color it was testing against was from an old expected response from the media library. Now if we ever change the local media in the karma tests, this test shouldn't fail.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
Made a test expectation dynamic instead of static
<!-- Please describe your changes. -->

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
NA
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10145 
