### PR TITLE
Context Menu: Remove 'clear styles' functionality

### DIFF
--- a/docs/right-click-menu.md
+++ b/docs/right-click-menu.md
@@ -57,7 +57,6 @@ Different actions will be rendered depending on the Element that is right clicke
 |--|--|
 |Detach image from background|Removes the media from the background of the page and sets it in the foreground.|
 |Scale & crop background image|Show the scale and crop UI so that the user may scale or crop the image to the desired size.|
-|Clear style|Remove all styles currently applied to the background media. A snackbar is displayed on completion.|
 
 </details>
 
@@ -73,7 +72,6 @@ Different actions will be rendered depending on the Element that is right clicke
 |Bring to front|Place media in front of all other elements. Disabled if the element is all the way forward.|
 |Copy image styles|Copy all styles applied to the media to the clipboard. A snackbar is displayed on completion.|
 |Paste image styles|Add all styles in the clipboard to the selected media. A snackbar is displayed on completion.|
-|Clear image styles|Remove all styles from the currently selected media. A snackbar is displayed on completion.|
 
 </details>
 
@@ -95,31 +93,21 @@ Different actions will be rendered depending on the Element that is right clicke
 
 ## Technical notes and considerations
 
-### Copying, pasting, and clearing styles
+### Copying and pasting styles
 
 When a user right clicks elements, they may be given the option to copy an element's styles and paste them to another element of the same type.
 
-They may also be given the option to 'clear' styles from the element. This resets some properties to the default values.
+**Note**: This does not override all styles of the element. Only styles that are in the table below are able to be copied and pasted:
 
-**Note**: This does not override all styles of the element. Only styles that are in the table below are able to be copied, pasted, and cleared:
-
-|Element type|Properties that are copy/paste-able and clear-able|
+|Element type|Properties that are copy/paste-able|
 |--|--|
 |Text|- `backgroundColor`<br/>- `backgroundTextMode`<br/>- `border`<br/>- `border-radius`<br/>- `flip`<br/>- `font`<br/>- `fontSize`<br/>- `lineHeight`<br/>- `opacity`<br/>- `padding`<br/>- `rotationAngle`<br/>- `textAlign`|
 |Foreground Media|- `border`<br/>- `border-radius`<br/>- `flip`<br/>- `opacity`<br/>- `overlay`<br/>- `rotationAngle`|
 |Shape|- `backgroundColor`<br/>- `flip`<br/>- `opacity`<br/>- `rotationAngle`|
 
-#### Copying and pasting styles
-
 A user may copy styles from any text, foreground media, and shape element. A user may not copy background media element styles.
 
 Once styles are copied, a user may select an element of the same type and 'paste' those onto the selected element. The selected element's properties will be overridden by the 'copied' styles.
-
-#### Clearing styles
-
-A user may clear styles from text, foreground media, shape, and background media elements. This action resets properties to their defaults.
-
-**Note:** Text presets are all different styled versions of the same _text_ element. Any clearing of text styles will make all text presets look exactly the same.
 
 ### Testing 
 

--- a/packages/story-editor/src/app/rightClickMenu/constants.js
+++ b/packages/story-editor/src/app/rightClickMenu/constants.js
@@ -32,11 +32,6 @@ export const RIGHT_CLICK_MENU_LABELS = {
   ADD_TO_TEXT_PRESETS: __('Add Style to “Saved Styles”', 'web-stories'),
   BRING_FORWARD: __('Bring Forward', 'web-stories'),
   BRING_TO_FRONT: __('Bring to Front', 'web-stories'),
-  CLEAR_IMAGE_STYLES: __('Clear Image Styles', 'web-stories'),
-  CLEAR_SHAPE_STYLES: __('Clear Shape Styles', 'web-stories'),
-  CLEAR_VIDEO_STYLES: __('Clear Video Styles', 'web-stories'),
-  CLEAR_STYLES: (numElements = 1) =>
-    _n('Clear style', 'Clear styles', numElements, 'web-stories'),
   COPY_IMAGE_STYLES: __('Copy Image Styles', 'web-stories'),
   COPY_SHAPE_STYLES: __('Copy Shape Styles', 'web-stories'),
   COPY_VIDEO_STYLES: __('Copy Video Styles', 'web-stories'),

--- a/packages/story-editor/src/app/rightClickMenu/provider.js
+++ b/packages/story-editor/src/app/rightClickMenu/provider.js
@@ -783,6 +783,8 @@ function RightClickMenuProvider({ children }) {
       ? RIGHT_CLICK_MENU_LABELS.SCALE_AND_CROP_BACKGROUND_VIDEO
       : RIGHT_CLICK_MENU_LABELS.SCALE_AND_CROP_BACKGROUND_IMAGE;
 
+    const showTrimModeAction = isVideo && hasTrimMode;
+
     return [
       {
         label: detachLabel,
@@ -794,14 +796,16 @@ function RightClickMenuProvider({ children }) {
         label: scaleLabel,
         onClick: handleOpenScaleAndCrop,
         disabled: disableBackgroundMediaActions,
+        separator: showTrimModeAction ? undefined : 'bottom',
         ...menuItemProps,
       },
-      ...(isVideo && hasTrimMode
+      ...(showTrimModeAction
         ? [
             {
               label: RIGHT_CLICK_MENU_LABELS.TRIM_VIDEO,
               onClick: toggleTrimMode,
               disabled: !canTranscodeResource(selectedElement?.resource),
+              separator: showTrimModeAction ? 'bottom' : undefined,
               ...menuItemProps,
             },
           ]

--- a/packages/story-editor/src/app/rightClickMenu/provider.js
+++ b/packages/story-editor/src/app/rightClickMenu/provider.js
@@ -61,15 +61,13 @@ import rightClickMenuReducer, {
   ACTION_TYPES,
   DEFAULT_RIGHT_CLICK_MENU_STATE,
 } from './reducer';
-import { getDefaultPropertiesForType, getElementStyles } from './utils';
+import { getElementStyles } from './utils';
 
 const UNDO_HELP_TEXT = sprintf(
   /* translators: %s: Ctrl/Cmd + Z keyboard shortcut */
   __('Press %s to undo the last change', 'web-stories'),
   prettifyShortcut('mod+z')
 );
-
-const CLEARABLE_ELEMENT_TYPES = ['image', 'video', 'gif', 'shape'];
 
 /**
  * Determines the items displayed in the right click menu
@@ -574,86 +572,6 @@ function RightClickMenuProvider({ children }) {
   ]);
 
   /**
-   * Reset styles for one element to their defaults. Return the styles that were reset
-   * or null if there are not styles to reset.
-   *
-   * @param {Object} element The element to reset.
-   * @return {Object|null} The new styles or null.
-   */
-  const clearElementStyles = useCallback(
-    (element) => {
-      const resetProperties = getDefaultPropertiesForType(element.type);
-
-      if (resetProperties) {
-        updateElementsById({
-          elementIds: [element.id],
-          properties: (currentProperties) =>
-            updateProperties(
-              currentProperties,
-              resetProperties,
-              /* commitValues */ true
-            ),
-        });
-      }
-
-      return resetProperties;
-    },
-    [updateElementsById]
-  );
-
-  /**
-   * Revert element styles to their defaults. Show a snackbar with a button
-   * that can 'undo' the change.
-   *
-   * Each element type has a different set of defaults.
-   */
-  const handleClearElementStyles = useCallback(() => {
-    if (!selectedElements.length) {
-      return;
-    }
-
-    const stylesReset = selectedElements
-      .map(
-        (element) =>
-          // only clear element styles for certain element types
-          CLEARABLE_ELEMENT_TYPES.includes(element.type) &&
-          clearElementStyles(element)
-      )
-      .some((styles) => Boolean(styles));
-
-    // only show snackbar if any elements had styles reset
-    if (stylesReset) {
-      showSnackbar({
-        actionLabel: __('Undo', 'web-stories'),
-        dismissible: false,
-        message: __('Cleared style.', 'web-stories'),
-        // don't pass a stale reference for undo
-        // need history updates to run so `undo` works correctly.
-        onAction: () => {
-          undoRef.current();
-
-          trackEvent('context_menu_action', {
-            name: 'undo_clear_styles',
-            elements: selectedElements.map((element) => element.type),
-            hasBackgroundElement: selectedElements.some(
-              (element) => element.isBackground
-            ),
-          });
-        },
-        actionHelpText: UNDO_HELP_TEXT,
-      });
-
-      trackEvent('context_menu_action', {
-        name: 'clear_styles',
-        elements: selectedElements.map((element) => element.type),
-        hasBackgroundElement: selectedElements.some(
-          (element) => element.isBackground
-        ),
-      });
-    }
-  }, [clearElementStyles, selectedElements, showSnackbar]);
-
-  /**
    * Set currently selected element as the page's background.
    */
   const handleSetPageBackground = useCallback(() => {
@@ -888,25 +806,16 @@ function RightClickMenuProvider({ children }) {
             },
           ]
         : []),
-      {
-        label: RIGHT_CLICK_MENU_LABELS.CLEAR_STYLES(selectedElements.length),
-        onClick: handleClearElementStyles,
-        disabled: disableBackgroundMediaActions,
-        separator: 'bottom',
-        ...menuItemProps,
-      },
       ...pageManipulationItems,
     ];
   }, [
     canTranscodeResource,
-    handleClearElementStyles,
     handleOpenScaleAndCrop,
     handleRemoveMediaFromBackground,
     hasTrimMode,
     menuItemProps,
     pageManipulationItems,
     selectedElement,
-    selectedElements.length,
     toggleTrimMode,
   ]);
 
@@ -971,9 +880,6 @@ function RightClickMenuProvider({ children }) {
     const pasteLabel = isVideo
       ? RIGHT_CLICK_MENU_LABELS.PASTE_VIDEO_STYLES
       : RIGHT_CLICK_MENU_LABELS.PASTE_IMAGE_STYLES;
-    const clearLabel = isVideo
-      ? RIGHT_CLICK_MENU_LABELS.CLEAR_VIDEO_STYLES
-      : RIGHT_CLICK_MENU_LABELS.CLEAR_IMAGE_STYLES;
 
     return [
       {
@@ -1020,16 +926,10 @@ function RightClickMenuProvider({ children }) {
         disabled: copiedElement.type !== selectedElement?.type,
         ...menuItemProps,
       },
-      {
-        label: clearLabel,
-        onClick: handleClearElementStyles,
-        ...menuItemProps,
-      },
     ];
   }, [
     canTranscodeResource,
     copiedElement,
-    handleClearElementStyles,
     handleCopyStyles,
     handleDuplicateElements,
     handleOpenScaleAndCrop,
@@ -1069,11 +969,6 @@ function RightClickMenuProvider({ children }) {
         ...menuItemProps,
       },
       {
-        label: RIGHT_CLICK_MENU_LABELS.CLEAR_SHAPE_STYLES,
-        onClick: handleClearElementStyles,
-        ...menuItemProps,
-      },
-      {
         label: RIGHT_CLICK_MENU_LABELS.ADD_TO_COLOR_PRESETS,
         onClick: handleAddColorPreset,
         ...menuItemProps,
@@ -1082,7 +977,6 @@ function RightClickMenuProvider({ children }) {
     [
       copiedElement?.type,
       handleAddColorPreset,
-      handleClearElementStyles,
       handleCopyStyles,
       handleDuplicateElements,
       handlePasteStyles,
@@ -1122,18 +1016,8 @@ function RightClickMenuProvider({ children }) {
         onClick: handleDuplicateElements,
         ...menuItemProps,
       },
-      {
-        label: RIGHT_CLICK_MENU_LABELS.CLEAR_STYLES(selectedElements.length),
-        onClick: handleClearElementStyles,
-        ...menuItemProps,
-      },
     ],
-    [
-      handleClearElementStyles,
-      handleDuplicateElements,
-      menuItemProps,
-      selectedElements.length,
-    ]
+    [handleDuplicateElements, menuItemProps, selectedElements.length]
   );
 
   const menuItems = useMemo(() => {

--- a/packages/story-editor/src/app/rightClickMenu/test/useRightClickMenu.js
+++ b/packages/story-editor/src/app/rightClickMenu/test/useRightClickMenu.js
@@ -211,7 +211,6 @@ describe('useRightClickMenu', () => {
       expect(labels).toStrictEqual([
         RIGHT_CLICK_MENU_LABELS.DETACH_IMAGE_FROM_BACKGROUND,
         RIGHT_CLICK_MENU_LABELS.SCALE_AND_CROP_BACKGROUND_IMAGE,
-        RIGHT_CLICK_MENU_LABELS.CLEAR_STYLES(1),
         RIGHT_CLICK_MENU_LABELS.ADD_NEW_PAGE_AFTER,
         RIGHT_CLICK_MENU_LABELS.ADD_NEW_PAGE_BEFORE,
         RIGHT_CLICK_MENU_LABELS.DUPLICATE_PAGE,
@@ -224,7 +223,7 @@ describe('useRightClickMenu', () => {
         wrapper: RightClickMenuProvider,
       });
 
-      const backgroundImageItems = result.current.menuItems.slice(0, 3);
+      const backgroundImageItems = result.current.menuItems.slice(0, 2);
       backgroundImageItems.map((item) => {
         expect(item.disabled).toBeTrue();
       });
@@ -307,7 +306,6 @@ describe('useRightClickMenu', () => {
       expect(labels).toStrictEqual([
         RIGHT_CLICK_MENU_LABELS.DETACH_IMAGE_FROM_BACKGROUND,
         RIGHT_CLICK_MENU_LABELS.SCALE_AND_CROP_BACKGROUND_IMAGE,
-        RIGHT_CLICK_MENU_LABELS.CLEAR_STYLES(1),
         RIGHT_CLICK_MENU_LABELS.ADD_NEW_PAGE_AFTER,
         RIGHT_CLICK_MENU_LABELS.ADD_NEW_PAGE_BEFORE,
         RIGHT_CLICK_MENU_LABELS.DUPLICATE_PAGE,
@@ -339,7 +337,6 @@ describe('useRightClickMenu', () => {
       expect(labels).toStrictEqual([
         RIGHT_CLICK_MENU_LABELS.DETACH_VIDEO_FROM_BACKGROUND,
         RIGHT_CLICK_MENU_LABELS.SCALE_AND_CROP_BACKGROUND_VIDEO,
-        RIGHT_CLICK_MENU_LABELS.CLEAR_STYLES(1),
         RIGHT_CLICK_MENU_LABELS.ADD_NEW_PAGE_AFTER,
         RIGHT_CLICK_MENU_LABELS.ADD_NEW_PAGE_BEFORE,
         RIGHT_CLICK_MENU_LABELS.DUPLICATE_PAGE,
@@ -438,12 +435,11 @@ describe('useRightClickMenu', () => {
         RIGHT_CLICK_MENU_LABELS.SCALE_AND_CROP_IMAGE,
         RIGHT_CLICK_MENU_LABELS.COPY_IMAGE_STYLES,
         RIGHT_CLICK_MENU_LABELS.PASTE_IMAGE_STYLES,
-        RIGHT_CLICK_MENU_LABELS.CLEAR_IMAGE_STYLES,
       ]);
     });
 
-    describe('copying, pasting, and clearing styles', () => {
-      it('should show a snackbar when copying, pasting, and clearing styles', () => {
+    describe('copying and pasting styles', () => {
+      it('should show a snackbar when copying and pasting styles', () => {
         const { result } = renderHook(() => useRightClickMenu(), {
           wrapper: RightClickMenuProvider,
         });
@@ -473,20 +469,6 @@ describe('useRightClickMenu', () => {
           expect.objectContaining({
             actionLabel: 'Undo',
             message: 'Pasted style.',
-          })
-        );
-
-        const clear = result.current.menuItems.find(
-          (item) => item.label === RIGHT_CLICK_MENU_LABELS.CLEAR_IMAGE_STYLES
-        );
-        act(() => {
-          clear.onClick();
-        });
-
-        expect(mockShowSnackbar).toHaveBeenCalledWith(
-          expect.objectContaining({
-            actionLabel: 'Undo',
-            message: 'Cleared style.',
           })
         );
       });
@@ -523,7 +505,6 @@ describe('useRightClickMenu', () => {
         RIGHT_CLICK_MENU_LABELS.SCALE_AND_CROP_VIDEO,
         RIGHT_CLICK_MENU_LABELS.COPY_VIDEO_STYLES,
         RIGHT_CLICK_MENU_LABELS.PASTE_VIDEO_STYLES,
-        RIGHT_CLICK_MENU_LABELS.CLEAR_VIDEO_STYLES,
       ]);
     });
 
@@ -590,8 +571,8 @@ describe('useRightClickMenu', () => {
       });
     });
 
-    describe('copying, pasting, and clearing styles', () => {
-      it('should show a snackbar when copying, pasting, and clearing styles', () => {
+    describe('copying and pasting styles', () => {
+      it('should show a snackbar when copying and pasting styles', () => {
         const { result } = renderHook(() => useRightClickMenu(), {
           wrapper: RightClickMenuProvider,
         });
@@ -623,20 +604,6 @@ describe('useRightClickMenu', () => {
             message: 'Pasted style.',
           })
         );
-
-        const clear = result.current.menuItems.find(
-          (item) => item.label === RIGHT_CLICK_MENU_LABELS.CLEAR_VIDEO_STYLES
-        );
-        act(() => {
-          clear.onClick();
-        });
-
-        expect(mockShowSnackbar).toHaveBeenCalledWith(
-          expect.objectContaining({
-            actionLabel: 'Undo',
-            message: 'Cleared style.',
-          })
-        );
       });
     });
   });
@@ -665,7 +632,6 @@ describe('useRightClickMenu', () => {
         ...expectedLayerActions,
         RIGHT_CLICK_MENU_LABELS.COPY_SHAPE_STYLES,
         RIGHT_CLICK_MENU_LABELS.PASTE_SHAPE_STYLES,
-        RIGHT_CLICK_MENU_LABELS.CLEAR_SHAPE_STYLES,
         RIGHT_CLICK_MENU_LABELS.ADD_TO_COLOR_PRESETS,
       ]);
     });
@@ -731,7 +697,6 @@ describe('useRightClickMenu', () => {
       const labels = result.current.menuItems.map((item) => item.label);
       expect(labels).toStrictEqual([
         RIGHT_CLICK_MENU_LABELS.DUPLICATE_ELEMENTS(2),
-        RIGHT_CLICK_MENU_LABELS.CLEAR_STYLES(2),
       ]);
     });
   });

--- a/packages/story-editor/src/app/rightClickMenu/test/utils.js
+++ b/packages/story-editor/src/app/rightClickMenu/test/utils.js
@@ -16,9 +16,9 @@
 /**
  * Internal dependencies
  */
-import { getDefinitionForType, ELEMENT_TYPES } from '../../../elements';
+import { ELEMENT_TYPES } from '../../../elements';
 import objectPick from '../../../utils/objectPick';
-import { getElementStyles, getDefaultPropertiesForType } from '../utils';
+import { getElementStyles } from '../utils';
 
 const ALL_PROPERTIES = {
   // style properties
@@ -65,17 +65,6 @@ const expectedTextStyles = objectPick(ALL_PROPERTIES, [
   'lineHeight',
 ]);
 
-const { clearableAttributes: clearableGifAttributes } =
-  getDefinitionForType('gif');
-const { clearableAttributes: clearableImageAttributes } =
-  getDefinitionForType('image');
-const { clearableAttributes: clearableShapeAttributes } =
-  getDefinitionForType('shape');
-const { clearableAttributes: clearableTextAttributes } =
-  getDefinitionForType('text');
-const { clearableAttributes: clearableVideoAttributes } =
-  getDefinitionForType('video');
-
 describe('getElementStyles', () => {
   it('should return `null` if the element does not have the correct structure', () => {
     // No element
@@ -99,32 +88,6 @@ describe('getElementStyles', () => {
     'should pick the correct properties for a `$type` element',
     ({ type, expectedProperties }) => {
       const result = getElementStyles({ ...ALL_PROPERTIES, type });
-
-      expect(result).toStrictEqual(expectedProperties);
-    }
-  );
-});
-
-describe('getDefaultPropertiesForType', () => {
-  it('should return `null` if the element does not have the correct structure', () => {
-    // No element type
-    expect(getDefaultPropertiesForType({})).toBeNull();
-
-    // Element type does not exist
-    expect(getDefaultPropertiesForType({ type: 'banana' })).toBeNull();
-  });
-
-  it.each`
-    type                   | expectedProperties
-    ${ELEMENT_TYPES.IMAGE} | ${clearableImageAttributes}
-    ${ELEMENT_TYPES.GIF}   | ${clearableGifAttributes}
-    ${ELEMENT_TYPES.VIDEO} | ${clearableVideoAttributes}
-    ${ELEMENT_TYPES.SHAPE} | ${clearableShapeAttributes}
-    ${ELEMENT_TYPES.TEXT}  | ${clearableTextAttributes}
-  `(
-    'should return the default properties for a `$type` element',
-    ({ type, expectedProperties }) => {
-      const result = getDefaultPropertiesForType(type);
 
       expect(result).toStrictEqual(expectedProperties);
     }

--- a/packages/story-editor/src/app/rightClickMenu/utils.js
+++ b/packages/story-editor/src/app/rightClickMenu/utils.js
@@ -34,23 +34,7 @@ export const getElementStyles = (element) => {
     return null;
   }
 
-  const { clearableAttributes } = getDefinitionForType(element.type);
+  const { copyableAttributes } = getDefinitionForType(element.type);
 
-  return objectPick(element, Object.keys(clearableAttributes));
-};
-
-/**
- *
- * @param {string} type the type of the element to update
- * @return {Object|null} the default properties for the element type.
- * Return `null` if `type` isn't valid.
- */
-export const getDefaultPropertiesForType = (type) => {
-  if (!type || !elementTypes.includes(type)) {
-    return null;
-  }
-
-  const { clearableAttributes } = getDefinitionForType(type);
-
-  return clearableAttributes;
+  return objectPick(element, Object.keys(copyableAttributes));
 };

--- a/packages/story-editor/src/components/canvas/karma/rightClickMenu.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/rightClickMenu.karma.js
@@ -23,9 +23,9 @@ import { waitFor, within } from '@testing-library/react';
  */
 import { useStory } from '../../../app';
 import { TEXT_ELEMENT_DEFAULT_FONT } from '../../../app/font/defaultFonts';
-import { clearableAttributes as imageAttributeDefaults } from '../../../elements/image';
-import { clearableAttributes as shapeAttributeDefaults } from '../../../elements/shape';
-import { clearableAttributes as textAttributeDefaults } from '../../../elements/text';
+import { copyableAttributes as imageAttributeDefaults } from '../../../elements/image';
+import { copyableAttributes as shapeAttributeDefaults } from '../../../elements/shape';
+import { copyableAttributes as textAttributeDefaults } from '../../../elements/text';
 import { Fixture } from '../../../karma';
 import objectPick from '../../../utils/objectPick';
 import useInsertElement from '../useInsertElement';

--- a/packages/story-editor/src/components/canvas/karma/rightClickMenu.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/rightClickMenu.karma.js
@@ -24,14 +24,12 @@ import { waitFor, within } from '@testing-library/react';
 import { useStory } from '../../../app';
 import { TEXT_ELEMENT_DEFAULT_FONT } from '../../../app/font/defaultFonts';
 import { copyableAttributes as imageAttributeDefaults } from '../../../elements/image';
-import { copyableAttributes as shapeAttributeDefaults } from '../../../elements/shape';
 import { copyableAttributes as textAttributeDefaults } from '../../../elements/text';
 import { Fixture } from '../../../karma';
 import objectPick from '../../../utils/objectPick';
 import useInsertElement from '../useInsertElement';
 
-const clearableImageProperties = Object.keys(imageAttributeDefaults);
-const clearableShapeProperties = Object.keys(shapeAttributeDefaults);
+const copyableImageProperties = Object.keys(imageAttributeDefaults);
 
 describe('Right Click Menu integration', () => {
   let fixture;
@@ -137,18 +135,6 @@ describe('Right Click Menu integration', () => {
   function pasteImageStyles() {
     return fixture.screen.getByRole('menuitem', {
       name: /^Paste Image Styles/i,
-    });
-  }
-
-  function clearImageStyles() {
-    return fixture.screen.getByRole('menuitem', {
-      name: /^Clear Image Styles/i,
-    });
-  }
-
-  function clearStyles() {
-    return fixture.screen.getByRole('menuitem', {
-      name: /^Clear Styles/i,
     });
   }
 
@@ -803,7 +789,7 @@ describe('Right Click Menu integration', () => {
       expect(bringToFront().disabled).toBeTrue();
     });
 
-    describe('right click menu: copying, pasting, and clearing styles', () => {
+    describe('right click menu: copying and pasting styles', () => {
       it('should copy and paste styles', async () => {
         const earthImage = await addEarthImage();
         const rangerImage = await addRangerImage();
@@ -859,67 +845,10 @@ describe('Right Click Menu integration', () => {
           (element) => !element.isBackground
         );
 
-        const copiedProperties = objectPick(
-          images[0],
-          clearableImageProperties
-        );
-        const pastedProperties = objectPick(
-          images[0],
-          clearableImageProperties
-        );
+        const copiedProperties = objectPick(images[0], copyableImageProperties);
+        const pastedProperties = objectPick(images[0], copyableImageProperties);
 
         expect(copiedProperties).toEqual(pastedProperties);
-      });
-
-      it('should reset styles to the default', async () => {
-        const earthImage = await addEarthImage();
-
-        // select earth image
-        await fixture.events.click(
-          fixture.editor.canvas.framesLayer.frame(earthImage.id).node
-        );
-
-        // add border
-        await fixture.events.click(
-          fixture.editor.inspector.designPanel.border.width()
-        );
-        await fixture.events.keyboard.type('20');
-
-        // add border radius
-        await fixture.events.click(
-          fixture.editor.inspector.designPanel.sizePosition.radius()
-        );
-        await fixture.events.keyboard.type('50');
-
-        // add filter
-        await fixture.events.click(
-          fixture.editor.inspector.designPanel.filters.solid
-        );
-
-        // add opacity
-        await fixture.events.click(
-          fixture.editor.inspector.designPanel.sizePosition.opacity
-        );
-        await fixture.events.keyboard.type('40');
-
-        // clear earth styles
-        await rightClickOnTarget(
-          fixture.editor.canvas.framesLayer.frame(earthImage.id).node
-        );
-        await fixture.events.click(clearImageStyles());
-
-        // verify styles were reset to defaults
-        const { elements } = await fixture.renderHook(() =>
-          useStory(({ state }) => ({
-            elements: state.currentPage.elements,
-          }))
-        );
-
-        const image = elements.find((element) => !element.isBackground);
-
-        expect(objectPick(image, clearableImageProperties)).toEqual(
-          imageAttributeDefaults
-        );
       });
     });
   });
@@ -927,7 +856,7 @@ describe('Right Click Menu integration', () => {
   describe('right click menu: text', () => {
     const { content: _, ...textAttributeDefaultsWithoutContent } =
       textAttributeDefaults;
-    const clearableTextProperties = Object.keys(
+    const copyableTextProperties = Object.keys(
       textAttributeDefaultsWithoutContent
     );
 
@@ -1041,10 +970,10 @@ describe('Right Click Menu integration', () => {
 
       const copiedProperties = objectPick(
         textElements[0],
-        clearableTextProperties
+        copyableTextProperties
       );
       const { content, ...pastedProperties } = objectPick(textElements[1], [
-        ...clearableTextProperties,
+        ...copyableTextProperties,
         'content',
       ]);
       expect(content).toBe(
@@ -1292,159 +1221,5 @@ describe('Right Click Menu integration', () => {
       expect(shapeElements.length).toBe(2);
       verifyElementDuplicated(shapeElements[0], shapeElements[1]);
     });
-  });
-
-  it('should only clear styles for foreground media and shapes', async () => {
-    const clearableTextProperties = Object.keys(textAttributeDefaults);
-
-    // add text element and styles
-    const text = await addText({
-      fontSize: 24,
-      content: '<span style="color: #ff0110">Some Text Element</span>',
-      backgroundColor: { r: 10, g: 0, b: 200 },
-      lineHeight: 1.4,
-      textAlign: 'center',
-      border: {
-        left: 1,
-        right: 1,
-        top: 1,
-        bottom: 1,
-        lockedWidth: true,
-        color: {
-          color: {
-            r: 0,
-            g: 0,
-            b: 0,
-          },
-        },
-      },
-      padding: {
-        vertical: 0,
-        horizontal: 20,
-        locked: true,
-      },
-      y: 300,
-    });
-
-    // add earth image and styles
-    const image = await addEarthImage();
-    await fixture.events.click(
-      fixture.editor.canvas.framesLayer.frame(image.id).node
-    );
-    await fixture.events.click(
-      fixture.editor.inspector.designPanel.border.width()
-    );
-    await fixture.events.keyboard.type('20');
-    await fixture.events.click(
-      fixture.editor.inspector.designPanel.sizePosition.radius()
-    );
-    await fixture.events.keyboard.type('50');
-    await fixture.events.click(
-      fixture.editor.inspector.designPanel.filters.solid
-    );
-    await fixture.events.click(
-      fixture.editor.inspector.designPanel.sizePosition.opacity
-    );
-    await fixture.events.keyboard.type('40');
-
-    // add shape and styles
-    const shape = await addShape({
-      backgroundColor: {
-        color: {
-          r: 201,
-          g: 24,
-          b: 74,
-          a: 0.75,
-        },
-      },
-      x: 50,
-      y: 400,
-    });
-
-    // select all elements and reset styles
-    const textFrame = fixture.editor.canvas.framesLayer.frame(text.id).node;
-    const imageFrame = fixture.editor.canvas.framesLayer.frame(image.id).node;
-    const shapeFrame = fixture.editor.canvas.framesLayer.frame(shape.id).node;
-    await clickOnTarget(textFrame);
-    await clickOnTarget(imageFrame, 'Shift');
-    await clickOnTarget(shapeFrame, 'Shift');
-
-    // multiple elements should be selected
-    const { initialElements, selectedElements } = await fixture.renderHook(() =>
-      useStory(({ state }) => ({
-        selectedElements: state.selectedElements,
-        initialElements: state.currentPage.elements,
-      }))
-    );
-
-    expect(selectedElements.length).toBe(3);
-    expect(initialElements.length).toBe(4);
-
-    // track initial state for comparison
-    const initialText = initialElements.find(
-      (element) => element.type === 'text'
-    );
-    const initialImage = initialElements.find(
-      (element) => element.type === 'image'
-    );
-    const initialShape = initialElements.find(
-      (element) => element.type === 'shape' && !element.isBackground
-    );
-
-    // open right click menu
-    await rightClickOnTarget(imageFrame);
-
-    // clear element styles
-    await fixture.events.click(clearStyles());
-
-    // verify image and shape styles were reset to default styles
-    const { elements } = await fixture.renderHook(() =>
-      useStory(({ state }) => ({
-        elements: state.currentPage.elements,
-      }))
-    );
-
-    const resetText = elements.find((element) => element.type === 'text');
-    const resetImage = elements.find((element) => element.type === 'image');
-    const resetShape = elements.find(
-      (element) => element.type === 'shape' && !element.isBackground
-    );
-
-    // text styles should not be reset to the default styles
-    expect(objectPick(resetText, clearableTextProperties)).not.toEqual(
-      textAttributeDefaults
-    );
-
-    // image and shape styles should have been reset
-    expect(objectPick(resetImage, clearableImageProperties)).toEqual(
-      imageAttributeDefaults
-    );
-    expect(objectPick(resetShape, clearableShapeProperties)).toEqual(
-      shapeAttributeDefaults
-    );
-
-    // undo should revert all reset styles at once
-    await fixture.events.click(
-      fixture.screen.getByRole('button', { name: /^Undo$/, hidden: true })
-    );
-
-    // Verify that everything is back to normal
-    const { finalElements } = await fixture.renderHook(() =>
-      useStory(({ state }) => ({
-        finalElements: state.currentPage.elements,
-      }))
-    );
-
-    const finalText = finalElements.find((element) => element.type === 'text');
-    const finalImage = finalElements.find(
-      (element) => element.type === 'image'
-    );
-    const finalShape = finalElements.find(
-      (element) => element.type === 'shape' && !element.isBackground
-    );
-
-    expect(finalText).toEqual(initialText);
-    expect(finalImage).toEqual(initialImage);
-    expect(finalShape).toEqual(initialShape);
   });
 });

--- a/packages/story-editor/src/elements/gif/constants.js
+++ b/packages/story-editor/src/elements/gif/constants.js
@@ -42,7 +42,7 @@ export const defaultAttributes = {
   ...MEDIA_DEFAULT_ATTRIBUTES,
 };
 
-export const clearableAttributes = {
+export const copyableAttributes = {
   ...SHARED_DEFAULT_CLEARABLE_ATTRIBUTES,
   ...MEDIA_DEFAULT_CLEARABLE_ATTRIBUTES,
 };

--- a/packages/story-editor/src/elements/image/constants.js
+++ b/packages/story-editor/src/elements/image/constants.js
@@ -41,7 +41,7 @@ export const defaultAttributes = {
   ...MEDIA_DEFAULT_ATTRIBUTES,
 };
 
-export const clearableAttributes = {
+export const copyableAttributes = {
   ...SHARED_DEFAULT_CLEARABLE_ATTRIBUTES,
   ...MEDIA_DEFAULT_CLEARABLE_ATTRIBUTES,
 };

--- a/packages/story-editor/src/elements/shape/constants.js
+++ b/packages/story-editor/src/elements/shape/constants.js
@@ -33,7 +33,7 @@ export const defaultAttributes = {
   backgroundColor: defaultBackgroundColor,
 };
 
-export const clearableAttributes = {
+export const copyableAttributes = {
   ...SHARED_DEFAULT_CLEARABLE_ATTRIBUTES,
   backgroundColor: defaultBackgroundColor,
 };

--- a/packages/story-editor/src/elements/text/constants.js
+++ b/packages/story-editor/src/elements/text/constants.js
@@ -41,7 +41,7 @@ export const defaultAttributes = {
   },
 };
 
-export const clearableAttributes = {
+export const copyableAttributes = {
   ...defaultAttributes,
   content: '',
   border: null,

--- a/packages/story-editor/src/elements/video/constants.js
+++ b/packages/story-editor/src/elements/video/constants.js
@@ -55,7 +55,7 @@ export const defaultAttributes = {
   },
 };
 
-export const clearableAttributes = {
+export const copyableAttributes = {
   ...SHARED_DEFAULT_CLEARABLE_ATTRIBUTES,
   ...MEDIA_DEFAULT_CLEARABLE_ATTRIBUTES,
 };


### PR DESCRIPTION
## Context

https://github.com/google/web-stories-wp/issues/10018#issuecomment-1018107396

## Summary

Remove 'clear styles' button from context menu and related code.

## Relevant Technical Choices

Renamed `clearableAttributes` to `copyableAttributes` because that constant is still used for copy/paste of styles.

## To-do

n/a

## User-facing changes

||Background Media|Image|Gif|Video|Shape|Text|Multiple|
|--|--|--|--|--|--|--|--|
|Before|![image](https://user-images.githubusercontent.com/22185279/150465040-d56d0afb-223b-48bd-a4de-fe972d075182.png)|![image](https://user-images.githubusercontent.com/22185279/150461821-6427c8fc-dd7e-4010-8d0e-f10b5d09c775.png)|![image](https://user-images.githubusercontent.com/22185279/150461841-c72247b9-d3a8-434a-bb50-56dd9c49fff5.png)|![image](https://user-images.githubusercontent.com/22185279/150461855-a898bb32-0e23-4ce8-aeaa-67dfbd0d5b2a.png)|![image](https://user-images.githubusercontent.com/22185279/150461868-ebe00a91-4522-4e01-8796-2123e216501a.png)|![image](https://user-images.githubusercontent.com/22185279/150461878-d6c33444-9722-48a0-91a1-7c255df4b93d.png)|![image](https://user-images.githubusercontent.com/22185279/150461896-14592233-f221-4096-a4d9-0207d15fb6de.png)|
|After|![image](https://user-images.githubusercontent.com/22185279/150464967-393b9ea0-7321-4c6b-b515-e7af8656f5a0.png)|![image](https://user-images.githubusercontent.com/22185279/150461628-fdc5cedb-5641-4267-bc10-73bf82048015.png)|![image](https://user-images.githubusercontent.com/22185279/150461663-a04aedbf-ed62-478d-bd08-3aa325d61b24.png)|![image](https://user-images.githubusercontent.com/22185279/150461682-ce40a29a-6002-4b46-896d-d619c33a2f40.png)|![image](https://user-images.githubusercontent.com/22185279/150461713-6483b7bc-8899-4907-bd8d-8ef92aa8da92.png)|![image](https://user-images.githubusercontent.com/22185279/150461726-47f1e773-4405-44e1-841c-b9bf0e75669b.png)|![image](https://user-images.githubusercontent.com/22185279/150461574-d37932a7-9e26-4b58-8409-f0ae3c09cfc1.png)|

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Verify that each element's individual context menu does not show a 'clear X styles' action
2. Verify that the context menu that is displayed when selecting multiple elements does not display a 'clear styles' action
3. Verify that copy and pasting styles still works as expected (using the context menu).


## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10293 
