### PR TITLE
Media: Do not trim all instances of video

### DIFF
--- a/packages/story-editor/src/app/media/utils/useMediaUploadQueue/index.js
+++ b/packages/story-editor/src/app/media/utils/useMediaUploadQueue/index.js
@@ -245,6 +245,8 @@ function useMediaUploadQueue() {
           return;
         }
 
+        delete trimData.elementId;
+
         additionalData.meta = {
           ...additionalData.meta,
           web_stories_trim_data: trimData,

--- a/packages/story-editor/src/app/media/utils/useMediaUploadQueue/index.js
+++ b/packages/story-editor/src/app/media/utils/useMediaUploadQueue/index.js
@@ -245,7 +245,7 @@ function useMediaUploadQueue() {
           return;
         }
 
-        delete trimData.elementId;
+        delete trimData.elementId; // remove transient ref to elementId
 
         additionalData.meta = {
           ...additionalData.meta,

--- a/packages/story-editor/src/app/media/utils/useProcessMedia.js
+++ b/packages/story-editor/src/app/media/utils/useProcessMedia.js
@@ -66,11 +66,11 @@ function useProcessMedia({
   );
 
   const copyResourceDataByElementId = useCallback(
-    ({ oldResource, resource }) => {
-      const { id, alt } = oldResource;
+    ({ elementId, oldResource, resource }) => {
+      const { alt } = oldResource;
 
       updateElementById({
-        elementId: id,
+        elementId,
         properties: () => {
           return {
             type: resource.type,
@@ -219,7 +219,7 @@ function useProcessMedia({
    * @param {string} end Time stamp of end time of new video. Example '00:02:00'.
    */
   const trimExistingVideo = useCallback(
-    ({ resource: oldResource, elementId, start, end }) => {
+    ({ resource: oldResource, canvasResourceId, elementId, start, end }) => {
       const { id: resourceId, ...oldResourceWithoutId } = oldResource;
       const { src: url, mimeType, poster, isMuted, isOptimized } = oldResource;
 
@@ -243,9 +243,10 @@ function useProcessMedia({
       const onUploadSuccess = ({ resource }) => {
         const oldCanvasResource = {
           alt: oldResource.alt,
-          id: elementId,
+          id: canvasResourceId,
         };
         copyResourceDataByElementId({
+          elementId,
           oldResource: oldCanvasResource,
           resource,
         });
@@ -253,7 +254,7 @@ function useProcessMedia({
       };
 
       const onUploadProgress = ({ resource }) => {
-        const newResourceWithCanvasId = { ...resource, id: elementId };
+        const newResourceWithCanvasId = { ...resource, id: canvasResourceId };
         updateExistingElement(elementId, {
           ...newResourceWithCanvasId,
         });
@@ -293,7 +294,7 @@ function useProcessMedia({
             ...oldResourceWithoutId,
             trimData,
           },
-          originalResourceId: elementId,
+          originalResourceId: canvasResourceId,
           posterFile,
         });
       };

--- a/packages/story-editor/src/app/media/utils/useProcessMedia.js
+++ b/packages/story-editor/src/app/media/utils/useProcessMedia.js
@@ -85,7 +85,7 @@ function useProcessMedia({
     [updateElementById]
   );
 
-  const updateExistingElement = useCallback(
+  const updateExistingElementById = useCallback(
     (elementId, resource) => {
       updateElementById({
         elementId,
@@ -102,7 +102,7 @@ function useProcessMedia({
     [updateElementById]
   );
 
-  const updateExistingElements = useCallback(
+  const updateExistingElementsByResourceId = useCallback(
     (resourceId, resource) => {
       updateElementsByResourceId({
         id: resourceId,
@@ -152,7 +152,7 @@ function useProcessMedia({
       const { id: resourceId, src: url, mimeType } = oldResource;
 
       const onUploadError = () =>
-        updateExistingElements(resourceId, {
+        updateExistingElementsByResourceId(resourceId, {
           isOptimized: false,
         });
 
@@ -166,7 +166,7 @@ function useProcessMedia({
       // TODO: Confirm which properties exactly need to be updated.
       const onUploadProgress = ({ resource }) => {
         const oldResourceWithId = { ...resource, id: oldResource.id };
-        updateExistingElements(resourceId, {
+        updateExistingElementsByResourceId(resourceId, {
           ...oldResourceWithId,
         });
       };
@@ -176,7 +176,7 @@ function useProcessMedia({
 
         // This video was optimized before, no need to optimize it again.
         if (optimizedResource) {
-          updateExistingElements(resourceId, optimizedResource);
+          updateExistingElementsByResourceId(resourceId, optimizedResource);
           return;
         }
 
@@ -201,7 +201,7 @@ function useProcessMedia({
       })();
     },
     [
-      updateExistingElements,
+      updateExistingElementsByResourceId,
       copyResourceData,
       updateOldTranscodedObject,
       deleteMediaElement,
@@ -231,12 +231,12 @@ function useProcessMedia({
       };
 
       const onUploadStart = () =>
-        updateExistingElement(elementId, {
+        updateExistingElementById(elementId, {
           trimData,
         });
 
       const onUploadError = () =>
-        updateExistingElement(elementId, {
+        updateExistingElementById(elementId, {
           trimData: oldResource.trimData || {},
         });
 
@@ -255,7 +255,7 @@ function useProcessMedia({
 
       const onUploadProgress = ({ resource }) => {
         const newResourceWithCanvasId = { ...resource, id: canvasResourceId };
-        updateExistingElement(elementId, {
+        updateExistingElementById(elementId, {
           ...newResourceWithCanvasId,
         });
       };
@@ -301,7 +301,7 @@ function useProcessMedia({
       return process();
     },
     [
-      updateExistingElement,
+      updateExistingElementById,
       copyResourceDataByElementId,
       postProcessingResource,
       uploadMedia,
@@ -319,7 +319,7 @@ function useProcessMedia({
       const { src: url, mimeType, poster, isOptimized } = oldResource;
 
       const onUploadError = () => {
-        updateExistingElements(resourceId, {
+        updateExistingElementsByResourceId(resourceId, {
           isMuted: false,
         });
       };
@@ -333,7 +333,7 @@ function useProcessMedia({
       // TODO: Confirm which properties exactly need to be updated.
       const onUploadProgress = ({ resource }) => {
         const oldResourceWithId = { ...resource, id: oldResource.id };
-        updateExistingElements(resourceId, {
+        updateExistingElementsByResourceId(resourceId, {
           ...oldResourceWithId,
         });
       };
@@ -343,7 +343,7 @@ function useProcessMedia({
 
         // This video was muted before, no need to mute it again.
         if (mutedResource) {
-          updateExistingElements(resourceId, mutedResource);
+          updateExistingElementsByResourceId(resourceId, mutedResource);
           return;
         }
 
@@ -384,7 +384,7 @@ function useProcessMedia({
       })();
     },
     [
-      updateExistingElements,
+      updateExistingElementsByResourceId,
       copyResourceData,
       updateOldMutedObject,
       postProcessingResource,
@@ -412,7 +412,7 @@ function useProcessMedia({
       // TODO: Confirm which properties exactly need to be updated.
       const onUploadProgress = ({ resource }) => {
         const oldResourceWithId = { ...resource, id: oldResource.id };
-        updateExistingElements(resourceId, {
+        updateExistingElementsByResourceId(resourceId, {
           ...oldResourceWithId,
         });
       };
@@ -447,7 +447,7 @@ function useProcessMedia({
       updateOldTranscodedObject,
       deleteMediaElement,
       postProcessingResource,
-      updateExistingElements,
+      updateExistingElementsByResourceId,
       uploadMedia,
     ]
   );

--- a/packages/story-editor/src/components/videoTrim/provider.js
+++ b/packages/story-editor/src/components/videoTrim/provider.js
@@ -56,6 +56,7 @@ function VideoTrimProvider({ children }) {
       return;
     }
     const lengthInSeconds = Math.round(endOffset / 1000 - startOffset / 1000);
+
     trimExistingVideo({
       resource: {
         ...resource,
@@ -63,8 +64,7 @@ function VideoTrimProvider({ children }) {
         lengthFormatted: getVideoLengthDisplay(lengthInSeconds),
       },
       // This is the ID of the resource that's currently on canvas and needs to be cloned.
-      // It's only different from the above resource, if the canvas resource is a trim of the other.
-      canvasResourceId: element.resource.id,
+      elementId: element.id,
       start: formatMsToHMS(startOffset),
       end: formatMsToHMS(endOffset),
     });

--- a/packages/story-editor/src/components/videoTrim/provider.js
+++ b/packages/story-editor/src/components/videoTrim/provider.js
@@ -63,6 +63,8 @@ function VideoTrimProvider({ children }) {
         lengthFormatted: getVideoLengthDisplay(lengthInSeconds),
       },
       // This is the ID of the resource that's currently on canvas and needs to be cloned.
+      // It's only different from the above resource, if the canvas resource is a trim of the other.
+      canvasResourceId: element.resource.id,
       elementId: element.id,
       start: formatMsToHMS(startOffset),
       end: formatMsToHMS(endOffset),

--- a/packages/story-editor/src/components/videoTrim/provider.js
+++ b/packages/story-editor/src/components/videoTrim/provider.js
@@ -56,7 +56,6 @@ function VideoTrimProvider({ children }) {
       return;
     }
     const lengthInSeconds = Math.round(endOffset / 1000 - startOffset / 1000);
-
     trimExistingVideo({
       resource: {
         ...resource,


### PR DESCRIPTION
## Context

When trimming a video within a story, currently all instances of that video within the story are being trimmed.

See: https://github.com/GoogleForCreators/web-stories-wp/issues/10409


## Summary

The existing code uses `canvasResourceId` & `updateExistingElements(canvasResourceId,  ...)` to updating existing elements.

See: https://github.com/GoogleForCreators/web-stories-wp/pull/10554/files#diff-284f5d5d8d1215d90a8fa6d991491806595892db0619411fbbea3b629868d366R66

When adding multiple copies of the same video element the canvasResourceId ends up getting duplicated "not unique"

When calling updateExistingElements with the canvasResourceId --- any elements with that ID will get updated

| Element # 1  |      Element # 2     | 
|----------|:-------------:|
| <img width="1084" alt="153723757-df3bedd4-41c8-4a58-85b5-11a834e552c2" src="https://user-images.githubusercontent.com/62242/154361412-cf86da1d-714a-4146-af9f-0977b4c6dfcc.png"> |  <img width="1127" alt="153723775-d4c56683-ea13-47d7-b8f3-a2788db846e7" src="https://user-images.githubusercontent.com/62242/154361552-573e627a-d689-4596-a01c-cad9bbf71170.png"> |


## Relevant Technical Choices

This PR updates the trimming functions to update existing elements by element ID (which should be unique).


## To-do

Write tests as needed

## User-facing changes

Bug fix for existing trim functionality 

## Testing Instructions


This PR can be tested by following these steps:
1) Drag video from media library to a page
2)  Drag the same video from media library to a page (same page or new one)
3) Trim first video
4) Observe that only the item that selected to be trimmed was updated

## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR



Fixes #10409
