### PR TITLE
Performance: Reduce Layout Forced Reflow Exploration

### DIFF
--- a/packages/story-editor/src/components/canvas/canvasLayout.js
+++ b/packages/story-editor/src/components/canvas/canvasLayout.js
@@ -52,7 +52,6 @@ const Background = styled.section.attrs({
   height: 100%;
   position: relative;
   user-select: none;
-  contain: strict;
 `;
 
 function CanvasLayout({ header, footer }) {

--- a/packages/story-editor/src/components/canvas/canvasLayout.js
+++ b/packages/story-editor/src/components/canvas/canvasLayout.js
@@ -52,6 +52,7 @@ const Background = styled.section.attrs({
   height: 100%;
   position: relative;
   user-select: none;
+  contain: strict;
 `;
 
 function CanvasLayout({ header, footer }) {

--- a/packages/story-editor/src/components/canvas/layout.js
+++ b/packages/story-editor/src/components/canvas/layout.js
@@ -367,7 +367,7 @@ function useLayoutParamsCssVars() {
 const PageArea = forwardRef(function PageArea(
   {
     children,
-    fullbleedRef = createRef(),
+    fullbleedRef: _fullbleedRef = null,
     fullBleedContainerLabel = __('Fullbleed area', 'web-stories'),
     overlay = [],
     background,
@@ -381,6 +381,8 @@ const PageArea = forwardRef(function PageArea(
   },
   ref
 ) {
+  const internalFullblledRef = useRef();
+  const fullbleedRef = _fullbleedRef || internalFullblledRef;
   const {
     hasVerticalOverflow,
     hasHorizontalOverflow,


### PR DESCRIPTION
## Context
Part of performance audit. Was exploring reducing the DOM rendering speed for updating an element position:

<img width="468" alt="Screen Shot 2022-01-27 at 12 46 26 PM" src="https://user-images.githubusercontent.com/35983235/151425121-dec32b93-53ce-43f6-824f-992cfc4edadc.png">

## Summary
Ultimately this ended up unfruitful. I tried a couple techniques:

**Reducing code causing the forced reflow**
This was the first attempt to just remove the forced reflow all together. Initially I removed the unnecessary effect run by not creating a new ref on every render of `PageArea` . All though this removed this part of our codebase invoking a forced reflow, the way forced reflows work, if any of these properties get called on an element after a style recalculation is scheduled, the browser forces the synchronous reflow, so you see no results unless you remove *all* reads of these properties:
https://gist.github.com/paulirish/5d52fb081b3570c81e3a

This ultimately doesn't work because the internal moveable library calls `target.offsetWidth` & `target.offsetHeight` internally on dragEnd regardless of if we make one of these reads in our internal code or not. This lead me to the next approach.

**Reducing effected elements from the reflow**
Since the forced reflow seemed unavoidable, the next approach was to reduce the scope of its impact. Currently it effects all elements in the DOM:
<img width="471" alt="Screen Shot 2022-01-27 at 1 39 12 PM" src="https://user-images.githubusercontent.com/35983235/151431713-2faac440-a780-4027-b1d6-1f0fdb810b84.png">

I attempted using the [css contain property](https://developer.mozilla.org/en-US/docs/Web/CSS/contain) on a common ancestor around where I imagined most of the DOM mutations and reads were coming from to indicate that the areas on the canvas were isolated from the rest of the DOM and the browser could limit the scope of the style and layout calculations to those elements. Primarily focused on adding the property to this element here:
https://github.com/GoogleForCreators/web-stories-wp/blob/6a6a1f072d0266c03476c9bb3587720e2f26057c/packages/story-editor/src/components/canvas/canvasLayout.js#L46-L55

but it didn't seem to limit the scope of the layout calculation at all. Sprinkled it in a couple other areas just to see if I could cull the effected scope at all, but had no success.

**Current Status**
Ultimately it's hard to pin point exactly which areas are causing the browser to opt out of the `contain` element and make the scope of the reflows effect every element on the page. The tools the browser provides us to identify this issue are relatively opaque to the best of my knowledge. 

For now, I'm going to put a pin in this and go back to focusing on reducing unnecessary re-renders. Right now the two lower hanging fruits are:
- Stopping the design panel from re-rendering all it's children every time theres an update to the currentPage
- limiting expensive calls in `useApplyStyles` if possible.

After that, it's probably wise to start looking into performance of the other library panels as I know different tabs can add performance impacts to these basic actions. There really shouldn't be variation of perf of updating an element property depending on which library tab you have open.

Hopefully after reducing re-renders some more, it clears up the waters a little but to circle back to this issue and gives us some more transparency as to the root cause.


<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
Just lots of reading. relevant articles:
- https://developers.google.com/web/fundamentals/performance/rendering/avoid-large-complex-layouts-and-layout-thrashing
- https://developers.google.com/web/updates/2016/06/css-containment#layout_contain_layout
- https://css-tricks.com/almanac/properties/c/contain/
- https://mattandre.ws/2014/05/really-fixing-layout-thrashing/
- https://gist.github.com/paulirish/5d52fb081b3570c81e3a
<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
NA
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10291 
