### PR TITLE
Status Panel: make options a Dropdown

### DIFF
--- a/packages/design-system/src/components/dropDown/components.js
+++ b/packages/design-system/src/components/dropDown/components.js
@@ -23,6 +23,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { Text } from '../typography';
+import { THEME_CONSTANTS } from '../../theme';
 
 export const DropDownContainer = styled.div`
   display: flex;
@@ -30,7 +31,9 @@ export const DropDownContainer = styled.div`
   width: 100%;
 `;
 
-export const Hint = styled(Text)`
+export const Hint = styled(Text).attrs({
+  size: THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL,
+})`
   margin-top: 12px;
   padding-left: 2px;
   color: ${({ theme, hasError }) =>

--- a/packages/design-system/src/components/dropDown/index.js
+++ b/packages/design-system/src/components/dropDown/index.js
@@ -31,7 +31,6 @@ import { __, sprintf } from '@googleforcreators/i18n';
 /**
  * Internal dependencies
  */
-import { THEME_CONSTANTS } from '../../theme';
 import { Menu, MENU_OPTIONS } from '../menu';
 import { Popup, PLACEMENT } from '../popup';
 import { DropDownContainer, Hint } from './components';
@@ -200,14 +199,7 @@ export const DropDown = forwardRef(
             {menu}
           </Popup>
         )}
-        {hint && (
-          <Hint
-            hasError={hasError}
-            size={THEME_CONSTANTS.TYPOGRAPHY.TEXT_SIZES.SMALL}
-          >
-            {hint}
-          </Hint>
-        )}
+        {hint && <Hint hasError={hasError}>{hint}</Hint>}
       </DropDownContainer>
     );
   }

--- a/packages/e2e-tests/src/specs/editor/contributorUser.js
+++ b/packages/e2e-tests/src/specs/editor/contributorUser.js
@@ -36,8 +36,10 @@ describe('Contributor User', () => {
     await expect(page).toClick('li[role="tab"]', { text: 'Document' });
 
     await expect(page).toMatchElement('button', { text: 'Public' });
-    await expect(page).not.toMatchElement('option', { text: 'Private' });
-    await expect(page).not.toMatchElement('option', {
+    await expect(page).not.toMatchElement('li[role="option"]', {
+      text: 'Private',
+    });
+    await expect(page).not.toMatchElement('li[role="option"]', {
       text: 'Password Protected',
     });
   });

--- a/packages/e2e-tests/src/specs/editor/contributorUser.js
+++ b/packages/e2e-tests/src/specs/editor/contributorUser.js
@@ -35,9 +35,9 @@ describe('Contributor User', () => {
 
     await expect(page).toClick('li[role="tab"]', { text: 'Document' });
 
-    await expect(page).toMatchElement('label', { text: 'Public' });
-    await expect(page).not.toMatchElement('label', { text: 'Private' });
-    await expect(page).not.toMatchElement('label', {
+    await expect(page).toMatchElement('button', { text: 'Public' });
+    await expect(page).not.toMatchElement('option', { text: 'Private' });
+    await expect(page).not.toMatchElement('option', {
       text: 'Password Protected',
     });
   });

--- a/packages/e2e-tests/src/specs/editor/passwordProtected.js
+++ b/packages/e2e-tests/src/specs/editor/passwordProtected.js
@@ -32,7 +32,8 @@ describe('Password protected stories', () => {
     await addTextElement();
 
     await expect(page).toClick('li[role="tab"]', { text: 'Document' });
-    await expect(page).toClick('label', { text: 'Password Protected' });
+    await expect(page).toClick('button', { text: 'Public' });
+    await expect(page).toClick('option', { text: 'Password Protected' });
 
     await expect(page).toMatchElement('input[placeholder="Enter a password"]');
     await page.type('input[placeholder="Enter a password"]', 'password');

--- a/packages/e2e-tests/src/specs/editor/passwordProtected.js
+++ b/packages/e2e-tests/src/specs/editor/passwordProtected.js
@@ -33,7 +33,9 @@ describe('Password protected stories', () => {
 
     await expect(page).toClick('li[role="tab"]', { text: 'Document' });
     await expect(page).toClick('button', { text: 'Public' });
-    await expect(page).toClick('option', { name: 'Password Protected' });
+    await expect(page).toClick('li[role="option"]', {
+      text: 'Password Protected',
+    });
 
     await expect(page).toMatchElement('input[placeholder="Enter a password"]');
     await page.type('input[placeholder="Enter a password"]', 'password');

--- a/packages/e2e-tests/src/specs/editor/passwordProtected.js
+++ b/packages/e2e-tests/src/specs/editor/passwordProtected.js
@@ -33,7 +33,7 @@ describe('Password protected stories', () => {
 
     await expect(page).toClick('li[role="tab"]', { text: 'Document' });
     await expect(page).toClick('button', { text: 'Public' });
-    await expect(page).toClick('option', { text: 'Password Protected' });
+    await expect(page).toClick('option', { name: 'Password Protected' });
 
     await expect(page).toMatchElement('input[placeholder="Enter a password"]');
     await page.type('input[placeholder="Enter a password"]', 'password');

--- a/packages/wp-story-editor/src/components/documentPane/index.js
+++ b/packages/wp-story-editor/src/components/documentPane/index.js
@@ -23,6 +23,7 @@ import {
   BackgroundAudioPanel,
   TaxonomiesPanel,
 } from '@googleforcreators/story-editor';
+import styled from 'styled-components';
 
 /**
  * Internal dependencies
@@ -60,9 +61,14 @@ export function PublishModalDocumentPane() {
 // Isolated Status Panel should not collapse and
 // should have its own name to prevent collapse
 // based on other implementations that have default name
+
+const IsolatedPanel = styled(StatusPanel)`
+  padding: 0;
+`;
+
 export function IsolatedStatusPanel() {
   return (
-    <StatusPanel
+    <IsolatedPanel
       nameOverride="storyDetailsStatus"
       canCollapse={false}
       isPersistable={false}

--- a/packages/wp-story-editor/src/components/documentPane/index.js
+++ b/packages/wp-story-editor/src/components/documentPane/index.js
@@ -66,6 +66,7 @@ export function IsolatedStatusPanel() {
       nameOverride="storyDetailsStatus"
       canCollapse={false}
       isPersistable={false}
+      popupZIndex={11}
     />
   );
 }

--- a/packages/wp-story-editor/src/components/documentPane/status/status.js
+++ b/packages/wp-story-editor/src/components/documentPane/status/status.js
@@ -32,6 +32,11 @@ import {
   useIsUploadingToStory,
 } from '@googleforcreators/story-editor';
 
+/**
+ * Internal dependencies
+ */
+import { VISIBILITY, STATUS } from '../../../constants';
+
 function StatusPanel({
   nameOverride,
   popupZIndex,
@@ -83,26 +88,26 @@ function StatusPanel({
   useEffect(() => {
     if (password) {
       updateStory({
-        properties: { visibility: 'protected' },
+        properties: { visibility: VISIBILITY.PASSWORD_PROTECTED },
       });
       return;
     }
 
-    if (status === 'private') {
+    if (status === STATUS.PRIVATE) {
       updateStory({
-        properties: { visibility: 'private' },
+        properties: { visibility: VISIBILITY.PRIVATE },
       });
       return;
     }
 
     updateStory({
-      properties: { visibility: 'public' },
+      properties: { visibility: VISIBILITY.PUBLIC },
     });
   }, [password, status, updateStory]);
 
   const visibilityOptions = [
     {
-      value: 'public',
+      value: VISIBILITY.PUBLIC,
       label: __('Public', 'web-stories'),
       helper: __('Visible to everyone', 'web-stories'),
     },
@@ -110,13 +115,13 @@ function StatusPanel({
 
   if (capabilities?.publish) {
     visibilityOptions.push({
-      value: 'private',
+      value: VISIBILITY.PRIVATE,
       label: __('Private', 'web-stories'),
       helper: __('Visible to site admins & editors only', 'web-stories'),
-      disabled: isUploading && visibility !== 'private',
+      disabled: isUploading && visibility !== VISIBILITY.PRIVATE,
     });
     visibilityOptions.push({
-      value: 'protected',
+      value: VISIBILITY.PASSWORD_PROTECTED,
       label: __('Password Protected', 'web-stories'),
       helper: __('Visible only to those with the password.', 'web-stories'),
     });
@@ -135,13 +140,13 @@ function StatusPanel({
 
   const publishPrivately = useCallback(() => {
     const properties = {
-      status: 'private',
+      status: STATUS.PRIVATE,
       password: '',
-      visibility: 'private',
+      visibility: VISIBILITY.PRIVATE,
     };
 
     trackEvent('publish_story', {
-      status: 'private',
+      status: STATUS.PRIVATE,
       title_length: title.length,
     });
     refreshPostEditURL();
@@ -149,13 +154,17 @@ function StatusPanel({
     saveStory(properties);
   }, [title.length, refreshPostEditURL, saveStory]);
 
-  const isAlreadyPublished = ['publish', 'future', 'private'].includes(status);
+  const isAlreadyPublished = [
+    STATUS.PUBLISH,
+    STATUS.FUTURE,
+    STATUS.PRIVATE,
+  ].includes(status);
 
   const handleChangeVisibility = useCallback(
     (_, value) => {
       const newVisibility = value;
 
-      if ('private' === newVisibility && !isAlreadyPublished) {
+      if (VISIBILITY.PRIVATE === newVisibility && !isAlreadyPublished) {
         if (
           !window.confirm(
             __(
@@ -171,25 +180,27 @@ function StatusPanel({
       const properties = {};
 
       switch (newVisibility) {
-        case 'public':
-          properties.status = visibility === 'private' ? 'draft' : status;
+        case VISIBILITY.PUBLIC:
+          properties.status =
+            visibility === VISIBILITY.PRIVATE ? STATUS.DRAFT : status;
           properties.password = '';
-          properties.visibility = 'public';
+          properties.visibility = VISIBILITY.PUBLIC;
           break;
 
-        case 'private':
+        case VISIBILITY.PRIVATE:
           if (shouldReviewDialogBeSeen && !isAlreadyPublished) {
             setShowReviewDialog(true);
-            properties.visibility = 'private';
+            properties.visibility = VISIBILITY.PRIVATE;
           } else {
             publishPrivately();
           }
           return;
 
-        case 'protected':
-          properties.status = visibility === 'private' ? 'draft' : status;
+        case VISIBILITY.PASSWORD_PROTECTED:
+          properties.status =
+            visibility === VISIBILITY.PRIVATE ? STATUS.DRAFT : status;
           properties.password = password || '';
-          properties.visibility = 'protected';
+          properties.visibility = VISIBILITY.PASSWORD_PROTECTED;
           break;
 
         default:
@@ -233,7 +244,7 @@ function StatusPanel({
               disabled={visibilityOptions.length <= 1}
             />
           </Row>
-          {visibility === 'protected' && (
+          {visibility === VISIBILITY.PASSWORD_PROTECTED && (
             <Row>
               <Input
                 aria-label={__('Password', 'web-stories')}

--- a/packages/wp-story-editor/src/components/documentPane/status/status.js
+++ b/packages/wp-story-editor/src/components/documentPane/status/status.js
@@ -100,10 +100,13 @@ function StatusPanel({
       return;
     }
 
-    updateStory({
-      properties: { visibility: VISIBILITY.PUBLIC },
-    });
-  }, [password, status, updateStory]);
+    if (!visibility) {
+      updateStory({
+        properties: { visibility: VISIBILITY.PUBLIC },
+      });
+      return;
+    }
+  }, [password, status, updateStory, visibility]);
 
   const visibilityOptions = [
     {

--- a/packages/wp-story-editor/src/components/documentPane/status/status.js
+++ b/packages/wp-story-editor/src/components/documentPane/status/status.js
@@ -226,6 +226,11 @@ function StatusPanel({
               selectedValue={visibility}
               onMenuItemClick={handleChangeVisibility}
               popupZIndex={popupZIndex}
+              hint={
+                visibilityOptions.find((option) => visibility === option.value)
+                  ?.helper
+              }
+              disabled={visibilityOptions.length <= 1}
             />
           </Row>
           {visibility === 'protected' && (

--- a/packages/wp-story-editor/src/components/documentPane/status/status.js
+++ b/packages/wp-story-editor/src/components/documentPane/status/status.js
@@ -21,11 +21,10 @@ import PropTypes from 'prop-types';
 import { useCallback, useMemo, useState } from '@googleforcreators/react';
 import styled from 'styled-components';
 import { __ } from '@googleforcreators/i18n';
-import { Input } from '@googleforcreators/design-system';
+import { Input, DropDown } from '@googleforcreators/design-system';
 import { trackEvent } from '@googleforcreators/tracking';
 import {
   Row,
-  RadioGroup,
   SimplePanel,
   ReviewChecklistDialog,
   useStory,
@@ -38,7 +37,7 @@ const InputRow = styled(Row)`
   margin-left: 34px;
 `;
 
-function StatusPanel({ nameOverride }) {
+function StatusPanel({ nameOverride, popupZIndex }) {
   const {
     status = '',
     password,
@@ -144,8 +143,8 @@ function StatusPanel({ nameOverride }) {
   const isAlreadyPublished = ['publish', 'future', 'private'].includes(status);
 
   const handleChangeVisibility = useCallback(
-    (evt) => {
-      const newVisibility = evt.target.value;
+    (_, value) => {
+      const newVisibility = value;
 
       if ('private' === newVisibility && !isAlreadyPublished) {
         if (
@@ -210,12 +209,11 @@ function StatusPanel({ nameOverride }) {
       >
         <>
           <Row>
-            <RadioGroup
-              groupLabel="Visibility"
-              name="radio-group-visibility"
+            <DropDown
               options={visibilityOptions}
-              onChange={handleChangeVisibility}
-              value={visibility}
+              selectedValue={visibility}
+              onMenuItemClick={handleChangeVisibility}
+              popupZIndex={popupZIndex}
             />
           </Row>
           {hasPassword && (
@@ -244,4 +242,5 @@ export default StatusPanel;
 
 StatusPanel.propTypes = {
   nameOverride: PropTypes.string,
+  popupZIndex: PropTypes.number,
 };

--- a/packages/wp-story-editor/src/components/documentPane/status/status.js
+++ b/packages/wp-story-editor/src/components/documentPane/status/status.js
@@ -137,6 +137,7 @@ function StatusPanel({
     const properties = {
       status: 'private',
       password: '',
+      visibility: 'private',
     };
 
     trackEvent('publish_story', {
@@ -215,6 +216,7 @@ function StatusPanel({
         title={__('Visibility', 'web-stories')}
         canCollapse={canCollapse}
         isPersistable={isPersistable}
+        collapsedByDefault={false}
         {...rest}
       >
         <>

--- a/packages/wp-story-editor/src/components/documentPane/status/test/status.js
+++ b/packages/wp-story-editor/src/components/documentPane/status/test/status.js
@@ -30,7 +30,8 @@ function arrange(
   capabilities = {
     publish: true,
   },
-  password = ''
+  password = '',
+  visibility = 'public'
 ) {
   const updateStory = jest.fn();
   const saveStory = jest.fn();
@@ -43,6 +44,7 @@ function arrange(
         title: '',
         storyId: 123,
         editLink: 'http://localhost/wp-admin/post.php?post=123&action=edit',
+        visibility,
       },
       capabilities,
     },
@@ -157,6 +159,7 @@ describe('statusPanel', () => {
     expect(saveStory).toHaveBeenCalledWith({
       status: 'private',
       password: '',
+      visibility: 'private',
     });
   });
 
@@ -165,17 +168,20 @@ describe('statusPanel', () => {
       {
         publish: true,
       },
-      'test'
+      'password',
+      'protected'
     );
+
     expect(screen.getByLabelText('Password')).toBeInTheDocument();
   });
 
-  it('should hide password field when changing visibility', () => {
+  it('should update properties changing visibility', () => {
     const { updateStory } = arrange(
       {
         publish: true,
       },
-      'test'
+      'password',
+      'protected'
     );
     expect(screen.getByLabelText('Password')).toBeInTheDocument();
 
@@ -193,8 +199,18 @@ describe('statusPanel', () => {
       properties: {
         status: 'draft',
         password: '',
+        visibility: 'public',
       },
     });
+  });
+  it('should hide password when public visibility', () => {
+    arrange(
+      {
+        publish: true,
+      },
+      undefined,
+      'public'
+    );
     expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
   });
 });

--- a/packages/wp-story-editor/src/components/documentPane/status/test/status.js
+++ b/packages/wp-story-editor/src/components/documentPane/status/test/status.js
@@ -25,13 +25,14 @@ import { StoryContext } from '@googleforcreators/story-editor';
  */
 import { renderWithTheme } from '../../../../testUtils';
 import StatusPanel from '../status';
+import { STATUS, VISIBILITY } from '../../../../constants';
 
 function arrange(
   capabilities = {
     publish: true,
   },
   password = '',
-  visibility = 'public'
+  visibility = VISIBILITY.PUBLIC
 ) {
   const updateStory = jest.fn();
   const saveStory = jest.fn();
@@ -39,7 +40,7 @@ function arrange(
   const storyContextValue = {
     state: {
       story: {
-        status: 'draft',
+        status: STATUS.DRAFT,
         password,
         title: '',
         storyId: 123,
@@ -157,9 +158,9 @@ describe('statusPanel', () => {
     );
     expect(windowConfirm).toHaveBeenCalledWith(expect.any(String));
     expect(saveStory).toHaveBeenCalledWith({
-      status: 'private',
+      status: STATUS.PRIVATE,
       password: '',
-      visibility: 'private',
+      visibility: VISIBILITY.PRIVATE,
     });
   });
 
@@ -181,7 +182,7 @@ describe('statusPanel', () => {
         publish: true,
       },
       'password',
-      'protected'
+      VISIBILITY.PASSWORD_PROTECTED
     );
     expect(screen.getByLabelText('Password')).toBeInTheDocument();
 
@@ -199,7 +200,7 @@ describe('statusPanel', () => {
       properties: {
         status: 'draft',
         password: '',
-        visibility: 'public',
+        visibility: VISIBILITY.PUBLIC,
       },
     });
   });
@@ -209,7 +210,7 @@ describe('statusPanel', () => {
         publish: true,
       },
       undefined,
-      'public'
+      VISIBILITY.PUBLIC
     );
     expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
   });

--- a/packages/wp-story-editor/src/components/documentPane/status/test/status.js
+++ b/packages/wp-story-editor/src/components/documentPane/status/test/status.js
@@ -122,8 +122,8 @@ describe('statusPanel', () => {
     clickDropdown();
 
     expect(
-      screen.getByRole('option', {
-        name: 'Selected Public',
+      screen.getByRole('button', {
+        name: 'Public',
       })
     ).toBeInTheDocument();
   });

--- a/packages/wp-story-editor/src/components/documentPane/status/test/status.js
+++ b/packages/wp-story-editor/src/components/documentPane/status/test/status.js
@@ -62,6 +62,13 @@ function arrange(
 
 const windowConfirm = jest.fn(() => true);
 
+const clickDropdown = () => {
+  const dropdownBtn = screen.getByRole('button', {
+    name: 'Public',
+  });
+  fireEvent.click(dropdownBtn);
+};
+
 describe('statusPanel', () => {
   beforeAll(() => {
     localStorage.setItem(
@@ -86,38 +93,66 @@ describe('statusPanel', () => {
 
   it('should render Status Panel', () => {
     arrange();
-    const element = screen.getByRole('button', {
-      name: 'Visibility',
-    });
-    expect(element).toBeInTheDocument();
+    clickDropdown();
 
-    const radioOptions = screen.getAllByRole('radio');
-    expect(radioOptions).toHaveLength(3);
-    expect(screen.getByLabelText('Public')).toBeInTheDocument();
-    expect(screen.getByLabelText('Private')).toBeInTheDocument();
-    expect(screen.getByLabelText('Password Protected')).toBeInTheDocument();
+    expect(screen.getAllByRole('option')).toHaveLength(3);
+    expect(
+      screen.getByRole('option', {
+        name: 'Selected Public',
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', {
+        name: 'Private',
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', {
+        name: 'Password Protected',
+      })
+    ).toBeInTheDocument();
   });
 
   it('should always render the "Public" visibility option', () => {
     arrange({
       publish: false,
     });
-    expect(screen.getByLabelText('Public')).toBeInTheDocument();
+    clickDropdown();
+
+    expect(
+      screen.getByRole('option', {
+        name: 'Selected Public',
+      })
+    ).toBeInTheDocument();
   });
 
   it('should not render other visibility options if lacking permissions', () => {
     arrange({
       publish: false,
     });
-    expect(screen.queryByLabelText('Private')).not.toBeInTheDocument();
+    clickDropdown();
+
     expect(
-      screen.queryByLabelText('Password Protected')
+      screen.queryByRole('option', {
+        name: 'Private',
+      })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('option', {
+        name: 'Password Protected',
+      })
     ).not.toBeInTheDocument();
   });
 
   it('should update the status when marking a story private', () => {
     const { saveStory } = arrange();
-    fireEvent.click(screen.getByLabelText('Private'));
+    clickDropdown();
+
+    fireEvent.click(
+      screen.getByRole('option', {
+        name: 'Private',
+      })
+    );
     expect(windowConfirm).toHaveBeenCalledWith(expect.any(String));
     expect(saveStory).toHaveBeenCalledWith({
       status: 'private',
@@ -143,7 +178,17 @@ describe('statusPanel', () => {
       'test'
     );
     expect(screen.getByLabelText('Password')).toBeInTheDocument();
-    fireEvent.click(screen.getByText('Public'));
+
+    const dropdownBtn = screen.getByRole('button', {
+      name: 'Password Protected',
+    });
+    fireEvent.click(dropdownBtn);
+
+    fireEvent.click(
+      screen.getByRole('option', {
+        name: 'Public',
+      })
+    );
     expect(updateStory).toHaveBeenCalledWith({
       properties: {
         status: 'draft',

--- a/packages/wp-story-editor/src/constants/status.js
+++ b/packages/wp-story-editor/src/constants/status.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './tips';
-export * from './wpAdmin.js';
-export * from './status.js';
+export const VISIBILITY = {
+  PUBLIC: 'public',
+  PRIVATE: 'private',
+  PASSWORD_PROTECTED: 'protected',
+};
+
+export const STATUS = {
+  PUBLISH: 'publish',
+  FUTURE: 'future',
+  PRIVATE: 'private',
+  DRAFT: 'draft',
+};


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
In the latest editor redesign, the visibility panel is getting updated from the legacy 3 radio buttons into a dropdown. This ticket is to handle that update in this panel. Functionality on select will remain the same as this is required by WordPress.

## Summary
Updating the Status Panel to show visibility options in a dropdown. 
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
Added a `visibility` to story state. This is so that we can keep `Document` pane and `Publish` modal in sync since the `Status` panel is being used in both places. 

<!-- Please describe your changes. -->

## To-do
- e2e test
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->
|Before|After|
|--|--|
|<img width="656" alt="Screen Shot 2022-02-15 at 4 16 44 PM" src="https://user-images.githubusercontent.com/1820266/154166022-1e224926-6cf5-4293-b53a-bf2dc14880fd.png">|<img width="870" alt="Screen Shot 2022-02-17 at 11 42 21 AM" src="https://user-images.githubusercontent.com/1820266/154549101-df13add3-f394-41f6-965a-1cf8ca55f625.png">|
|<img width="480" alt="Screen Shot 2022-02-17 at 11 17 32 AM" src="https://user-images.githubusercontent.com/1820266/154549985-ebf6f888-7e70-472c-9424-a97d7707300a.png">|<img width="535" alt="Screen Shot 2022-02-17 at 11 47 00 AM" src="https://user-images.githubusercontent.com/1820266/154549923-117c79d6-725b-4fa0-82e9-49135ee51bf3.png">


### New Modal
|Public|Password|
|--|--|
|<img width="1256" alt="Screen Shot 2022-02-16 at 2 46 37 PM" src="https://user-images.githubusercontent.com/1820266/154362927-986221fb-07d1-4fe3-86b2-700164b93d19.png">|<img width="1073" alt="Screen Shot 2022-02-17 at 11 49 15 AM" src="https://user-images.githubusercontent.com/1820266/154550212-270c19ac-7389-41d1-a926-9ba57ab3c466.png">|


## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Regression on Status (Visibility) Panel. It should all work the same as staging, we are just showing in a dropdown format now. 


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10579 
