### PR TITLE
E2E Tests: Use different demo story in tests

### DIFF
--- a/packages/e2e-tests/src/specs/wordpress/blockWidget.js
+++ b/packages/e2e-tests/src/specs/wordpress/blockWidget.js
@@ -55,7 +55,7 @@ describe('Web Stories Widget Block', () => {
 
     await page.type(
       'input[aria-label="Story URL"]',
-      'https://preview.amp.dev/documentation/examples/introduction/stories_in_amp'
+      'https://wp.stories.google/stories/intro-to-web-stories-storytime'
     );
     await expect(page).toClick('button[aria-label="Embed"]');
 

--- a/packages/e2e-tests/src/specs/wordpress/webStoriesBlock.js
+++ b/packages/e2e-tests/src/specs/wordpress/webStoriesBlock.js
@@ -34,8 +34,8 @@ import {
 import { addAllowedErrorMessage } from '../../config/bootstrap';
 
 const EMBED_BLOCK_CONTENT = `
-<!-- wp:web-stories/embed {"url":"https://preview.amp.dev/documentation/examples/introduction/stories_in_amp","title":"Stories in AMP - Hello World","poster":"https://amp.dev/static/samples/img/story_dog2_portrait.jpg"} -->
-<div class="wp-block-web-stories-embed alignnone"><amp-story-player style="width:360px;height:600px" data-testid="amp-story-player"><a href="https://preview.amp.dev/documentation/examples/introduction/stories_in_amp" style="--story-player-poster:url('https://amp.dev/static/samples/img/story_dog2_portrait.jpg')">Stories in AMP - Hello World</a></amp-story-player></div>
+<!-- wp:web-stories/embed {"url":"https://wp.stories.google/stories/intro-to-web-stories-storytime","title":"Stories in AMP - Hello World","poster":"https://amp.dev/static/samples/img/story_dog2_portrait.jpg"} -->
+<div class="wp-block-web-stories-embed alignnone"><amp-story-player style="width:360px;height:600px" data-testid="amp-story-player"><a href="https://wp.stories.google/stories/intro-to-web-stories-storytime" style="--story-player-poster:url('https://amp.dev/static/samples/img/story_dog2_portrait.jpg')">Stories in AMP - Hello World</a></amp-story-player></div>
 <!-- /wp:web-stories/embed -->
 `;
 
@@ -94,7 +94,7 @@ describe('Web Stories Block', () => {
 
     await page.type(
       'input[aria-label="Story URL"]',
-      'https://preview.amp.dev/documentation/examples/introduction/stories_in_amp'
+      'https://wp.stories.google/stories/intro-to-web-stories-storytime'
     );
     await expect(page).toClick('button[aria-label="Embed"]');
 

--- a/packages/stories-block/src/block/block-types/single-story/test/embedPreview.js
+++ b/packages/stories-block/src/block/block-types/single-story/test/embedPreview.js
@@ -24,8 +24,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
  */
 import EmbedPreview from '../embedPreview';
 
-const url =
-  'https://preview.amp.dev/documentation/examples/introduction/stories_in_amp';
+const url = 'https://wp.stories.google/stories/intro-to-web-stories-storytime';
 const title = 'Stories in AMP';
 
 jest.mock('../storyPlayer', () => {

--- a/packages/stories-block/src/block/block-types/single-story/test/storyPlayer.js
+++ b/packages/stories-block/src/block/block-types/single-story/test/storyPlayer.js
@@ -24,8 +24,7 @@ import { render } from '@testing-library/react';
  */
 import StoryPlayer from '../storyPlayer';
 
-const url =
-  'https://preview.amp.dev/documentation/examples/introduction/stories_in_amp';
+const url = 'https://wp.stories.google/stories/intro-to-web-stories-storytime';
 const title = 'Stories in AMP';
 const poster = 'https://amp.dev/static/samples/img/story_dog2_portrait.jpg';
 
@@ -39,7 +38,7 @@ describe('StoryPlayer', () => {
         data-testid="amp-story-player"
       >
         <a
-          href="https://preview.amp.dev/documentation/examples/introduction/stories_in_amp"
+          href="https://wp.stories.google/stories/intro-to-web-stories-storytime"
         >
           Stories in AMP
         </a>
@@ -58,7 +57,7 @@ describe('StoryPlayer', () => {
         data-testid="amp-story-player"
       >
         <a
-          href="https://preview.amp.dev/documentation/examples/introduction/stories_in_amp"
+          href="https://wp.stories.google/stories/intro-to-web-stories-storytime"
         >
           <img
             alt="Stories in AMP"

--- a/packages/stories-block/src/block/test/save.js
+++ b/packages/stories-block/src/block/test/save.js
@@ -24,8 +24,7 @@ import { render } from '@testing-library/react';
  */
 import Save from '../save';
 
-const url =
-  'https://preview.amp.dev/documentation/examples/introduction/stories_in_amp';
+const url = 'https://wp.stories.google/stories/intro-to-web-stories-storytime';
 const title = 'Stories in AMP';
 const poster = 'https://amp.dev/static/samples/img/story_dog2_portrait.jpg';
 
@@ -39,7 +38,7 @@ describe('save', () => {
         class="wp-block-web-stories-embed alignnone"
       >
         <a
-          href="https://preview.amp.dev/documentation/examples/introduction/stories_in_amp"
+          href="https://wp.stories.google/stories/intro-to-web-stories-storytime"
         >
           <img
             alt="Stories in AMP"
@@ -57,7 +56,7 @@ describe('save', () => {
         class="wp-block-web-stories-embed alignnone"
       >
         <a
-          href="https://preview.amp.dev/documentation/examples/introduction/stories_in_amp"
+          href="https://wp.stories.google/stories/intro-to-web-stories-storytime"
         >
           Stories in AMP
         </a>


### PR DESCRIPTION
## Context

Fixes E2E tests given the current default story is broken

See https://github.com/GoogleForCreators/web-stories-wp/issues/10553#issue-1133945008

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Update to use `https://wp.stories.google/stories/intro-to-web-stories-storytime/ ` as the default Web Story for E2E tests

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10553