### PR TITLE
Fix incompatibility with WPGraphQL

### DIFF
--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -195,16 +195,19 @@ class Settings extends Service_Base {
 			self::SETTING_GROUP,
 			self::SETTING_NAME_PUBLISHER_LOGOS,
 			[
-				'description'  => __( 'Publisher Logos', 'web-stories' ),
-				'type'         => 'array',
-				'default'      => [],
-				'show_in_rest' => [
+				'description'     => __( 'Publisher Logos', 'web-stories' ),
+				'type'            => 'array',
+				'default'         => [],
+				'show_in_rest'    => [
 					'schema' => [
 						'items' => [
 							'type' => 'integer',
 						],
 					],
 				],
+				// WPGraphQL errors when encountering array or object types.
+				// See https://github.com/wp-graphql/wp-graphql/issues/2065.
+				'show_in_graphql' => false,
 			]
 		);
 
@@ -250,14 +253,17 @@ class Settings extends Service_Base {
 			self::SETTING_GROUP_EXPERIMENTS,
 			self::SETTING_NAME_EXPERIMENTS,
 			[
-				'description'  => __( 'Experiments', 'web-stories' ),
-				'type'         => 'object',
-				'default'      => [],
-				'show_in_rest' => [
+				'description'     => __( 'Experiments', 'web-stories' ),
+				'type'            => 'object',
+				'default'         => [],
+				'show_in_rest'    => [
 					'schema' => [
 						'properties' => [],
 					],
 				],
+				// WPGraphQL errors when encountering array or object types.
+				// See https://github.com/wp-graphql/wp-graphql/issues/2065.
+				'show_in_graphql' => false,
 			]
 		);
 	}


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

See #10533 for context

## Summary

<!-- A brief description of what this PR does. -->

Hides certain settings from the GraphQL schema which WPGraphQL doesn't support yet.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

None

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Install both the Web Stories plugin and the WPGraphQL plugin
2. Visit the GraphiQL IDE and see that the schema is loading properly


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10533
