### PR TITLE
Karma: Move percy upload to separate job

### DIFF
--- a/.github/workflows/tests-karma-editor.yml
+++ b/.github/workflows/tests-karma-editor.yml
@@ -87,10 +87,18 @@ jobs:
           file: build/logs/karma-coverage/story-editor/lcov.info
           flags: karmatests
 
+      # Replace slash with a dash to get a valid artifact name
+      - name: Set artifact name
+        id: artifact_name
+        run: echo "::set-output name=artifact_name::${SHARD//\//-}"
+        env:
+          DISABLE_ERROR_BOUNDARIES: true
+          SHARD: ${{ matrix.shard }}
+
       - name: Upload snapshot files artifact
         uses: actions/upload-artifact@v2
         with:
-          name: karma-snapshots-${{ matrix.shard }}
+          name: karma-snapshots-${{ steps.artifact_name.outputs.artifact_name }}
           path: .test_artifacts/karma_snapshots
 
   percy:

--- a/.github/workflows/tests-karma-editor.yml
+++ b/.github/workflows/tests-karma-editor.yml
@@ -98,10 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # The action cannot access the secret when run from a PR fork or authored by Dependabot.
-    if: >
-      github.event.pull_request.draft == false &&
-      github.event.pull_request.head.repo.fork == false &&
-      github.event.pull_request.user.login != 'dependabot[bot]'
+    if: always()
     needs: karma
     steps:
       - name: Checkout

--- a/.github/workflows/tests-karma-editor.yml
+++ b/.github/workflows/tests-karma-editor.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Upload snapshot files artifact
         uses: actions/upload-artifact@v2
         with:
-          name: karma_snapshots
+          name: karma-snapshots-${{ matrix.shard }}
           path: .test_artifacts/karma_snapshots
 
   percy:
@@ -107,14 +107,16 @@ jobs:
       - name: Install dependencies
         run: npm install @percy/cli
 
-      - name: Download snapshot files artifact
+      - name: Download snapshot files artifacts
         uses: actions/download-artifact@v2
         with:
-          name: karma_snapshots
           path: .test_artifacts
         continue-on-error: true
 
       - name: Upload Percy snapshots
-        run: npx percy snapshot --config=percy.config.yml .test_artifacts/karma_snapshots
+        run: |
+          ls -lah
+          ls -lah .test_artifacts
+          npx percy snapshot --config=percy.config.yml ./.test_artifacts
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/.github/workflows/tests-karma-editor.yml
+++ b/.github/workflows/tests-karma-editor.yml
@@ -104,13 +104,19 @@ jobs:
       github.event.pull_request.user.login != 'dependabot[bot]'
     needs: karma
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: npm install @percy/cli
+
       - name: Download snapshot files artifact
         uses: actions/download-artifact@v2
         with:
           name: karma_snapshots
           path: .test_artifacts
         continue-on-error: true
-  
+
       - name: Upload Percy snapshots
         run: npx percy snapshot --config=percy.config.yml .test_artifacts/karma_snapshots
         env:

--- a/.github/workflows/tests-karma-editor.yml
+++ b/.github/workflows/tests-karma-editor.yml
@@ -102,7 +102,7 @@ jobs:
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.user.login != 'dependabot[bot]'
-    needs: [karma]
+    needs: karma
     steps:
       - name: Download snapshot files artifact
         uses: actions/download-artifact@v2
@@ -110,8 +110,8 @@ jobs:
           name: karma_snapshots
           path: .test_artifacts
         continue-on-error: true
-
-    - name: Upload Percy snapshots
-      run: npx percy snapshot --config=percy.config.yml .test_artifacts/karma_snapshots
-      env:
-        PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+  
+      - name: Upload Percy snapshots
+        run: npx percy snapshot --config=percy.config.yml .test_artifacts/karma_snapshots
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/.github/workflows/tests-karma-editor.yml
+++ b/.github/workflows/tests-karma-editor.yml
@@ -111,10 +111,7 @@ jobs:
           path: .test_artifacts
         continue-on-error: true
 
-      - name: Upload Percy snapshots
-        uses: percy/snapshot-action@v0.1.2
-        with:
-          build-directory: '.test_artifacts/karma_snapshots'
-          flags: '--config=percy.config.yml'
-        env:
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+    - name: Upload Percy snapshots
+      run: npx percy snapshot --config=percy.config.yml .test_artifacts/karma_snapshots
+      env:
+        PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/.github/workflows/tests-karma-editor.yml
+++ b/.github/workflows/tests-karma-editor.yml
@@ -12,6 +12,7 @@ on:
       - '**/package.json'
       - 'package-lock.json'
       - '__static__/**'
+      - '.github/workflows/tests-karma-editor.yml'
     branches:
       - main
       - release/*
@@ -26,6 +27,7 @@ on:
       - '**/package.json'
       - 'package-lock.json'
       - '__static__/**'
+      - '.github/workflows/tests-karma-editor.yml'
     types:
       - opened
       - reopened

--- a/.github/workflows/tests-karma-editor.yml
+++ b/.github/workflows/tests-karma-editor.yml
@@ -85,6 +85,30 @@ jobs:
           file: build/logs/karma-coverage/story-editor/lcov.info
           flags: karmatests
 
+      - name: Upload snapshot files artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: karma_snapshots
+          path: .test_artifacts/karma_snapshots
+
+  percy:
+    name: Percy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # The action cannot access the secret when run from a PR fork or authored by Dependabot.
+    if: >
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.fork == false &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
+    needs: [karma]
+    steps:
+      - name: Download snapshot files artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: karma_snapshots
+          path: .test_artifacts
+        continue-on-error: true
+
       - name: Upload Percy snapshots
         uses: percy/snapshot-action@v0.1.2
         with:
@@ -92,8 +116,3 @@ jobs:
           flags: '--config=percy.config.yml'
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
-        # The action cannot access the secret when run from a PR fork or authored by Dependabot.
-        if: >
-          github.event.pull_request.draft == false &&
-          github.event.pull_request.head.repo.fork == false &&
-          github.event.pull_request.user.login != 'dependabot[bot]'

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@googleforcreators/migration": "*",
         "@googleforcreators/story-editor": "*",
         "@jsdevtools/coverage-istanbul-loader": "^3.0.5",
+        "@percy/cli": "^1.0.0-beta.74",
         "@prettier/plugin-xml": "^1.2.0",
         "@storybook/addon-a11y": "^6.3.6",
         "@storybook/addon-actions": "^6.3.6",
@@ -39161,7 +39162,6 @@
         "@wordpress/url": "^3.2.1"
       },
       "devDependencies": {
-        "@percy/cli": "^1.0.0-beta.74",
         "@percy/puppeteer": "^2.0.0"
       },
       "engines": {
@@ -47332,7 +47332,6 @@
     "@web-stories-wp/e2e-test-utils": {
       "version": "file:packages/e2e-test-utils",
       "requires": {
-        "@percy/cli": "^1.0.0-beta.74",
         "@percy/puppeteer": "^2.0.0",
         "@wordpress/e2e-test-utils": "^5.4.10",
         "@wordpress/url": "^3.2.1"

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@googleforcreators/migration": "*",
     "@googleforcreators/story-editor": "*",
     "@jsdevtools/coverage-istanbul-loader": "^3.0.5",
+    "@percy/cli": "^1.0.0-beta.74",
     "@prettier/plugin-xml": "^1.2.0",
     "@storybook/addon-a11y": "^6.3.6",
     "@storybook/addon-actions": "^6.3.6",

--- a/packages/e2e-test-utils/package.json
+++ b/packages/e2e-test-utils/package.json
@@ -29,7 +29,6 @@
     "@wordpress/url": "^3.2.1"
   },
   "devDependencies": {
-    "@percy/cli": "^1.0.0-beta.74",
     "@percy/puppeteer": "^2.0.0"
   }
 }


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

Now that our Karma tests are running in a parallel job, it means that we're uploading Percy snapshots 4 times instead of once.

To fix this, we need to move the Upload Percy snapshots step to its own job that runs after the matrix job, passing around the snapshot files using actions/upload-artifact

## Summary

<!-- A brief description of what this PR does. -->

Moves percy upload to separate job

## Relevant Technical Choices

<!-- Please describe your changes. -->

Uses artifacts because that's how you pass data between jobs

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10332
