### PR TITLE
Fix Video Trimmer re-rendering when `currentTime` changes

### DIFF
--- a/packages/story-editor/src/components/videoTrim/currentTime.js
+++ b/packages/story-editor/src/components/videoTrim/currentTime.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+import { __ } from '@googleforcreators/i18n';
+
+/**
+ * Internal dependencies
+ */
+import Slider from './slider';
+import useVideoTrim from './useVideoTrim';
+
+const StyledSlider = styled(Slider)`
+  top: -3px;
+  bottom: -3px;
+  width: 6px;
+  margin-left: -3px;
+  border-radius: 6px;
+  border-width: 0;
+  background-color: ${({ theme }) => theme.colors.interactiveBg.primaryNormal};
+  box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3),
+    0px 1px 3px 1px rgba(60, 64, 67, 0.15);
+`;
+
+function CurrentTime(props) {
+  const currentTime = useVideoTrim(({ state: { currentTime } }) => currentTime);
+  return (
+    <StyledSlider
+      aria-label={__('Current time', 'web-stories')}
+      value={currentTime}
+      disabled
+      {...props}
+    />
+  );
+}
+
+export default CurrentTime;

--- a/packages/story-editor/src/components/videoTrim/trimmerComponents.js
+++ b/packages/story-editor/src/components/videoTrim/trimmerComponents.js
@@ -83,18 +83,6 @@ export const Handle = styled(Slider)`
   }
 `;
 
-export const CurrentTime = styled(Slider)`
-  top: -3px;
-  bottom: -3px;
-  width: 6px;
-  margin-left: -3px;
-  border-radius: 6px;
-  border-width: 0;
-  background-color: ${({ theme }) => theme.colors.interactiveBg.primaryNormal};
-  box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3),
-    0px 1px 3px 1px rgba(60, 64, 67, 0.15);
-`;
-
 const SVG = styled.svg`
   position: absolute;
   top: -1px;

--- a/packages/story-editor/src/components/videoTrim/videoTrimmer.js
+++ b/packages/story-editor/src/components/videoTrim/videoTrimmer.js
@@ -38,13 +38,13 @@ import useLayout from '../../app/layout/useLayout';
 import useFocusTrapping from '../../utils/useFocusTrapping';
 import useVideoTrim from './useVideoTrim';
 import useRailBackground from './useRailBackground';
+import CurrentTime from './currentTime';
 import {
   Menu,
   RailWrapper,
   Rail,
   Duration,
   Handle,
-  CurrentTime,
   Scrim,
   ButtonWrapper,
 } from './trimmerComponents';
@@ -53,7 +53,6 @@ const BUTTON_SPACE = 130;
 
 function VideoTrimmer() {
   const {
-    currentTime,
     startOffset,
     endOffset,
     maxOffset,
@@ -66,14 +65,7 @@ function VideoTrimmer() {
     videoData,
   } = useVideoTrim(
     ({
-      state: {
-        currentTime,
-        startOffset,
-        endOffset,
-        maxOffset,
-        hasChanged,
-        videoData,
-      },
+      state: { startOffset, endOffset, maxOffset, hasChanged, videoData },
       actions: {
         setStartOffset,
         setEndOffset,
@@ -82,7 +74,6 @@ function VideoTrimmer() {
         setIsDraggingHandles,
       },
     }) => ({
-      currentTime,
       startOffset,
       endOffset,
       maxOffset,
@@ -173,13 +164,7 @@ function VideoTrimmer() {
         >
           <Scrim isLeftAligned width={(startOffset / maxOffset) * railWidth} />
           <Scrim width={((maxOffset - endOffset) / maxOffset) * railWidth} />
-          <CurrentTime
-            railWidth={railWidth}
-            aria-label={__('Current time', 'web-stories')}
-            disabled
-            value={currentTime}
-            {...sliderProps}
-          />
+          <CurrentTime railWidth={railWidth} {...sliderProps} />
           <Handle
             railWidth={railWidth}
             value={startOffset}


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Moves getting `currentTime` to the new `CurrentTime` component to avoid re-rendering the whole `VideoTrimmer` constantly every second while the video is playing.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

- [x] Test that it actually works

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
N/A
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10243 
