### PR TITLE
Editor: Added floating menu to text while in edit-mode

### DIFF
--- a/packages/story-editor/src/components/canvas/editElement.js
+++ b/packages/story-editor/src/components/canvas/editElement.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { useState, forwardRef } from '@googleforcreators/react';
+import { memo, useState, forwardRef } from '@googleforcreators/react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { useUnits } from '@googleforcreators/units';
@@ -39,35 +39,35 @@ const Wrapper = styled.div`
   pointer-events: initial;
 `;
 
-const EditElement = forwardRef(function EditElement(
-  { element, editWrapper, onResize },
-  ref
-) {
-  const { id, type } = element;
-  const { getBox } = useUnits((state) => ({
-    getBox: state.actions.getBox,
-  }));
+const EditElement = memo(
+  forwardRef(function EditElement({ element, editWrapper, onResize }, ref) {
+    const { id, type } = element;
+    const { getBox } = useUnits((state) => ({
+      getBox: state.actions.getBox,
+    }));
 
-  // Needed for elements that can scale in edit mode.
-  const [localProperties, setLocalProperties] = useState(null);
+    // Needed for elements that can scale in edit mode.
+    const [localProperties, setLocalProperties] = useState(null);
 
-  const { Edit } = getDefinitionForType(type);
-  const box = getBox(
-    localProperties ? { ...element, ...localProperties } : element
-  );
+    const { Edit } = getDefinitionForType(type);
+    const elementWithLocal = localProperties
+      ? { ...element, ...localProperties }
+      : element;
+    const box = getBox(elementWithLocal);
 
-  return (
-    <Wrapper aria-labelledby={`layer-${id}`} {...box} ref={ref}>
-      <Edit
-        element={localProperties ? { ...element, ...localProperties } : element}
-        box={box}
-        editWrapper={editWrapper}
-        onResize={onResize}
-        setLocalProperties={setLocalProperties}
-      />
-    </Wrapper>
-  );
-});
+    return (
+      <Wrapper aria-labelledby={`layer-${id}`} {...box} ref={ref}>
+        <Edit
+          element={elementWithLocal}
+          box={box}
+          editWrapper={editWrapper}
+          onResize={onResize}
+          setLocalProperties={setLocalProperties}
+        />
+      </Wrapper>
+    );
+  })
+);
 
 EditElement.propTypes = {
   element: PropTypes.object.isRequired,

--- a/packages/story-editor/src/components/canvas/editElement.js
+++ b/packages/story-editor/src/components/canvas/editElement.js
@@ -17,6 +17,7 @@
 /**
  * External dependencies
  */
+import { useState, forwardRef } from '@googleforcreators/react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { useUnits } from '@googleforcreators/units';
@@ -24,73 +25,54 @@ import { useUnits } from '@googleforcreators/units';
 /**
  * Internal dependencies
  */
-import { useState, useRef } from '@googleforcreators/react';
 import { getDefinitionForType } from '../../elements';
 import {
   elementWithPosition,
   elementWithSize,
   elementWithRotation,
 } from '../../elements/shared';
-import SingleSelectionMoveable from './singleSelectionMoveable';
 
 const Wrapper = styled.div`
   ${elementWithPosition}
   ${elementWithSize}
-	${elementWithRotation}
-	pointer-events: initial;
+  ${elementWithRotation}
+  pointer-events: initial;
 `;
 
-function EditElement({ element }) {
+const EditElement = forwardRef(function EditElement(
+  { element, editWrapper, onResize },
+  ref
+) {
   const { id, type } = element;
   const { getBox } = useUnits((state) => ({
     getBox: state.actions.getBox,
   }));
 
-  const [editWrapper, setEditWrapper] = useState(null);
   // Needed for elements that can scale in edit mode.
   const [localProperties, setLocalProperties] = useState(null);
 
-  const { Edit, hasEditModeMoveable } = getDefinitionForType(type);
+  const { Edit } = getDefinitionForType(type);
   const box = getBox(
     localProperties ? { ...element, ...localProperties } : element
   );
 
-  const moveable = useRef(null);
-
-  const onResize = () => {
-    // Update moveable when resizing.
-    if (moveable.current) {
-      moveable.current.updateRect();
-    }
-  };
-
   return (
-    <>
-      <Wrapper aria-labelledby={`layer-${id}`} {...box} ref={setEditWrapper}>
-        <Edit
-          element={
-            localProperties ? { ...element, ...localProperties } : element
-          }
-          box={box}
-          editWrapper={hasEditModeMoveable && editWrapper}
-          onResize={onResize}
-          setLocalProperties={setLocalProperties}
-        />
-      </Wrapper>
-      {hasEditModeMoveable && editWrapper && (
-        <SingleSelectionMoveable
-          selectedElement={element}
-          targetEl={editWrapper}
-          isEditMode
-          ref={moveable}
-        />
-      )}
-    </>
+    <Wrapper aria-labelledby={`layer-${id}`} {...box} ref={ref}>
+      <Edit
+        element={localProperties ? { ...element, ...localProperties } : element}
+        box={box}
+        editWrapper={editWrapper}
+        onResize={onResize}
+        setLocalProperties={setLocalProperties}
+      />
+    </Wrapper>
   );
-}
+});
 
 EditElement.propTypes = {
   element: PropTypes.object.isRequired,
+  editWrapper: PropTypes.object,
+  onResize: PropTypes.func,
 };
 
 export default EditElement;

--- a/packages/story-editor/src/components/canvas/editLayer.js
+++ b/packages/story-editor/src/components/canvas/editLayer.js
@@ -19,7 +19,13 @@
  */
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { memo, useEffect, useRef } from '@googleforcreators/react';
+import {
+  memo,
+  useEffect,
+  useRef,
+  useCallback,
+  useState,
+} from '@googleforcreators/react';
 import { _x, __ } from '@googleforcreators/i18n';
 import { useKeyDownEffect } from '@googleforcreators/design-system';
 
@@ -33,11 +39,12 @@ import withOverlay from '../overlay/withOverlay';
 import EditElement from './editElement';
 import { Layer, PageArea, FooterArea, Z_INDEX } from './layout';
 import useFocusCanvas from './useFocusCanvas';
+import SingleSelectionMoveable from './singleSelectionMoveable';
 
-const LayerWithGrayout = styled(Layer)`
+const LayerWithGrayout = withOverlay(styled(Layer)`
   background-color: ${({ grayout, theme }) =>
     grayout ? theme.colors.opacity.overlayDark : 'transparent'};
-`;
+`);
 
 const EditPageArea = withOverlay(PageArea);
 
@@ -74,11 +81,14 @@ function EditLayerForElement({ element, showOverflow }) {
   const pageAreaRef = useRef(null);
   const { editModeGrayout, EditMenu } = getDefinitionForType(element.type);
 
-  const { clearEditing } = useCanvas((state) => ({
+  const { clearEditing, onMoveableMount } = useCanvas((state) => ({
     clearEditing: state.actions.clearEditing,
+    onMoveableMount: state.state.onMoveableMount,
   }));
 
   const focusCanvas = useFocusCanvas();
+
+  const [editWrapper, setEditWrapper] = useState(null);
 
   useKeyDownEffect(ref, { key: 'esc', editable: true }, () => clearEditing(), [
     clearEditing,
@@ -90,37 +100,73 @@ function EditLayerForElement({ element, showOverflow }) {
     return () => focusCanvas(/* force */ false);
   }, [focusCanvas]);
 
+  const moveable = useRef(null);
+  const setRef = useCallback(
+    (moveableRef) => {
+      moveable.current = moveableRef;
+      onMoveableMount?.(moveableRef);
+    },
+    [onMoveableMount]
+  );
+
+  const onResize = () => {
+    // Update moveable when resizing.
+    if (moveable.current) {
+      moveable.current.updateRect();
+    }
+  };
+
+  const { hasEditModeMoveable } = getDefinitionForType(element.type);
+
   return (
-    <LayerWithGrayout
-      ref={ref}
-      aria-label={_x('Edit layer', 'compound noun', 'web-stories')}
-      data-testid="editLayer"
-      grayout={editModeGrayout}
-      zIndex={Z_INDEX.EDIT}
-      onPointerDown={(evt) => {
-        if (evt.target === ref.current || evt.target === pageAreaRef.current) {
-          clearEditing();
-        }
-      }}
-    >
-      <EditPageArea
-        ref={pageAreaRef}
-        fullBleedContainerLabel={__(
-          'Fullbleed area (Edit layer)',
-          'web-stories'
-        )}
-        isControlled
-        showOverflow={showOverflow}
-        overflow={showOverflow ? 'visible' : 'hidden'}
+    <div>
+      <LayerWithGrayout
+        ref={ref}
+        aria-label={_x('Edit layer', 'compound noun', 'web-stories')}
+        data-testid="editLayer"
+        grayout={editModeGrayout}
+        zIndex={Z_INDEX.EDIT}
+        onPointerDown={(evt) => {
+          if (
+            evt.target === ref.current ||
+            evt.target === pageAreaRef.current
+          ) {
+            clearEditing();
+          }
+        }}
       >
-        <EditElement element={element} />
-      </EditPageArea>
-      {EditMenu && (
-        <FooterArea showOverflow>
-          <EditMenu />
-        </FooterArea>
-      )}
-    </LayerWithGrayout>
+        <EditPageArea
+          ref={pageAreaRef}
+          fullBleedContainerLabel={__(
+            'Fullbleed area (Edit layer)',
+            'web-stories'
+          )}
+          isControlled
+          showOverflow={showOverflow}
+          overflow={showOverflow ? 'visible' : 'hidden'}
+        >
+          <EditElement
+            editWrapper={hasEditModeMoveable && editWrapper}
+            onResize={onResize}
+            element={element}
+            ref={setEditWrapper}
+          />
+        </EditPageArea>
+        {hasEditModeMoveable && editWrapper && (
+          <SingleSelectionMoveable
+            selectedElement={element}
+            targetEl={editWrapper}
+            isEditMode
+            ref={setRef}
+          />
+        )}
+        {EditMenu && (
+          <FooterArea showOverflow>
+            <EditMenu />
+          </FooterArea>
+        )}
+      </LayerWithGrayout>
+    </div>
   );
 }
 

--- a/packages/story-editor/src/components/canvas/editLayer.js
+++ b/packages/story-editor/src/components/canvas/editLayer.js
@@ -119,54 +119,49 @@ function EditLayerForElement({ element, showOverflow }) {
   const { hasEditModeMoveable } = getDefinitionForType(element.type);
 
   return (
-    <div>
-      <LayerWithGrayout
-        ref={ref}
-        aria-label={_x('Edit layer', 'compound noun', 'web-stories')}
-        data-testid="editLayer"
-        grayout={editModeGrayout}
-        zIndex={Z_INDEX.EDIT}
-        onPointerDown={(evt) => {
-          if (
-            evt.target === ref.current ||
-            evt.target === pageAreaRef.current
-          ) {
-            clearEditing();
-          }
-        }}
+    <LayerWithGrayout
+      ref={ref}
+      aria-label={_x('Edit layer', 'compound noun', 'web-stories')}
+      data-testid="editLayer"
+      grayout={editModeGrayout}
+      zIndex={Z_INDEX.EDIT}
+      onPointerDown={(evt) => {
+        if (evt.target === ref.current || evt.target === pageAreaRef.current) {
+          clearEditing();
+        }
+      }}
+    >
+      <EditPageArea
+        ref={pageAreaRef}
+        fullBleedContainerLabel={__(
+          'Fullbleed area (Edit layer)',
+          'web-stories'
+        )}
+        isControlled
+        showOverflow={showOverflow}
+        overflow={showOverflow ? 'visible' : 'hidden'}
       >
-        <EditPageArea
-          ref={pageAreaRef}
-          fullBleedContainerLabel={__(
-            'Fullbleed area (Edit layer)',
-            'web-stories'
-          )}
-          isControlled
-          showOverflow={showOverflow}
-          overflow={showOverflow ? 'visible' : 'hidden'}
-        >
-          <EditElement
-            editWrapper={hasEditModeMoveable && editWrapper}
-            onResize={onResize}
-            element={element}
-            ref={setEditWrapper}
-          />
-        </EditPageArea>
-        {hasEditModeMoveable && editWrapper && (
-          <SingleSelectionMoveable
-            selectedElement={element}
-            targetEl={editWrapper}
-            isEditMode
-            ref={setRef}
-          />
-        )}
-        {EditMenu && (
-          <FooterArea showOverflow>
-            <EditMenu />
-          </FooterArea>
-        )}
-      </LayerWithGrayout>
-    </div>
+        <EditElement
+          editWrapper={hasEditModeMoveable && editWrapper}
+          onResize={onResize}
+          element={element}
+          ref={setEditWrapper}
+        />
+      </EditPageArea>
+      {hasEditModeMoveable && editWrapper && (
+        <SingleSelectionMoveable
+          selectedElement={element}
+          targetEl={editWrapper}
+          isEditMode
+          ref={setRef}
+        />
+      )}
+      {EditMenu && (
+        <FooterArea showOverflow>
+          <EditMenu />
+        </FooterArea>
+      )}
+    </LayerWithGrayout>
   );
 }
 

--- a/packages/story-editor/src/components/canvas/editLayer.js
+++ b/packages/story-editor/src/components/canvas/editLayer.js
@@ -109,12 +109,12 @@ function EditLayerForElement({ element, showOverflow }) {
     [onMoveableMount]
   );
 
-  const onResize = () => {
+  const onResize = useCallback(() => {
     // Update moveable when resizing.
     if (moveable.current) {
       moveable.current.updateRect();
     }
-  };
+  }, []);
 
   const { hasEditModeMoveable } = getDefinitionForType(element.type);
 


### PR DESCRIPTION
## Context

This is another partial PR for #10112. This time adding the floating menu to the text-edit element.

## Relevant Technical Choices

* Adding the floating menu was easy, but because the coordinate system was shifted in the edit element, I had to reorganize some things. Edit mode still works exactly as before though.

## User-facing changes

You can see that the element is in edit mode, when the squiggly red line is visible below the non-word (because of spellchecker).
![text-edit-menu](https://user-images.githubusercontent.com/637548/151888496-14ba8f8c-438f-4581-b5ce-42df4b0f4743.gif)

## Testing Instructions

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Partially addresses #10112
