### PR TITLE
Make editor ErrorBoundary more useful

### DIFF
--- a/packages/story-editor/src/components/errorBoundary/errorActions.js
+++ b/packages/story-editor/src/components/errorBoundary/errorActions.js
@@ -38,6 +38,11 @@ const Message = styled.div`
   }
 `;
 
+const TextArea = styled.textarea`
+  width: 100%;
+  min-height: 200px;
+`;
+
 const P = styled.p`
   margin: 0 0 8px 0;
 `;
@@ -47,8 +52,9 @@ const Wrapper = styled.div`
 `;
 
 function ErrorActions({ error, errorInfo }) {
-  const body = encodeURIComponent(`${error}${errorInfo.componentStack}`);
-  const reportUrl = `https://github.com/googleforcreators/web-stories-wp/issues/new?labels=Type%3A+Bug&template=bug_report.md&title=${error}&body=${body}`;
+  const textAreaContent = `${error}\n${errorInfo.componentStack}`;
+  const reportUrl =
+    'https://wordpress.org/support/plugin/web-stories/#new-topic-0';
 
   const reload = () => {
     window.location.reload(true);
@@ -64,6 +70,12 @@ function ErrorActions({ error, errorInfo }) {
         )}
       </P>
       <P>{__('Apologies for the inconvenience.', 'web-stories')}</P>
+      <P>
+        <TextArea
+          value={textAreaContent}
+          onFocus={(e) => e.target.setSelectionRange(0, textAreaContent.length)}
+        />
+      </P>
       <Wrapper>
         <Button
           variant={BUTTON_VARIANTS.RECTANGLE}


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

This is really a long overdue change

If the stack trace is too long, the GitHub URL  will be too long and it won't work.

Also, for support requests it's super important to have the error message visible so that they can just copy it and send it to us, or take a screenshot of it.

## Summary

<!-- A brief description of what this PR does. -->

Changes the report button to point to the forums

Adds a textarea with the error message

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

![Screenshot 2022-01-25 at 18 50 31](https://user-images.githubusercontent.com/841956/151161902-607be9a9-80ca-4212-abfb-1532211d2941.png)


## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Trigger an error somewhere to make the error boundary appear


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10374
