### PR TITLE
Update PHP-Scoper to v0.16.2 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     "roave/security-advisories": "dev-latest",
     "sirbrillig/phpcs-variable-analysis": "^2.8",
     "slevomat/coding-standard": "^7.0.18",
+    "sniccowp/php-scoper-wordpress-excludes": "^5.9",
     "szepeviktor/phpstan-wordpress": "^1.0",
     "wp-coding-standards/wpcs": "^2.3",
     "yoast/wp-test-utils": "^1.0.0"
@@ -87,7 +88,7 @@
       "php-scoper": {
         "path": "vendor/bin/php-scoper",
         "type": "phar",
-        "url": "https://github.com/humbug/php-scoper/releases/download/0.15.0/php-scoper.phar"
+        "url": "https://github.com/humbug/php-scoper/releases/download/0.16.2/php-scoper.phar"
       }
     },
     "enable-patching": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "621ecd976d4596a8f0c67b12a5f08c6b",
+    "content-hash": "a3b314a5a1b11abaf5ad9d921d8ddf75",
     "packages": [
         {
             "name": "ampproject/amp-toolbox",
@@ -86,12 +86,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ampproject/amp-wp",
-                "reference": "93225e7623b28e934b735b665e15ab0df420868b"
+                "reference": "95c009ad45d07177d7f202f21a2c3b9e42679639"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ampproject/amp-wp/zipball/93225e7623b28e934b735b665e15ab0df420868b",
-                "reference": "93225e7623b28e934b735b665e15ab0df420868b",
+                "url": "https://api.github.com/repos/ampproject/amp-wp/zipball/95c009ad45d07177d7f202f21a2c3b9e42679639",
+                "reference": "95c009ad45d07177d7f202f21a2c3b9e42679639",
                 "shasum": ""
             },
             "require": {
@@ -194,7 +194,7 @@
             ],
             "description": "WordPress plugin for adding AMP support.",
             "homepage": "https://github.com/ampproject/amp-wp",
-            "time": "2022-02-05T01:19:40+00:00"
+            "time": "2022-02-08T18:56:56+00:00"
         },
         {
             "name": "civicrm/composer-downloads-plugin",
@@ -683,16 +683,16 @@
     "packages-dev": [
         {
             "name": "antecedent/patchwork",
-            "version": "2.1.19",
+            "version": "2.1.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/antecedent/patchwork.git",
-                "reference": "94fe587cb0a6c1695b1ddc650e877231be80b8bc"
+                "reference": "25c1fa0cd9a6e6d0d13863d8df8f050b6733f16d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/94fe587cb0a6c1695b1ddc650e877231be80b8bc",
-                "reference": "94fe587cb0a6c1695b1ddc650e877231be80b8bc",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/25c1fa0cd9a6e6d0d13863d8df8f050b6733f16d",
+                "reference": "25c1fa0cd9a6e6d0d13863d8df8f050b6733f16d",
                 "shasum": ""
             },
             "require": {
@@ -725,9 +725,9 @@
             ],
             "support": {
                 "issues": "https://github.com/antecedent/patchwork/issues",
-                "source": "https://github.com/antecedent/patchwork/tree/2.1.19"
+                "source": "https://github.com/antecedent/patchwork/tree/2.1.21"
             },
-            "time": "2022-01-20T04:47:04+00:00"
+            "time": "2022-02-07T07:28:34+00:00"
         },
         {
             "name": "automattic/vipwpcs",
@@ -813,12 +813,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Brain\\Monkey\\": "src/"
-                },
                 "files": [
                     "inc/api.php"
-                ]
+                ],
+                "psr-4": {
+                    "Brain\\Monkey\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1479,16 +1479,16 @@
         },
         {
             "name": "phar-io/version",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "bae7c545bef187884426f042434e561ab1ddb182"
+                "reference": "15a90844ad40f127afd244c0cad228de2a80052a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/bae7c545bef187884426f042434e561ab1ddb182",
-                "reference": "bae7c545bef187884426f042434e561ab1ddb182",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/15a90844ad40f127afd244c0cad228de2a80052a",
+                "reference": "15a90844ad40f127afd244c0cad228de2a80052a",
                 "shasum": ""
             },
             "require": {
@@ -1524,9 +1524,9 @@
             "description": "Library for handling version information and constraints",
             "support": {
                 "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/3.1.0"
+                "source": "https://github.com/phar-io/version/tree/3.1.1"
             },
-            "time": "2021-02-23T14:00:09+00:00"
+            "time": "2022-02-07T21:56:48+00:00"
         },
         {
             "name": "php-stubs/wordpress-stubs",
@@ -3997,6 +3997,52 @@
                 }
             ],
             "time": "2021-12-07T17:19:06+00:00"
+        },
+        {
+            "name": "sniccowp/php-scoper-wordpress-excludes",
+            "version": "5.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sniccowp/php-scoper-wordpress-excludes.git",
+                "reference": "36c2078e9ffaa5ea8c9752c3ec2b49587cf2a51c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sniccowp/php-scoper-wordpress-excludes/zipball/36c2078e9ffaa5ea8c9752c3ec2b49587cf2a51c",
+                "reference": "36c2078e9ffaa5ea8c9752c3ec2b49587cf2a51c",
+                "shasum": ""
+            },
+            "require-dev": {
+                "php": "^7.4",
+                "php-stubs/wordpress-stubs": "5.9.0",
+                "sniccowp/php-scoper-excludes": "dev-master"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Calvin Alkan",
+                    "email": "calvin@snicco.de"
+                },
+                {
+                    "name": "Marlon Alkan",
+                    "email": "marlon@snicco.de"
+                }
+            ],
+            "description": "A list of all WordPress core classes, functions and constants. Meant to be used with the PHP-Scoper exclusion functionality.",
+            "keywords": [
+                "php-scoper",
+                "scoping WordPress",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/sniccowp/php-scoper-wordpress-excludes/issues",
+                "source": "https://github.com/sniccowp/php-scoper-wordpress-excludes/tree/5.9.0"
+            },
+            "time": "2022-02-09T14:28:25+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -186,9 +186,10 @@ return [
 
 	'exclude-functions' => $wp_functions,
 	
-	// Note the hardcoded WP constants can be removed if a fix gets merged for
-	// currently exclude-wordpress-constants.json is empty []
-	// https://github.com/sniccowp/php-scoper-wordpress-excludes/issues/2
+	// Currently exclude-wordpress-constants.json is empty [].
+	// Issue https://github.com/sniccowp/php-scoper-wordpress-excludes/issues/2 .
+	// If fixed we can remove the hardcoded WP constants.
+	
 	'exclude-constants' => array_merge(
 		$wp_constants,
 		[

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -185,7 +185,10 @@ return [
 	'exclude-classes'   => $wp_classes,
 
 	'exclude-functions' => $wp_functions,
-
+	
+	// Note the hardcoded WP constants can be removed if a fix gets merged for
+	// currently exclude-wordpress-constants.json is empty []
+	// https://github.com/sniccowp/php-scoper-wordpress-excludes/issues/2
 	'exclude-constants' => array_merge(
 		$wp_constants,
 		[

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -10,11 +10,15 @@
 
 use Isolated\Symfony\Component\Finder\Finder;
 
+$wp_classes   = json_decode( file_get_contents( 'vendor/sniccowp/php-scoper-wordpress-excludes/generated/exclude-wordpress-classes.json' ) );
+$wp_functions = json_decode( file_get_contents( 'vendor/sniccowp/php-scoper-wordpress-excludes/generated/exclude-wordpress-functions.json' ) );
+$wp_constants = json_decode( file_get_contents( 'vendor/sniccowp/php-scoper-wordpress-excludes/generated/exclude-wordpress-constants.json' ) );
+
 return [
-	'prefix'                     => 'Google\\Web_Stories_Dependencies',
+	'prefix'            => 'Google\\Web_Stories_Dependencies',
 
 	// See: https://github.com/humbug/php-scoper#finders-and-paths.
-	'finders'                    => [
+	'finders'           => [
 		// Main AMP PHP Library.
 		Finder::create()
 			->files()
@@ -173,99 +177,34 @@ return [
 	],
 
 	// See: https://github.com/humbug/php-scoper#patchers.
-	'patchers'                   => [
-		function ( $file_path, $prefix, $contents ) {
-			/*
-			 * There is currently no easy way to simply whitelist all global WordPress functions.
-			 *
-			 * This list here is a manual attempt after scanning through the AMP plugin, which means
-			 * it needs to be maintained and kept in sync with any changes to the dependency.
-			 *
-			 * As long as there's no built-in solution in PHP-Scoper for this, an alternative could be
-			 * to generate a list based on php-stubs/wordpress-stubs. devowlio/wp-react-starter/ seems
-			 * to be doing just this successfully.
-			 *
-			 * @see https://github.com/humbug/php-scoper/issues/303
-			 * @see https://github.com/php-stubs/wordpress-stubs
-			 * @see https://github.com/devowlio/wp-react-starter/
-			 */
-			$contents = str_replace( "\\$prefix\\_doing_it_wrong", '\\_doing_it_wrong', $contents );
-			$contents = str_replace( "\\$prefix\\__", '\\__', $contents );
-			$contents = str_replace( "\\$prefix\\esc_html_e", '\\esc_html_e', $contents );
-			$contents = str_replace( "\\$prefix\\esc_html", '\\esc_html', $contents );
-			$contents = str_replace( "\\$prefix\\esc_attr", '\\esc_attr', $contents );
-			$contents = str_replace( "\\$prefix\\esc_url", '\\esc_url', $contents );
-			$contents = str_replace( "\\$prefix\\site_url", '\\site_url', $contents );
-			$contents = str_replace( "\\$prefix\\wp_guess_url", '\\wp_guess_url', $contents );
-			$contents = str_replace( "\\$prefix\\untrailingslashit", '\\untrailingslashit', $contents );
-			$contents = str_replace( "\\$prefix\\WP_CONTENT_URL", '\\WP_CONTENT_URL', $contents );
-			$contents = str_replace( "\\$prefix\\wp_list_pluck", '\\wp_list_pluck', $contents );
-			$contents = str_replace( "\\$prefix\\is_customize_preview", '\\is_customize_preview', $contents );
-			$contents = str_replace( "\\$prefix\\do_action", '\\do_action', $contents );
-			$contents = str_replace( "\\$prefix\\trailingslashit", '\\trailingslashit', $contents );
-			$contents = str_replace( "\\$prefix\\get_template_directory_uri", '\\get_template_directory_uri', $contents );
-			$contents = str_replace( "\\$prefix\\get_stylesheet_directory_uri", '\\get_stylesheet_directory_uri', $contents );
-			$contents = str_replace( "\\$prefix\\includes_url", '\\includes_url', $contents );
-			$contents = str_replace( "\\$prefix\\wp_styles", '\\wp_styles', $contents );
-			$contents = str_replace( "\\$prefix\\get_stylesheet", '\\get_stylesheet', $contents );
-			$contents = str_replace( "\\$prefix\\get_template", '\\get_template', $contents );
-			$contents = str_replace( "\\$prefix\\wp_parse_url", '\\wp_parse_url', $contents );
-			$contents = str_replace( "\\$prefix\\is_wp_error", '\\is_wp_error', $contents );
-			$contents = str_replace( "\\$prefix\\content_url", '\\content_url', $contents );
-			$contents = str_replace( "\\$prefix\\get_admin_url", '\\get_admin_url', $contents );
-			$contents = str_replace( "\\$prefix\\WP_CONTENT_DIR", '\\WP_CONTENT_DIR', $contents );
-			$contents = str_replace( "\\$prefix\\AMP__FILE__", '\\AMP__FILE__', $contents );
-			$contents = str_replace( "\\$prefix\\AMP__DIR__", '\\AMP__DIR__', $contents );
-			$contents = str_replace( "\\$prefix\\AMP__VERSION", '\\AMP__VERSION', $contents );
-			$contents = str_replace( "\\$prefix\\ABSPATH", '\\ABSPATH', $contents );
-			$contents = str_replace( "\\$prefix\\WPINC", '\\WPINC', $contents );
-			$contents = str_replace( "\\$prefix\\MINUTE_IN_SECONDS", '\\MINUTE_IN_SECONDS', $contents );
-			$contents = str_replace( "\\$prefix\\HOUR_IN_SECONDS", '\\HOUR_IN_SECONDS', $contents );
-			$contents = str_replace( "\\$prefix\\DAY_IN_SECONDS", '\\DAY_IN_SECONDS', $contents );
-			$contents = str_replace( "\\$prefix\\MONTH_IN_SECONDS", '\\MONTH_IN_SECONDS', $contents );
-			$contents = str_replace( "\\$prefix\\WP_DEBUG_DISPLAY", '\\WP_DEBUG_DISPLAY', $contents );
-			$contents = str_replace( "\\$prefix\\home_url", '\\home_url', $contents );
-			$contents = str_replace( "\\$prefix\\wp_array_slice_assoc", '\\wp_array_slice_assoc', $contents );
-			$contents = str_replace( "\\$prefix\\wp_json_encode", '\\wp_json_encode', $contents );
-			$contents = str_replace( "\\$prefix\\get_transient", '\\get_transient', $contents );
-			$contents = str_replace( "\\$prefix\\wp_cache_get", '\\wp_cache_get', $contents );
-			$contents = str_replace( "\\$prefix\\set_transient", '\\set_transient', $contents );
-			$contents = str_replace( "\\$prefix\\wp_cache_set", '\\wp_cache_set', $contents );
-			$contents = str_replace( "\\$prefix\\wp_using_ext_object_cache", '\\wp_using_ext_object_cache', $contents );
-			$contents = str_replace( "\\$prefix\\_doing_it_wrong", '\\_doing_it_wrong', $contents );
-			$contents = str_replace( "\\$prefix\\plugin_dir_url", '\\plugin_dir_url', $contents );
-			$contents = str_replace( "\\$prefix\\is_admin_bar_showing", '\\is_admin_bar_showing', $contents );
-			$contents = str_replace( "\\$prefix\\get_bloginfo", '\\get_bloginfo', $contents );
-			$contents = str_replace( "\\$prefix\\add_filter", '\\add_filter', $contents );
-			$contents = str_replace( "\\$prefix\\remove_filter", '\\remove_filter', $contents );
-			$contents = str_replace( "\\$prefix\\apply_filters", '\\apply_filters', $contents );
-			$contents = str_replace( "\\$prefix\\add_query_arg", '\\add_query_arg', $contents );
-			$contents = str_replace( "\\$prefix\\remove_query_arg", '\\remove_query_arg', $contents );
-			$contents = str_replace( "\\$prefix\\get_post", '\\get_post', $contents );
-			$contents = str_replace( "\\$prefix\\wp_scripts", '\\wp_scripts', $contents );
-			$contents = str_replace( "\\$prefix\\wp_style_is", '\\wp_style_is', $contents );
-			$contents = str_replace( "\\$prefix\\WPMU_PLUGIN_DIR", '\\WPMU_PLUGIN_DIR', $contents );
-			$contents = str_replace( "\\$prefix\\WP_PLUGIN_DIR", '\\WP_PLUGIN_DIR', $contents );
-			$contents = str_replace( "\\$prefix\\WP_PLUGIN_URL", '\\WP_PLUGIN_URL', $contents );
-			$contents = str_replace( "\\$prefix\\WPMU_PLUGIN_URL", '\\WPMU_PLUGIN_URL', $contents );
-			$contents = str_replace( "\\$prefix\\wp_array_slice_assoc", '\\wp_array_slice_assoc', $contents );
-			$contents = str_replace( "\\$prefix\\wp_json_encode", '\\wp_json_encode', $contents );
-			$contents = str_replace( "$prefix\\WP_Http", 'WP_Http', $contents );
-			$contents = str_replace( "$prefix\\WP_Error", 'WP_Error', $contents );
-
-			return $contents;
-		},
-	],
+	'patchers'          => [],
 
 	// See https://github.com/humbug/php-scoper#whitelist.
-	'whitelist'                  => [],
+	'whitelist'         => [],
 
-	// See https://github.com/humbug/php-scoper#constants--classes--functions-from-the-global-namespace.
-	'whitelist-global-constants' => false,
+	'exclude-classes'   => $wp_classes,
 
-	// See https://github.com/humbug/php-scoper#constants--classes--functions-from-the-global-namespace.
-	'whitelist-global-classes'   => false,
+	'exclude-functions' => $wp_functions,
 
-	// See https://github.com/humbug/php-scoper#constants--classes--functions-from-the-global-namespace.
-	'whitelist-global-functions' => false,
+	'exclude-constants' => array_merge(
+		$wp_constants,
+		[
+			'WP_CONTENT_DIR',
+			'WP_CONTENT_URL',
+			'ABSPATH',
+			'WPINC',
+			'WP_DEBUG_DISPLAY',
+			'WPMU_PLUGIN_DIR',
+			'WP_PLUGIN_DIR',
+			'WP_PLUGIN_URL',
+			'WPMU_PLUGIN_URL',
+			'AMP__FILE__',
+			'AMP__DIR__',
+			'AMP__VERSION',
+			'MINUTE_IN_SECONDS',
+			'HOUR_IN_SECONDS',
+			'DAY_IN_SECONDS',
+			'MONTH_IN_SECONDS',
+		]
+	),
 ];


### PR DESCRIPTION
## Context

Updates PHP-Scoper to 0.16.2 which allows us to clean up the config file

## Summary
Updates the PHP-Scoper version + config

- Removes "str_replace" calls in the config

## Relevant Technical Choices

- Pulls in `sniccwp/php-scoper-wordpress-excludes` which provides .json files for WP functions, classes to exclude


## User-facing changes

N/A

## Testing Instructions



<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

No outside of introduces a new package `sniccwp/php-scoper-wordpress-excludes`

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No new package is MIT License

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10407 
