### PR TITLE
Add `type: module` to packages with CLI scripts

### DIFF
--- a/packages/fonts/package.json
+++ b/packages/fonts/package.json
@@ -26,6 +26,7 @@
     "node": ">= 16",
     "npm": ">= 7.3"
   },
+  "type": "module",
   "main": "dist/index.js",
   "module": "dist-module/index.js",
   "source": "src/index.js",

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -24,6 +24,7 @@
     "node": ">= 16",
     "npm": ">= 7.3"
   },
+  "type": "module",
   "main": "dist/index.js",
   "module": "dist-module/index.js",
   "source": "src/index.js",

--- a/packages/text-sets/package.json
+++ b/packages/text-sets/package.json
@@ -24,6 +24,7 @@
     "node": ">= 16",
     "npm": ">= 7.3"
   },
+  "type": "module",
   "main": "dist/index.js",
   "module": "dist-module/index.js",
   "source": "src/index.js",


### PR DESCRIPTION
Ensures that commands like `node packages/text-sets/scripts/cli.js` work again

Prevents failures like this: https://github.com/GoogleForCreators/web-stories-wp/runs/5092652859?check_suite_focus=true