### PR TITLE
Fix ad manager slot id regex

### DIFF
--- a/packages/wp-dashboard/src/components/editorSettings/utils/test/validateAdManagerSlotIdFormat.js
+++ b/packages/wp-dashboard/src/components/editorSettings/utils/test/validateAdManagerSlotIdFormat.js
@@ -30,7 +30,7 @@ const idsToValidate = [
   ['clearly wrong', false],
   ['/1234567,1234/Travel', true],
   ['/123456789/post.mobileamp/webstory', true],
-  ['/123456789/abc_123-.*/\\![:()', true],
+  ['/123456789/abc_123-.*/\\!<:()', true],
   [`/123456789/${one_hundred_chars}/${one_hundred_chars}`, true],
   [`/123456789/${one_hundred_chars}f/${one_hundred_chars}`, false],
   [`/123456789/${one_hundred_chars}/${one_hundred_chars}a`, false],

--- a/packages/wp-dashboard/src/components/editorSettings/utils/validateAdManagerSlotIdFormat.js
+++ b/packages/wp-dashboard/src/components/editorSettings/utils/validateAdManagerSlotIdFormat.js
@@ -18,7 +18,7 @@
 // Ad unit codes  (the "amp_story_dfp_example" part) can be up to 100 characters in length.
 // Only letters, numbers, underscores, hyphens, periods, asterisks, forward slashes, backslashes, exclamations, left angle brackets, colons and parentheses are allowed.
 const adManagerSlotIdFormatRegex =
-  /^\/\d+(,\d+)?(\/[\w\-.*/\\![:()]{1,99}[^/])*$/;
+  /^\/\d+(,\d+)?(\/[\w\d_\-.*\\!<:()]{1,99}[^/])*$/;
 
 export default function validateAdManagerSlotIdFormat(value = '') {
   return Boolean(value.toLowerCase().match(adManagerSlotIdFormatRegex));


### PR DESCRIPTION
LGTM warns about exponential backtracking with this regex.

See https://lgtm.com/projects/g/GoogleForCreators/web-stories-wp/snapshot/e1b824011ed9faf6dcac91a2be27eb6e78968189/files/packages/wp-dashboard/src/components/editorSettings/utils/validateAdManagerSlotIdFormat.js?sort=name&dir=ASC&mode=heatmap#x9e464c7d8e0b042f:1

Also noted that the regex+tests don't really match the description. Angle brackets are allowed, not square brackets. Numbers are allowed too.