### PR TITLE
Editor: First stage of floating menu bar

### DIFF
--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -385,9 +385,9 @@ class Experiments extends Service_Base implements HasRequirements {
 			 * Creation date: 2022-01-27
 			 */
 			[
-				'name'        => 'newDesignPanel',
-				'label'       => __( 'New Design Panel', 'web-stories' ),
-				'description' => __( 'Enable the new design panel integrated in the left-side menu including floating design bar', 'web-stories' ),
+				'name'        => 'floatingMenu',
+				'label'       => __( 'Floating Menu', 'web-stories' ),
+				'description' => __( 'Enable the new floating design menu', 'web-stories' ),
 				'group'       => 'editor',
 			],
 		];

--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -378,6 +378,18 @@ class Experiments extends Service_Base implements HasRequirements {
 				'description' => __( 'Enable adding captions to background audio', 'web-stories' ),
 				'group'       => 'editor',
 			],
+
+			/**
+			 * Author: @barklund
+			 * Issue: #10112
+			 * Creation date: 2022-01-27
+			 */
+			[
+				'name'        => 'newDesignPanel',
+				'label'       => __( 'New Design Panel', 'web-stories' ),
+				'description' => __( 'Enable the new design panel integrated in the left-side menu including floating design bar', 'web-stories' ),
+				'group'       => 'editor',
+			],
 		];
 	}
 

--- a/packages/story-editor/src/app/canvas/canvasProvider.js
+++ b/packages/story-editor/src/app/canvas/canvasProvider.js
@@ -195,6 +195,8 @@ function CanvasProvider({ children }) {
 
   useCanvasCopyPaste();
 
+  const [onMoveableMount, setMoveableMount] = useState(null);
+
   const state = useMemo(
     () => ({
       state: {
@@ -217,6 +219,7 @@ function CanvasProvider({ children }) {
         pageCanvasPromise,
         boundingBoxes,
         clientRectObserver,
+        onMoveableMount,
       },
       actions: {
         setPageContainer,
@@ -238,6 +241,7 @@ function CanvasProvider({ children }) {
         setEyedropperPixelData,
         setPageCanvasData,
         setPageCanvasPromise,
+        setMoveableMount,
       },
     }),
     [
@@ -266,6 +270,8 @@ function CanvasProvider({ children }) {
       clearEditing,
       handleSelectElement,
       selectIntersection,
+      onMoveableMount,
+      setMoveableMount,
     ]
   );
   return (

--- a/packages/story-editor/src/app/layout/useZoomSetting.js
+++ b/packages/story-editor/src/app/layout/useZoomSetting.js
@@ -49,6 +49,7 @@ const INITIAL_STATE = {
   workspaceSize: {
     width: null,
     height: null,
+    availableHeight: null,
   },
   scrollOffset: {
     left: 0,
@@ -83,7 +84,7 @@ const reducer = {
 function calculateViewportProperties(workspaceSize, zoomSetting, zoomLevel) {
   // Calculate page size based on zoom setting
   let maxPageWidth;
-  const workspaceRatio = workspaceSize.width / workspaceSize.height;
+  const workspaceRatio = workspaceSize.width / workspaceSize.availableHeight;
   switch (zoomSetting) {
     case ZOOM_SETTING.FILL: {
       // See how much we can fit inside so all space is used minus gap
@@ -96,7 +97,7 @@ function calculateViewportProperties(workspaceSize, zoomSetting, zoomLevel) {
       } else {
         // workspace is limited in the width, so use the height minus room for scrollbar converted
         maxPageWidth =
-          (workspaceSize.height - themeHelpers.SCROLLBAR_WIDTH) *
+          (workspaceSize.availableHeight - themeHelpers.SCROLLBAR_WIDTH) *
             FULLBLEED_RATIO -
           ZOOM_PADDING_LARGE;
       }
@@ -111,7 +112,7 @@ function calculateViewportProperties(workspaceSize, zoomSetting, zoomLevel) {
         // However, it can never be wider than the max width calculated above
         maxPageWidth = Math.min(
           maxWidth,
-          (workspaceSize.height - ZOOM_PADDING_LARGE) * FULLBLEED_RATIO
+          (workspaceSize.availableHeight - ZOOM_PADDING_LARGE) * FULLBLEED_RATIO
         );
       } else {
         // workspace is limited in the width, so use the width - padding
@@ -146,7 +147,7 @@ function calculateViewportProperties(workspaceSize, zoomSetting, zoomLevel) {
   // Is full height of available area minus gap used (up to two zoom factors off)
   const hasVerticalOverflow =
     pageHeight >=
-    workspaceSize.height - ZOOM_PADDING_LARGE - 2 * PAGE_WIDTH_FACTOR;
+    workspaceSize.availableHeight - ZOOM_PADDING_LARGE - 2 * PAGE_WIDTH_FACTOR;
   const hasAnyOverflow = hasHorizontalOverflow || hasVerticalOverflow;
   const hasPageNavigation =
     !hasAnyOverflow && pageWidth < workspaceSize.width - 2 * PAGE_NAV_WIDTH;
@@ -157,7 +158,7 @@ function calculateViewportProperties(workspaceSize, zoomSetting, zoomLevel) {
     ? workspaceSize.width
     : pageWidth + pagePadding;
   const viewportHeight = hasAnyOverflow
-    ? workspaceSize.height
+    ? workspaceSize.availableHeight
     : fullbleedHeight + pagePadding;
   return {
     pageWidth,

--- a/packages/story-editor/src/components/canvas/canvasLayout.js
+++ b/packages/story-editor/src/components/canvas/canvasLayout.js
@@ -82,7 +82,7 @@ function CanvasLayout({ header, footer }) {
     })
   );
 
-  const isFloatingMenuEnabled = useFeature('newDesignPanel');
+  const isFloatingMenuEnabled = useFeature('floatingMenu');
 
   // If we don't have proper canvas dimensions yet, don't bother rendering element layers.
   const hasDimensions = pageWidth !== 0 && pageHeight !== 0;

--- a/packages/story-editor/src/components/canvas/canvasLayout.js
+++ b/packages/story-editor/src/components/canvas/canvasLayout.js
@@ -21,6 +21,7 @@ import styled, { StyleSheetManager } from 'styled-components';
 import { memo, useRef, useCombinedRefs } from '@googleforcreators/react';
 import { __ } from '@googleforcreators/i18n';
 import PropTypes from 'prop-types';
+import { useFeature } from 'flagged';
 
 /**
  * Internal dependencies
@@ -31,6 +32,7 @@ import {
   useCanvasBoundingBoxRef,
   useLayout,
 } from '../../app';
+import { FloatingMenuLayer } from '../floatingMenu';
 import EditLayer from './editLayer';
 import DisplayLayer from './displayLayer';
 import FramesLayer from './framesLayer';
@@ -80,6 +82,8 @@ function CanvasLayout({ header, footer }) {
     })
   );
 
+  const isFloatingMenuEnabled = useFeature('newDesignPanel');
+
   // If we don't have proper canvas dimensions yet, don't bother rendering element layers.
   const hasDimensions = pageWidth !== 0 && pageHeight !== 0;
 
@@ -99,6 +103,7 @@ function CanvasLayout({ header, footer }) {
             </SelectionCanvas>
             <EditLayer />
             <EyedropperLayer />
+            {isFloatingMenuEnabled && <FloatingMenuLayer />}
           </CanvasElementDropzone>
         </CanvasUploadDropTarget>
       </Background>

--- a/packages/story-editor/src/components/canvas/editElement.js
+++ b/packages/story-editor/src/components/canvas/editElement.js
@@ -82,7 +82,7 @@ function EditElement({ element }) {
           selectedElement={element}
           targetEl={editWrapper}
           isEditMode
-          editMoveableRef={moveable}
+          ref={moveable}
         />
       )}
     </>

--- a/packages/story-editor/src/components/canvas/layout.js
+++ b/packages/story-editor/src/components/canvas/layout.js
@@ -37,7 +37,7 @@ import {
 /**
  * Internal dependencies
  */
-import { HEADER_HEIGHT } from '../../constants';
+import { HEADER_HEIGHT, HEADER_GAP } from '../../constants';
 import pointerEventsCss from '../../utils/pointerEventsCss';
 import { useLayout } from '../../app';
 import useFooterHeight from '../footer/useFooterHeight';
@@ -54,7 +54,6 @@ export const Z_INDEX = {
   EDIT: 3,
 };
 
-const HEADER_GAP = 16;
 // 8px extra is for the focus outline to display.
 const PAGE_NAV_WIDTH = THEME_CONSTANTS.LARGE_BUTTON_SIZE + 8;
 const PAGE_NAV_GAP = 20;
@@ -294,15 +293,14 @@ function useLayoutParams(containerRef) {
     ({ width, height }) => {
       // See Layer's `grid` CSS above. Per the layout, the maximum available
       // space for the page is:
-      const maxWidth = width;
-      const maxHeight =
+      const availableHeight =
         height -
         HEADER_HEIGHT -
         HEADER_GAP -
         footerHeight -
         FOOTER_BOTTOM_MARGIN;
 
-      setWorkspaceSize({ width: maxWidth, height: maxHeight });
+      setWorkspaceSize({ width, height, availableHeight });
     },
     [setWorkspaceSize, footerHeight]
   );

--- a/packages/story-editor/src/components/canvas/multiSelectionMoveable/index.js
+++ b/packages/story-editor/src/components/canvas/multiSelectionMoveable/index.js
@@ -18,7 +18,13 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useRef, useEffect, useState } from '@googleforcreators/react';
+import {
+  forwardRef,
+  useRef,
+  useEffect,
+  useState,
+  useCombinedRefs,
+} from '@googleforcreators/react';
 import { useUnits } from '@googleforcreators/units';
 /**
  * Internal dependencies
@@ -38,7 +44,10 @@ import useRotate from './useRotate';
 
 const CORNER_HANDLES = ['nw', 'ne', 'sw', 'se'];
 
-function MultiSelectionMoveable({ selectedElements, ...props }) {
+const MultiSelectionMoveable = forwardRef(function MultiSelectionMoveable(
+  { selectedElements, ...props },
+  ref
+) {
   const moveable = useRef();
 
   const { updateElementsById, deleteElementsById, backgroundElement } =
@@ -227,6 +236,8 @@ function MultiSelectionMoveable({ selectedElements, ...props }) {
     frames,
   });
 
+  const combinedRef = useCombinedRefs(moveable, ref);
+
   // Not all targets have been defined yet.
   if (targetList.some(({ node }) => node === undefined)) {
     return null;
@@ -236,7 +247,7 @@ function MultiSelectionMoveable({ selectedElements, ...props }) {
     <Moveable
       {...props}
       className={'default-moveable'}
-      ref={moveable}
+      ref={combinedRef}
       zIndex={0}
       target={targetList.map(({ node }) => node)}
       draggable
@@ -249,7 +260,7 @@ function MultiSelectionMoveable({ selectedElements, ...props }) {
       {...snapProps}
     />
   );
-}
+});
 
 MultiSelectionMoveable.propTypes = {
   selectedElements: PropTypes.arrayOf(PropTypes.object).isRequired,

--- a/packages/story-editor/src/components/canvas/selection.js
+++ b/packages/story-editor/src/components/canvas/selection.js
@@ -40,13 +40,22 @@ function Selection(props) {
       STORY_ANIMATION_STATE.SCRUBBING,
     ].includes(state.state.animationState),
   }));
-  const { editingElement, lastSelectionEvent, nodesById } = useCanvas(
-    ({ state: { editingElement, lastSelectionEvent, nodesById } }) => ({
-      editingElement,
-      lastSelectionEvent,
-      nodesById,
-    })
-  );
+  const { editingElement, lastSelectionEvent, nodesById, onMoveableMount } =
+    useCanvas(
+      ({
+        state: {
+          editingElement,
+          lastSelectionEvent,
+          nodesById,
+          onMoveableMount,
+        },
+      }) => ({
+        editingElement,
+        lastSelectionEvent,
+        nodesById,
+        onMoveableMount,
+      })
+    );
 
   // No selection.
   if (selectedElements.length === 0) {
@@ -82,13 +91,19 @@ function Selection(props) {
         selectedElement={selectedElement}
         targetEl={target}
         pushEvent={lastSelectionEvent}
+        {...props}
+        {...(onMoveableMount && { ref: onMoveableMount })}
       />
     );
   }
 
   // Multi-selection.
   return (
-    <MultiSelectionMoveable {...props} selectedElements={selectedElements} />
+    <MultiSelectionMoveable
+      selectedElements={selectedElements}
+      {...props}
+      {...(onMoveableMount && { ref: onMoveableMount })}
+    />
   );
 }
 

--- a/packages/story-editor/src/components/canvas/singleSelectionMoveable/index.js
+++ b/packages/story-editor/src/components/canvas/singleSelectionMoveable/index.js
@@ -19,6 +19,7 @@
  */
 import PropTypes from 'prop-types';
 import {
+  forwardRef,
   useRef,
   useEffect,
   useState,
@@ -44,13 +45,10 @@ import useDrag from './useDrag';
 import useResize from './useResize';
 import useRotate from './useRotate';
 
-function SingleSelectionMoveable({
-  selectedElement,
-  targetEl,
-  pushEvent,
-  isEditMode,
-  editMoveableRef,
-}) {
+const SingleSelectionMoveable = forwardRef(function SingleSelectionMoveable(
+  { selectedElement, targetEl, pushEvent, isEditMode, ...props },
+  ref
+) {
   const moveable = useRef(null);
   const [isDragging, setIsDragging] = useState(false);
 
@@ -226,9 +224,10 @@ function SingleSelectionMoveable({
 
   return (
     <Moveable
+      {...props}
       className={classNames}
       zIndex={0}
-      ref={useCombinedRefs(moveable, editMoveableRef)}
+      ref={useCombinedRefs(moveable, ref)}
       target={targetEl}
       edge
       draggable={actionsEnabled}
@@ -242,7 +241,7 @@ function SingleSelectionMoveable({
       pinchable
     />
   );
-}
+});
 
 SingleSelectionMoveable.propTypes = {
   selectedElement: PropTypes.object.isRequired,

--- a/packages/story-editor/src/components/floatingMenu/index.js
+++ b/packages/story-editor/src/components/floatingMenu/index.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default as FloatingMenuLayer } from './layer';
+export { default as FloatingMenu } from './menu';

--- a/packages/story-editor/src/components/floatingMenu/layer.js
+++ b/packages/story-editor/src/components/floatingMenu/layer.js
@@ -23,6 +23,7 @@ import { useEffect, useRef, useState } from '@googleforcreators/react';
  * Internal dependencies
  */
 import { useCanvas, useLayout } from '../../app';
+import { FLOATING_MENU_DISTANCE } from '../../constants';
 import FloatingMenu from './menu';
 
 // Note that this has to work for a lot of different types of moveable
@@ -55,6 +56,9 @@ function FloatingMenuLayer() {
   const workspaceSize = useRef();
 
   // Whenever the selection frame (un)mounts, update the reference to moveable
+  // This happens when selection changes between the three possible states: None,
+  // single, multiple. If the selection merely changes inside one of those (so
+  // from single to another single), this function is not invoked.
   useEffect(() => {
     setMoveableMount(() => setMoveable);
     return () => setMoveableMount(null);
@@ -81,7 +85,7 @@ function FloatingMenuLayer() {
       menu.style.display = 'flex';
       const centerX = frameRect.left + frameRect.width / 2;
       menu.style.left = `clamp(0px, ${centerX}px - (var(--width) / 2), ${width}px - var(--width))`;
-      const bottomX = frameRect.top + frameRect.height + 10;
+      const bottomX = frameRect.top + frameRect.height + FLOATING_MENU_DISTANCE;
       menu.style.top = `clamp(0px, ${bottomX}px, ${height}px - var(--height))`;
     };
 

--- a/packages/story-editor/src/components/floatingMenu/layer.js
+++ b/packages/story-editor/src/components/floatingMenu/layer.js
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useEffect, useRef, useState } from '@googleforcreators/react';
+
+/**
+ * Internal dependencies
+ */
+import { useCanvas, useLayout } from '../../app';
+import FloatingMenu from './menu';
+
+const MV_NW = '.moveable-control-box';
+const MV_SE = '.moveable-direction.moveable-se';
+
+function FloatingMenuLayer() {
+  const { setMoveableMount } = useCanvas(
+    ({ actions: { setMoveableMount } }) => ({ setMoveableMount })
+  );
+  const { workspaceWidth, workspaceHeight } = useLayout(
+    ({ state: { workspaceWidth, workspaceHeight } }) => ({
+      workspaceWidth,
+      workspaceHeight,
+    })
+  );
+
+  const [moveable, setMoveable] = useState(null);
+  const menuRef = useRef();
+  const workspaceSize = useRef();
+
+  // Whenever the selection frame (un)mounts, update the reference to moveable
+  useEffect(() => {
+    setMoveableMount(() => setMoveable);
+    return () => setMoveableMount(null);
+  }, [setMoveableMount]);
+
+  // Whenever the workspace resizes, update size
+  useEffect(() => {
+    workspaceSize.current = { width: workspaceWidth, height: workspaceHeight };
+  }, [workspaceWidth, workspaceHeight]);
+
+  // Whenever moveable is set (because selection count changed between none, single, or multiple)
+  useEffect(() => {
+    const menu = menuRef.current;
+    if (!moveable) {
+      menu.style.display = 'none';
+      return null;
+    }
+
+    const updatePosition = () => {
+      const frameRect = moveable.getRect();
+      const { width, height } = workspaceSize.current;
+      menu.style.display = 'flex';
+      const centerX = frameRect.left + frameRect.width / 2;
+      menu.style.left = `clamp(0px, ${centerX}px - (var(--width) / 2), ${width}px - var(--width))`;
+      const bottomX = frameRect.top + frameRect.height + 10;
+      menu.style.top = `clamp(0px, ${bottomX}px, ${height}px - var(--height))`;
+    };
+
+    // Update now
+    updatePosition();
+
+    // And update when certain elements' properties update
+    const observer = new MutationObserver(updatePosition);
+    // Observe the top right and bottom left corner of the moveable frame
+    observer.observe(document.querySelector(MV_NW), { attributes: true });
+    observer.observe(document.querySelector(MV_SE), { attributes: true });
+
+    return () => observer.disconnect();
+  }, [moveable]);
+
+  return <FloatingMenu ref={menuRef} />;
+}
+
+export default FloatingMenuLayer;

--- a/packages/story-editor/src/components/floatingMenu/menu.js
+++ b/packages/story-editor/src/components/floatingMenu/menu.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { forwardRef, useLayoutEffect } from '@googleforcreators/react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+const Menu = styled.nav`
+  position: absolute;
+  background: hotpink;
+  padding: 5px;
+  border: 1px solid white;
+  color: white;
+  z-index: 2;
+`;
+
+const FloatingMenu = forwardRef(function FloatingMenu(props, ref) {
+  useLayoutEffect(() => {
+    const node = ref.current;
+    const bounds = node.getBoundingClientRect();
+    node.style.setProperty('--width', `${bounds.width.toFixed(2)}px`);
+    node.style.setProperty('--height', `${bounds.height.toFixed(2)}px`);
+  }, [ref]);
+
+  return (
+    <Menu ref={ref}>
+      {`Floating Menu | Floating Menu | Floating Menu | Floating Menu`}
+    </Menu>
+  );
+});
+
+FloatingMenu.propTypes = {
+  isVisible: PropTypes.bool,
+};
+
+export default FloatingMenu;

--- a/packages/story-editor/src/constants/index.js
+++ b/packages/story-editor/src/constants/index.js
@@ -20,6 +20,7 @@ export * from './multipleValue';
 
 export const ADMIN_TOOLBAR_HEIGHT = 32;
 export const HEADER_HEIGHT = 64;
+export const HEADER_GAP = 16;
 export const CANVAS_MIN_WIDTH = 570;
 export const LIBRARY_MIN_WIDTH = 220;
 export const LIBRARY_MAX_WIDTH = 360;

--- a/packages/story-editor/src/constants/index.js
+++ b/packages/story-editor/src/constants/index.js
@@ -29,6 +29,7 @@ export const INSPECTOR_MAX_WIDTH = 308;
 export const PAGE_NAV_PADDING = 60;
 export const PAGE_NAV_BUTTON_SIZE = 40;
 export const PAGE_NAV_WIDTH = PAGE_NAV_PADDING + PAGE_NAV_BUTTON_SIZE;
+export const FLOATING_MENU_DISTANCE = 10;
 
 export const ZOOM_SETTING = {
   FILL: 'FILL',


### PR DESCRIPTION
## Context

This PR is the first partial PR to implement the floating menu bar.

Included in this PR:

* New feature flag
* Floating menu that aligns below the current selection whatever that may be



## Relevant Technical Choices

* I decided to listen directly to the mutation events of the moveable object rather than all the ways an object can be moved because they are plenty. I actually started out by listening to some of those events but realized that there were way more than expected. This seemed a lot faster! The current selection can update in many different ways:
  * Selecting and deselecting elements
  * Moving selected elements using the keyboard
  * Resizing, moving, or rotating the current selection using the mouse
  * Changing properties directly in the design panel
  * Resizing the browser window
  * Zooming the canvas using the zoom dropdown or pinch-zoom
  * Scrolling a zoomed canvas
* Also, the clamping of the menu inside the workspace is done in CSS! That's an incredibly efficient way to do it, so very happy with that!
* To get the full workspace height, I had to do some hacks in the layout provider, but that wasn't a big deal.

## To-do

* This does not work in text-edit mode and it probably should. It's most likely a small fix to also call the onMoveableMount callback in `editElement`, if the element is a text element (and not if media!), but left that for future optimization.
* [x] ~This has not been tested in RTL and the semantics for the menu are not proper either.~ It does work in RTL!

## User-facing changes

_Note: These aren't actually user-facing, because it's behind a feature flag._

The menu isn't pretty (or is it?), but it's correctly placed!

| Manipulation | View |
|-|-|
| Single element | ![menu-single-element](https://user-images.githubusercontent.com/637548/151675181-d6c008eb-5d03-4dca-9429-6aa7b8879cf7.gif) |
| Multi-selection | ![menu-multi-select](https://user-images.githubusercontent.com/637548/151675189-9f3905fc-a147-4e6a-932e-f9639c2b7f7a.gif) |
| Window resize | ![menu-window-resize](https://user-images.githubusercontent.com/637548/151675222-8c61097c-d353-474b-bd67-5798c95adf75.gif) |
| Workspace clamping | ![menu-workspace-clamp](https://user-images.githubusercontent.com/637548/151675226-266541b3-0726-4e3e-a666-7426ff0f836b.gif) |
| Zoom and scroll | ![menu-zoom](https://user-images.githubusercontent.com/637548/151675234-56e94627-7065-45da-945d-0e79cff54b9e.gif) |

Note this weirdness when it comes to the multi-selection. When rotating, the frame will reset on completed rotation, which causes the menu to also jump. But the menu perfectly follows the selection rectangle, so I feel it's okay:
![menu-multi-weird](https://user-images.githubusercontent.com/637548/151675216-1e8ddeb4-307e-400a-a13f-8f8c151aa568.gif)

## Testing Instructions

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Partially addresses #10112
