### PR TITLE
Fix keyboard modifier for disabling drop-targeting

### DIFF
--- a/packages/story-editor/src/components/dropTargets/provider.js
+++ b/packages/story-editor/src/components/dropTargets/provider.js
@@ -205,8 +205,8 @@ function DropTargetsProvider({ children }) {
     [activeDropTargetId, combineElements, elements, dropTargets, pushTransform]
   );
 
-  // ⌘ key disables drop-targeting.
-  const isDropTargetingDisabled = useGlobalIsKeyPressed('meta');
+  // mod key (⌘ on macOS, Ctrl on Windows) disables drop-targeting.
+  const isDropTargetingDisabled = useGlobalIsKeyPressed('mod');
 
   const state = {
     state: {


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

It's currently not possible to disable drop-targeting / snapping on Windows using the Ctrl key, even though it's advertised as such in the help dialog.

## Summary

<!-- A brief description of what this PR does. -->

This PR changes the keyboard modifier so that the expected key for macOS is Cmd while for  Windows it's Ctrl.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

No visual changes

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Move element around while holding the <kbd>Ctrl</kbd> key on Windows (or <kbd>⌘</kbd> on macOS)
2. See that drop-targeting / snapping is disabled


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10491
