### PR TITLE
Add default WP version for E2E tests

### DIFF
--- a/packages/e2e-test-utils/src/minWPVersionRequired.js
+++ b/packages/e2e-test-utils/src/minWPVersionRequired.js
@@ -25,7 +25,7 @@ import checkVersion from './checkVersion';
  * @param {string} minVersion Minimum require WordPress version.
  */
 function minWPVersionRequired(minVersion) {
-  const WPVersion = process.env?.WP_VERSION;
+  const WPVersion = process.env?.WP_VERSION || 'latest';
   if ('latest' !== WPVersion && !checkVersion(WPVersion, minVersion)) {
     //eslint-disable-next-line jest/no-focused-tests
     test.only('minimum WordPress requirement not met', () => {});


### PR DESCRIPTION
## Context

When running End to End test without a WP version set in the .env file the test can break

i.e.

```
TypeError: Cannot read properties of undefined (reading 'split')
      16 |
      17 | function checkVersion(a, b) {
    > 18 |   const x = a.split('.').map((e) => parseInt(e));
         |               ^
      19 |   const y = b.split('.').map((e) => parseInt(e));
      20 |
```


## Summary

This will default the WP version to WP Latest

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
