### PR TITLE
Remove `MockMoveable` export from `moveable`  package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41795,7 +41795,8 @@
         "jest-axe": "^5.0.1",
         "jest-matcher-deep-close-to": "^3.0.2",
         "mockdate": "^3.0.5",
-        "react": "^17.0.2"
+        "react": "^17.0.2",
+        "react-moveable": "^0.30.3"
       },
       "engines": {
         "node": ">= 12 || >= 14 || >= 16",
@@ -44282,6 +44283,7 @@
         "react-blurhash": "^0.1.3",
         "react-calendar": "^3.6.0",
         "react-color": "^2.19.3",
+        "react-moveable": "^0.30.3",
         "react-photo-gallery": "^8.0.0",
         "react-transition-group": "^4.4.2",
         "react-virtual": "^2.10.4",

--- a/packages/moveable/src/index.js
+++ b/packages/moveable/src/index.js
@@ -16,11 +16,7 @@
 /**
  * External dependencies
  */
-//eslint-disable-next-line import/named
-import { MockMoveable } from 'react-moveable';
-
 export { default as Moveable } from './moveable.js';
-export { MockMoveable };
 export { GlobalStyle as CropMoveableGlobalStyle } from './cropStyle';
 export { GlobalStyle as DefaultMoveableGlobalStyle } from './moveStyle';
 export { default as InOverlay } from './overlay';

--- a/packages/story-editor/package.json
+++ b/packages/story-editor/package.json
@@ -86,6 +86,7 @@
     "jest-axe": "^5.0.1",
     "jest-matcher-deep-close-to": "^3.0.2",
     "mockdate": "^3.0.5",
-    "react": "^17.0.2"
+    "react": "^17.0.2",
+    "react-moveable": "^0.30.3"
   }
 }

--- a/packages/story-editor/src/components/canvas/test/multiSelectionMoveable.js
+++ b/packages/story-editor/src/components/canvas/test/multiSelectionMoveable.js
@@ -18,7 +18,8 @@
  * External dependencies
  */
 import { render, act, waitFor } from '@testing-library/react';
-import { MockMoveable, withOverlay } from '@googleforcreators/moveable';
+import { withOverlay } from '@googleforcreators/moveable';
+import { MockMoveable } from 'react-moveable'; // eslint-disable-line import/named
 import PropTypes from 'prop-types';
 import { forwardRef } from '@googleforcreators/react';
 import { UnitsProvider } from '@googleforcreators/units';

--- a/packages/story-editor/src/components/canvas/test/multiSelectionMoveable.js
+++ b/packages/story-editor/src/components/canvas/test/multiSelectionMoveable.js
@@ -19,7 +19,7 @@
  */
 import { render, act, waitFor } from '@testing-library/react';
 import { withOverlay } from '@googleforcreators/moveable';
-import { MockMoveable } from 'react-moveable'; // eslint-disable-line import/named
+import { MockMoveable } from 'react-moveable'; // eslint-disable-line import/named -- This is a custom Jest mock
 import PropTypes from 'prop-types';
 import { forwardRef } from '@googleforcreators/react';
 import { UnitsProvider } from '@googleforcreators/units';

--- a/packages/story-editor/src/components/canvas/test/singleSelectionMoveable.js
+++ b/packages/story-editor/src/components/canvas/test/singleSelectionMoveable.js
@@ -17,7 +17,8 @@
  * External dependencies
  */
 import { render, act, waitFor } from '@testing-library/react';
-import { MockMoveable, withOverlay } from '@googleforcreators/moveable';
+import { withOverlay } from '@googleforcreators/moveable';
+import { MockMoveable } from 'react-moveable'; // eslint-disable-line import/named
 import PropTypes from 'prop-types';
 import { forwardRef } from '@googleforcreators/react';
 import { UnitsProvider } from '@googleforcreators/units';

--- a/packages/story-editor/src/components/canvas/test/singleSelectionMoveable.js
+++ b/packages/story-editor/src/components/canvas/test/singleSelectionMoveable.js
@@ -18,7 +18,7 @@
  */
 import { render, act, waitFor } from '@testing-library/react';
 import { withOverlay } from '@googleforcreators/moveable';
-import { MockMoveable } from 'react-moveable'; // eslint-disable-line import/named
+import { MockMoveable } from 'react-moveable'; // eslint-disable-line import/named -- This is a custom Jest mock
 import PropTypes from 'prop-types';
 import { forwardRef } from '@googleforcreators/react';
 import { UnitsProvider } from '@googleforcreators/units';


### PR DESCRIPTION
## Context

`MockMoveable` from `react-moveable`  was being exported from `moveable` package for the unit test which is not available in `react-moveable` however is being mocked here https://github.com/GoogleForCreators/web-stories-wp/blob/main/__mocks__/react-moveable.js

## Summary

Remove `MockMoveable` export from `moveable` package and make `react-moveable` dev dependency of `story-editor` as its only being used to for test.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes https://github.com/GoogleForCreators/web-stories-wp/issues/10536
