### PR TITLE
Design System: Bugfix for dropdown positioning regression in popup

### DIFF
--- a/packages/design-system/src/components/dropDown/index.js
+++ b/packages/design-system/src/components/dropDown/index.js
@@ -195,6 +195,7 @@ export const DropDown = forwardRef(
             refCallback={positionPlacement}
             fillWidth={popupFillWidth}
             zIndex={popupZIndex}
+            ignoreMaxOffsetY
           >
             {menu}
           </Popup>

--- a/packages/design-system/src/components/popup/index.js
+++ b/packages/design-system/src/components/popup/index.js
@@ -80,6 +80,7 @@ function Popup({
   topOffset = DEFAULT_TOPOFFSET,
   zIndex = DEFAULT_POPUP_Z_INDEX,
   noOverFlow = false,
+  ignoreMaxOffsetY,
 }) {
   const [popupState, setPopupState] = useState(null);
   const isMounted = useRef(false);
@@ -103,12 +104,21 @@ function Popup({
       }
       setPopupState({
         offset: anchor.current
-          ? getOffset(placement, spacing, anchor, dock, popup, isRTL, topOffset)
+          ? getOffset({
+              placement,
+              spacing,
+              anchor,
+              dock,
+              popup,
+              isRTL,
+              topOffset,
+              ignoreMaxOffsetY,
+            })
           : {},
         height: popup.current?.getBoundingClientRect()?.height,
       });
     },
-    [anchor, dock, isRTL, placement, spacing, topOffset]
+    [anchor, dock, isRTL, placement, spacing, topOffset, ignoreMaxOffsetY]
   );
   useEffect(() => {
     // If the popup height changes meanwhile, let's update the popup, too.
@@ -185,6 +195,7 @@ Popup.propTypes = {
   topOffset: PropTypes.number,
   zIndex: PropTypes.number,
   noOverFlow: PropTypes.bool,
+  ignoreMaxOffsetY: PropTypes.bool,
 };
 
 export { Popup, PLACEMENT };


### PR DESCRIPTION
## Context

Popups were deduplicated recently (#10089 ) - the offsets that were updated to respect the newer needs of the color picker overruled the initial fix for this positioning issue found here #6533. 

## Summary

Since our popup is a true renaissance component and is the foundation of sooo many different things, we need an escape hatch for when the view scrolls. Because this app is mostly a fixed height, it's rare that we need this update - only really on the dropdowns. 

## Relevant Technical Choices

- Add a new prop called `ignoreMaxOffsetY` to provide a popup option that respects page scroll. 
- Set to false by default, when present it will ignore the found `maxYOffset` in the popup positioning. 
- Useful when scroll will occur on an element. Only comes up in dashboard pages since editor is a fixed height. This is an updated version of the original fix that was overwritten - that fix is in #6533

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

| 😢  | 😄  |
| --- | --- | 
| <img width="1097" alt="Screenshot 2022-02-10 at 15 51 29" src="https://user-images.githubusercontent.com/10720454/153451853-24c4c886-7211-4c7f-b1b2-635dab1563e0.png"> | <img width="949" alt="Screen Shot 2022-02-10 at 9 30 11 AM" src="https://user-images.githubusercontent.com/10720454/153452162-3d8107ee-3573-4202-ac58-b5ea124703f9.png"> |



## Testing Instructions

- See that dropDowns are staying close to their affiliated select buttons (ie: Dashboard Settings, Editor animation selection, Editor authors) 
- See that popups used in editor still show up how they were meant to be - should see no impact on these (ie: links on canvas, color popup, three dot menus on media, tooltips) 
- And then check all of this again for RTL

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10538 
