### PR TITLE
E2E Tests: Optimize workflow for parallel runs

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -215,6 +215,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Setup Node
+        uses: actions/setup-node@v2.5.1
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+
       - name: Install dependencies
         run: npm install @percy/cli
 

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -62,11 +62,59 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build:
+    name: Build plugin
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v2.5.1
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+          coverage: none
+          tools: composer
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
+
+      - name: Install PHP dependencies
+        uses: 'ramsey/composer-install@v1'
+        with:
+          composer-options: '--prefer-dist --no-progress --no-interaction'
+
+      - name: Build plugin
+        run: npm run build:js
+        env:
+          # TODO: remove eventually
+          DISABLE_PREVENT: true
+          DISABLE_QUICK_TIPS: true
+
+      - name: Bundle plugin
+        run: npm run workflow:build-plugin
+
+      - name: Upload bundle
+        uses: actions/upload-artifact@v2
+        with:
+          name: web-stories
+          path: build/web-stories
+
   e2e:
     name: '${{ matrix.browser }} - WP ${{ matrix.wp }} (${{ matrix.shard }})'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     continue-on-error: ${{ matrix.experimental == true }}
+    needs: build
     strategy:
       matrix:
         # TODO: add back Firefox once support is more mature.
@@ -99,42 +147,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Download bundle
+        uses: actions/download-artifact@v2
+        with:
+          name: web-stories
+
       # See https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#chrome-headless-doesnt-launch-on-unix
       - name: Install libgbm1
         run: sudo apt-get install libgbm1
 
-      - name: Setup Node
-        uses: actions/setup-node@v2.5.1
-        with:
-          node-version-file: '.nvmrc'
-          cache: npm
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.0'
-          coverage: none
-          tools: composer
-
-      # TODO: Remove need for `npm install puppeteer`.
       - name: Install dependencies
-        run: |
-          npm ci
-          npm install puppeteer
+        run: npm install puppeteer
         env:
           PUPPETEER_PRODUCT: ${{ matrix.browser }}
-
-      - name: Install PHP dependencies
-        uses: 'ramsey/composer-install@v1'
-        with:
-          composer-options: '--prefer-dist --no-progress --no-interaction'
-
-      - name: Build plugin
-        run: npm run build:js
-        env:
-          # TODO: remove eventually
-          DISABLE_PREVENT: true
-          DISABLE_QUICK_TIPS: true
 
       - name: Start Docker environment
         run: npm run env:start

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -176,11 +176,19 @@ jobs:
           COMPOSE_INTERACTIVE_NO_CLI: true
           WP_VERSION: ${{ matrix.wp }}
 
+      - name: Get Chromium executable path
+        id: chromium_path
+        run: |
+          CHROMIUM=$(node -p "const puppeteer = require('puppeteer'); puppeteer.executablePath();")
+          echo "::set-output name=chromium_path::${CHROMIUM}"
+        if: ( matrix.snapshots ) && ( github.event.pull_request.draft == false )
+
       - name: Run E2E tests with percy
         run: npm run test:e2e:percy
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_E2E }}
           WP_VERSION: ${{ matrix.wp }}
+          PERCY_BROWSER_EXECUTABLE: ${{ steps.chromium_path.outputs.chromium_path }}
           PERCY_PARALLEL_NONCE: ${{ needs.nonce.outputs.result }}
         if: ( matrix.snapshots ) && ( github.event.pull_request.draft == false )
 

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -109,12 +109,20 @@ jobs:
           name: web-stories
           path: build/web-stories
 
+  nonce:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.nonce.outputs.result }}
+    steps:
+      - id: nonce
+        run: echo "::set-output name=result::${{ github.run_id }}-$(date +%s)"
+
   e2e:
     name: '${{ matrix.browser }} - WP ${{ matrix.wp }} (${{ matrix.shard }})'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     continue-on-error: ${{ matrix.experimental == true }}
-    needs: build
+    needs: [build, nonce]
     strategy:
       matrix:
         # TODO: add back Firefox once support is more mature.
@@ -172,6 +180,7 @@ jobs:
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_E2E }}
           WP_VERSION: ${{ matrix.wp }}
+          PERCY_PARALLEL_NONCE: ${{ needs.nonce.outputs.result }}
         if: ( matrix.snapshots ) && ( github.event.pull_request.draft == false )
 
       - name: Run E2E tests
@@ -186,3 +195,21 @@ jobs:
         if: always()
         env:
           COMPOSE_INTERACTIVE_NO_CLI: true
+
+  percy:
+    name: Percy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: always()
+    needs: e2e
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: npm install @percy/cli
+
+      - name: Finalize Percy build
+        run: npx percy build:finalize
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_E2E }}

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -110,6 +110,7 @@ jobs:
           path: build/web-stories
 
   nonce:
+    name: Percy Nonce
     runs-on: ubuntu-latest
     outputs:
       result: ${{ steps.nonce.outputs.result }}
@@ -201,7 +202,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: always()
-    needs: e2e
+    needs: [e2e, nonce]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -213,3 +214,4 @@ jobs:
         run: npx percy build:finalize
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_E2E }}
+          PERCY_PARALLEL_NONCE: ${{ needs.nonce.outputs.result }}

--- a/package.json
+++ b/package.json
@@ -217,7 +217,7 @@
     "test:php:unit:help": "npm run test:php -- --help",
     "test:e2e": "JEST_PUPPETEER_CONFIG=jest-puppeteer.config.cjs jest --runInBand --config=packages/e2e-tests/src/jest.config.js",
     "test:e2e:help": "npm run test:e2e -- --help",
-    "test:e2e:percy": "percy exec --config=percy.config.yml -- npm run test:e2e",
+    "test:e2e:percy": "percy exec --parallel --config=percy.config.yml -- npm run test:e2e",
     "test:e2e:watch": "npm run test:e2e -- --watch",
     "test:e2e:interactive": "PUPPETEER_HEADLESS=false PUPPETEER_SLOWMO=80 npm run test:e2e",
     "test:e2e:debug": "PUPPETEER_HEADLESS=false PUPPETEER_DEVTOOLS=true JEST_PUPPETEER_CONFIG=jest-puppeteer.config.cjs node --inspect-brk node_modules/.bin/jest --runInBand --config=packages/e2e-tests/src/jest.config.js",


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

Now that our e2e tests are running in a parallel job, it means that we're uploading Percy snapshots 2 times instead of once

To fix this, we need to somehow move the snapshot upload step to its own job that runs after the matrix job

## Summary

<!-- A brief description of what this PR does. -->

Luckily, Percy has documented best practices for this, so it was easy to configure Percy correctly for our setup.

In addition to optimizing the Percy step, this change also moves the build out of the test step so that we only build the plugin once.

## Relevant Technical Choices

<!-- Please describe your changes. -->

Followed recommendations from https://docs.percy.io/docs/parallel-test-suites#parallel-suites-split-across-different-machines

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10333
