### PR TITLE
Storybook: fix Left Rail

### DIFF
--- a/packages/dashboard/src/components/pageStructure/stories/index.js
+++ b/packages/dashboard/src/components/pageStructure/stories/index.js
@@ -18,6 +18,7 @@
  * Internal dependencies
  */
 import { AppFrame, PageContent, LeftRail } from '..';
+import NavProvider from '../../navProvider';
 
 export default {
   title: 'Dashboard/Components/LeftRail',
@@ -26,8 +27,10 @@ export default {
 export const _default = () => {
   return (
     <AppFrame>
-      <LeftRail />
-      <PageContent />
+      <NavProvider>
+        <LeftRail />
+        <PageContent />
+      </NavProvider>
     </AppFrame>
   );
 };

--- a/packages/dashboard/src/components/pageStructure/stories/menuButton.js
+++ b/packages/dashboard/src/components/pageStructure/stories/menuButton.js
@@ -25,6 +25,9 @@ export default {
   args: {
     showOnlyOnSmallViewport: true,
   },
+  argTypes: {
+    showOnlyOnSmallViewport: { name: 'Show only on Small (Mobile) Viewort' },
+  },
 };
 
 const Status = () => {


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
The Storybook story for the Dashboard component `Left Rail` was returning an error. This was due to no context provider being present.  



## Relevant Technical Choices
Added `NavProvider` to the story. 
<!-- Please describe your changes. -->

## To-do
n/a
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
<img width="661" alt="Screen Shot 2022-02-01 at 1 04 26 PM" src="https://user-images.githubusercontent.com/1820266/152042729-1042846b-1929-47b5-a329-a221e13031dd.png">

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Fire up Storybook and check that `Dashboard/Components/LeftRail` loads as expected. 


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10376 
