### PR TITLE
Media: Don't set transcoding state for non-videos

### DIFF
--- a/packages/story-editor/src/app/media/utils/useMediaUploadQueue/index.js
+++ b/packages/story-editor/src/app/media/utils/useMediaUploadQueue/index.js
@@ -482,24 +482,26 @@ function useMediaUploadQueue() {
           }
 
           if (isTranscodingEnabled) {
-            currentTranscodingItem.current = id;
-
             if (isGifThatNeedsTranscoding) {
+              currentTranscodingItem.current = id;
               convertGifItem(item);
               return;
             }
 
             if (canTranscodeFile(file)) {
               if (trimData) {
+                currentTranscodingItem.current = id;
                 trimVideoItem(item);
                 return;
               }
 
               if (muteVideo) {
+                currentTranscodingItem.current = id;
                 muteVideoItem(item);
                 return;
               }
 
+              currentTranscodingItem.current = id;
               // Transcode/Optimize videos before upload.
               // TODO: Only transcode & optimize video if needed (criteria TBD).
               // Probably need to use FFmpeg first to get more information (dimensions, fps, etc.)

--- a/packages/story-editor/src/app/media/utils/useMediaUploadQueue/index.js
+++ b/packages/story-editor/src/app/media/utils/useMediaUploadQueue/index.js
@@ -489,19 +489,18 @@ function useMediaUploadQueue() {
             }
 
             if (canTranscodeFile(file)) {
+              currentTranscodingItem.current = id;
+
               if (trimData) {
-                currentTranscodingItem.current = id;
                 trimVideoItem(item);
                 return;
               }
 
               if (muteVideo) {
-                currentTranscodingItem.current = id;
                 muteVideoItem(item);
                 return;
               }
 
-              currentTranscodingItem.current = id;
               // Transcode/Optimize videos before upload.
               // TODO: Only transcode & optimize video if needed (criteria TBD).
               // Probably need to use FFmpeg first to get more information (dimensions, fps, etc.)


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

When uploading asset, you upload images first and the video, videos will never process. This is because, images are added to the `currentTranscodingItem` ref and NEVER cleared. It would always hang. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Create story.
2. Drag 5 images into canvas.
3. Wait for images to upload complete. 
4. Drag 5 videos into canvas.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10301
