### PR TITLE
Add separate `get_default_archive_link()` method

### DIFF
--- a/includes/Admin/Dashboard.php
+++ b/includes/Admin/Dashboard.php
@@ -432,7 +432,7 @@ class Dashboard extends Service_Base {
 			'locale'                  => $this->locale->get_locale_settings(),
 			'newStoryURL'             => $new_story_url,
 			'archiveURL'              => $this->story_post_type->get_archive_link(),
-			'defaultArchiveURL'       => $this->story_post_type->get_archive_link( true ),
+			'defaultArchiveURL'       => $this->story_post_type->get_default_archive_link(),
 			'cdnURL'                  => trailingslashit( WEBSTORIES_CDN_URL ),
 			'allowedImageMimeTypes'   => $this->types->get_allowed_image_mime_types(),
 			'version'                 => WEBSTORIES_VERSION,

--- a/tests/phpunit/integration/includes/Fixture/DummyPostTypeWithCustomArchive.php
+++ b/tests/phpunit/integration/includes/Fixture/DummyPostTypeWithCustomArchive.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Web_Stories\Tests\Integration\Fixture;
+
+class DummyPostTypeWithCustomArchive extends \Google\Web_Stories\Post_Type_Base {
+	public function get_slug(): string {
+		return 'cpt-custom-archive';
+	}
+
+	public function get_args(): array {
+		return [
+			'public'      => true,
+			'rewrite'     => true,
+			'has_archive' => 'custom-archive-slug',
+		];
+	}
+}

--- a/tests/phpunit/integration/includes/Fixture/DummyPostTypeWithoutArchive.php
+++ b/tests/phpunit/integration/includes/Fixture/DummyPostTypeWithoutArchive.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Web_Stories\Tests\Integration\Fixture;
+
+class DummyPostTypeWithoutArchive extends \Google\Web_Stories\Post_Type_Base {
+	public function get_slug(): string {
+		return 'cpt-without-archive';
+	}
+
+	public function get_args(): array {
+		return [
+			'public'      => true,
+			'rewrite'     => true,
+			'has_archive' => false,
+		];
+	}
+}

--- a/tests/phpunit/integration/tests/Post_Type_Base.php
+++ b/tests/phpunit/integration/tests/Post_Type_Base.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Web_Stories\Tests\Integration;
+
+use Google\Web_Stories\Tests\Integration\Fixture\DummyPostTypeWithCustomArchive;
+use Google\Web_Stories\Tests\Integration\Fixture\DummyPostTypeWithoutArchive;
+use Google\Web_Stories\Tests\Integration\Fixture\DummyTaxonomy;
+
+/**
+ * @coversDefaultClass \Google\Web_Stories\Post_Type_Base
+ */
+class Post_Type_Base extends DependencyInjectedTestCase {
+
+	/**
+	 * @var \Google\Web_Stories\Post_Type_Base
+	 */
+	protected static $cpt_no_archive;
+
+	/**
+	 * @var \Google\Web_Stories\Post_Type_Base
+	 */
+	protected static $cpt_custom_archive;
+
+	public function set_up() {
+		parent::set_up();
+
+		self::$cpt_no_archive = new DummyPostTypeWithoutArchive();
+		self::$cpt_no_archive->register();
+
+		self::$cpt_custom_archive = new DummyPostTypeWithCustomArchive();
+		self::$cpt_custom_archive->register();
+	}
+
+	public function tear_down() {
+		self::$cpt_no_archive->unregister_post_type();
+		self::$cpt_custom_archive->unregister_post_type();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * @covers ::get_archive_link
+	 */
+	public function test_get_archive_link_no_archive() {
+		$link = self::$cpt_no_archive->get_archive_link();
+		$this->assertSame( home_url( '/?post_type=cpt-without-archive' ), $link );
+	}
+
+	/**
+	 * @covers ::get_archive_link
+	 */
+	public function test_get_archive_link_no_archive_pretty_permalinks() {
+		$this->set_permalink_structure( '/%postname%/' );
+
+		self::$cpt_no_archive->unregister_post_type();
+		self::$cpt_no_archive = new DummyPostTypeWithoutArchive();
+		self::$cpt_no_archive->register();
+
+		$link = self::$cpt_no_archive->get_archive_link();
+		$this->assertSame( home_url( '/' ), $link );
+	}
+
+	/**
+	 * @covers ::get_archive_link
+	 */
+	public function test_get_archive_link_custom_archive() {
+		$link = self::$cpt_custom_archive->get_archive_link();
+		$this->assertSame( home_url( '/?post_type=cpt-custom-archive' ), $link );
+	}
+
+	/**
+	 * @covers ::get_archive_link
+	 */
+	public function test_get_archive_link_custom_archive_pretty_permalinks() {
+		$this->set_permalink_structure( '/%postname%/' );
+
+		self::$cpt_custom_archive->unregister_post_type();
+		self::$cpt_custom_archive = new DummyPostTypeWithCustomArchive();
+		self::$cpt_custom_archive->register();
+
+		$link = self::$cpt_custom_archive->get_archive_link();
+		$this->assertSame( home_url( '/custom-archive-slug/' ), $link );
+	}
+
+	/**
+	 * @covers ::get_default_archive_link
+	 */
+	public function test_get_default_archive_link_no_archive() {
+		$link = self::$cpt_no_archive->get_default_archive_link();
+		$this->assertSame( home_url( '?post_type=cpt-without-archive' ), $link );
+	}
+
+	/**
+	 * @covers ::get_default_archive_link
+	 */
+	public function test_get_default_archive_link_no_archive_pretty_permalinks() {
+		$this->set_permalink_structure( '/%postname%/' );
+
+		self::$cpt_no_archive->unregister_post_type();
+		self::$cpt_no_archive = new DummyPostTypeWithoutArchive();
+		self::$cpt_no_archive->register();
+
+		$link = self::$cpt_no_archive->get_default_archive_link();
+		$this->assertSame( home_url( '/cpt-without-archive/' ), $link );
+	}
+
+	/**
+	 * @covers ::get_default_archive_link
+	 */
+	public function test_get_default_archive_link_custom_archive() {
+		$link = self::$cpt_custom_archive->get_default_archive_link();
+		$this->assertSame( home_url( '?post_type=cpt-custom-archive' ), $link );
+	}
+	/**
+	 * @covers ::get_default_archive_link
+	 */
+	public function test_get_default_archive_link_custom_archive_pretty_permalinks() {
+		$this->set_permalink_structure( '/%postname%/' );
+
+		self::$cpt_custom_archive->unregister_post_type();
+		self::$cpt_custom_archive = new DummyPostTypeWithCustomArchive();
+		self::$cpt_custom_archive->register();
+
+		$link = self::$cpt_custom_archive->get_default_archive_link();
+		$this->assertSame( home_url( '/cpt-custom-archive/' ), $link );
+	}
+}


### PR DESCRIPTION
As per my feedback at https://github.com/GoogleForCreators/web-stories-wp/pull/10414#discussion_r796014224

This is what I had in mind.

Deliberately adds and accepts some code duplication by adding a separate `get_default_archive_link()` method for post types.