### PR TITLE
New Stories Detail Modal: Cover Preview UI

### DIFF
--- a/packages/story-editor/src/components/publishModal/mainContent/storyPreview.js
+++ b/packages/story-editor/src/components/publishModal/mainContent/storyPreview.js
@@ -125,10 +125,13 @@ const ScrimTop = styled.div`
   justify-content: inherit;
   width: 100%;
 `;
+// Publisher logo border radius and box shadow are outside of theme to match Search Cover Preview
 const PublisherLogo = styled.img`
   grid-area: publisherLogo;
   height: 24px;
   width: 24px;
+  border-radius: 2px;
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.08);
 `;
 
 // TODO https://github.com/GoogleForCreators/web-stories-wp/issues/10584

--- a/packages/story-editor/src/components/publishModal/mainContent/storyPreview.js
+++ b/packages/story-editor/src/components/publishModal/mainContent/storyPreview.js
@@ -39,6 +39,7 @@ const PreviewContainer = styled.div`
   width: ${({ width }) => width}px;
   height: ${({ height }) => height}px;
   position: relative;
+  margin-top: 8px;
 `;
 
 const PreviewWrapper = styled.div`
@@ -165,6 +166,9 @@ const Publisher = styled(Text).attrs({
   color: ${({ theme }) => theme.colors.fg.secondary};
 `;
 
+// TODO https://github.com/GoogleForCreators/web-stories-wp/issues/10584
+const ENABLE_EDIT_FEATURED_MEDIA = false;
+
 const StoryPreview = () => {
   const { title, featuredMedia, publisherLogo } = useStory(
     ({ state: { story } }) => ({
@@ -219,8 +223,7 @@ const StoryPreview = () => {
                       alt={__('Publisher Logo', 'web-stories')}
                     />
                   )}
-                  {/* TODO separately as follow up */}
-                  {hasUploadMediaAction && (
+                  {ENABLE_EDIT_FEATURED_MEDIA && hasUploadMediaAction && (
                     <EditFeaturedMedia
                       aria-label={__('Edit Publisher Logo', 'web-stories')}
                     >

--- a/packages/story-editor/src/components/publishModal/mainContent/storyPreview.js
+++ b/packages/story-editor/src/components/publishModal/mainContent/storyPreview.js
@@ -62,7 +62,7 @@ export const Image = styled.img`
   height: 100%;
   width: 100%;
   display: block;
-  aspect-ratio: auto ${PAGE_RATIO};
+  aspect-ratio: ${PAGE_RATIO};
   object-fit: cover;
   border-radius: ${({ theme }) => theme.borders.radius.medium};
   background: ${({ theme }) => theme.colors.interactiveBg.primaryNormal};

--- a/packages/story-editor/src/components/publishModal/mainContent/storyPreview.js
+++ b/packages/story-editor/src/components/publishModal/mainContent/storyPreview.js
@@ -172,10 +172,9 @@ const ENABLE_EDIT_FEATURED_MEDIA = false;
 const StoryPreview = () => {
   const { title, featuredMedia, publisherLogo } = useStory(
     ({ state: { story } }) => ({
-      title: story.title,
-      featuredMedia: story.featuredMedia,
-      publisherLogo: story.publisherLogo,
-      story,
+      title: story?.title,
+      featuredMedia: story?.featuredMedia || {},
+      publisherLogo: story?.publisherLogo || {},
     })
   );
 
@@ -198,13 +197,14 @@ const StoryPreview = () => {
       </Headline>
       <PreviewContainer width={mediaWidth} height={mediaHeight}>
         <PreviewWrapper width={mediaWidth} height={mediaHeight}>
-          {featuredMedia.url ? (
+          {featuredMedia?.url ? (
             <Image
               crossOrigin="anonymous"
               src={featuredMedia.url}
               width={featuredMedia.width}
               height={featuredMedia.height}
               alt={__('Preview image', 'web-stories')}
+              data-testid="story_preview_featured_media"
             />
           ) : (
             <EmptyPlaceholder />
@@ -214,13 +214,14 @@ const StoryPreview = () => {
             <ScrimContainer>
               <ScrimContent>
                 <TopOverlay>
-                  {publisherLogo?.url.length > 0 && (
+                  {publisherLogo?.url?.length > 0 && (
                     <PublisherLogo
                       crossOrigin="anonymous"
                       width={publisherLogo.width}
                       height={publisherLogo.height}
                       src={publisherLogo.url}
                       alt={__('Publisher Logo', 'web-stories')}
+                      data-testid="story_preview_logo"
                     />
                   )}
                   {ENABLE_EDIT_FEATURED_MEDIA && hasUploadMediaAction && (
@@ -232,8 +233,14 @@ const StoryPreview = () => {
                   )}
                 </TopOverlay>
                 <BottomOverlay>
-                  {title && <Title>{title}</Title>}
-                  {publisher && <Publisher>{publisher}</Publisher>}
+                  {title && (
+                    <Title data-testid="story_preview_title">{title}</Title>
+                  )}
+                  {publisher && (
+                    <Publisher data-testid="story_preview_publisher">
+                      {publisher}
+                    </Publisher>
+                  )}
                 </BottomOverlay>
               </ScrimContent>
             </ScrimContainer>

--- a/packages/story-editor/src/components/publishModal/mainContent/storyPreview.js
+++ b/packages/story-editor/src/components/publishModal/mainContent/storyPreview.js
@@ -16,20 +16,154 @@
 /**
  * External dependencies
  */
-import { Headline, THEME_CONSTANTS } from '@googleforcreators/design-system';
+import {
+  Button,
+  Headline,
+  Icons,
+  Text,
+  THEME_CONSTANTS,
+  BUTTON_VARIANTS,
+  BUTTON_TYPES,
+  BUTTON_SIZES,
+} from '@googleforcreators/design-system';
 import styled from 'styled-components';
 import { __ } from '@googleforcreators/i18n';
+/**
+ * Internal dependencies
+ */
+import { useConfig, useStory } from '../../../app';
 
 const PreviewContainer = styled.div`
-  margin: 8px 0;
-  object-fit: contain;
+  position: relative;
   width: 100%;
-  & > img {
-    border-radius: ${({ theme }) => theme.borders.radius.medium};
-  }
+  height: calc(100% - 16px);
+  margin: 8px 0;
+`;
+
+export const Image = styled.img`
+  height: 100%;
+  width: 100%;
+  display: block;
+  object-fit: cover;
+  border-radius: ${({ theme }) => theme.borders.radius.medium};
+  background: ${({ theme }) => theme.colors.gradient.placeholder};
+`;
+
+const EmptyPlaceholder = styled.div`
+  height: 100%;
+  width: 100%;
+  border-radius: ${({ theme }) => theme.borders.radius.medium};
+  background: ${({ theme }) => theme.colors.gradient.placeholder};
+`;
+
+const PreviewWrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  position: absolute;
+`;
+
+const Gradient = styled.div`
+  position: absolute;
+  bottom: 0;
+  height: 67%;
+  width: 100%;
+  border-radius: ${({ theme }) => theme.borders.radius.medium};
+  background: ${({ theme }) => theme.colors.gradient.posterOverlay};
+`;
+
+const Scrim = styled.div`
+  position: absolute;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  border-radius: ${({ theme }) => theme.borders.radius.medium};
+  background: ${({ theme }) => theme.colors.opacity.black3};
+`;
+
+const ScrimContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  overflow: hidden;
+`;
+
+const ScrimContent = styled.div`
+  height: 100%;
+  box-sizing: border-box;
+  position: absolute;
+  width: 100%;
+  top: 0;
+  padding: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+`;
+
+const PublisherLogo = styled.img`
+  height: 32px;
+  width: 32px;
+`;
+
+const EditFeaturedMedia = styled(Button).attrs({
+  variant: BUTTON_VARIANTS.SQUARE,
+  type: BUTTON_TYPES.SECONDARY,
+  size: BUTTON_SIZES.SMALL,
+})`
+  height: 32px;
+  width: 32px;
+`;
+
+const Copy = styled.div`
+  width: 100%;
+  margin: auto 0 0;
+  align-self: flex-end;
+`;
+const Title = styled(Headline).attrs({
+  as: 'h3',
+  size: THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL,
+})`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: ${({ theme }) => theme.colors.fg.primary};
+  padding: 0;
+  margin: 0 0 4px;
+  max-height: calc(1.2em * 3);
+  /* stylelint-disable-next-line */
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  /* stylelint-disable-next-line */
+  -webkit-box-orient: vertical;
+`;
+
+const Publisher = styled(Text).attrs({
+  forwardAs: 'span',
+  size: THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.MEDIUM,
+})`
+  display: block;
+  margin: 0;
+  padding: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: ${({ theme }) => theme.colors.fg.secondary};
 `;
 
 const StoryPreview = () => {
+  const { title, featuredMedia, publisherLogo } = useStory(
+    ({ state: { story } }) => ({
+      title: story.title,
+      featuredMedia: story.featuredMedia,
+      publisherLogo: story.publisherLogo,
+      story,
+    })
+  );
+
+  const publisher = useConfig(({ metadata }) => metadata?.publisher || null);
+
   return (
     <>
       <Headline
@@ -39,7 +173,44 @@ const StoryPreview = () => {
         {__('Cover Preview', 'web-stories')}
       </Headline>
       <PreviewContainer>
-        <img src="http://placekitten.com/230/342" alt="" />
+        <PreviewWrapper>
+          {featuredMedia.url ? (
+            <Image
+              crossOrigin="anonymous"
+              width={featuredMedia.width}
+              height={featuredMedia.height}
+              src={featuredMedia.url}
+              alt={__('Preview image', 'web-stories')}
+            />
+          ) : (
+            <EmptyPlaceholder />
+          )}
+          <Gradient />
+          <Scrim>
+            <ScrimContainer>
+              <ScrimContent>
+                {publisherLogo?.url.length > 0 && (
+                  <PublisherLogo
+                    crossOrigin="anonymous"
+                    width={publisherLogo.width}
+                    height={publisherLogo.height}
+                    src={publisherLogo.url}
+                    alt={__('Publisher Logo', 'web-stories')}
+                  />
+                )}
+                <EditFeaturedMedia
+                  aria-label={__('Edit Publisher Logo', 'web-stories')}
+                >
+                  <Icons.Pencil aria-hidden="true" />
+                </EditFeaturedMedia>
+                <Copy>
+                  <Title>{title}</Title>
+                  {publisher && <Publisher>{publisher}</Publisher>}
+                </Copy>
+              </ScrimContent>
+            </ScrimContainer>
+          </Scrim>
+        </PreviewWrapper>
       </PreviewContainer>
     </>
   );

--- a/packages/story-editor/src/components/publishModal/mainContent/storyPreview.js
+++ b/packages/story-editor/src/components/publishModal/mainContent/storyPreview.js
@@ -16,6 +16,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import {
   Button,
@@ -41,12 +42,20 @@ const PreviewContainer = styled.div`
   position: relative;
   margin-top: 8px;
 `;
+PreviewContainer.propTypes = {
+  width: PropTypes.number.isRequired,
+  height: PropTypes.number.isRequired,
+};
 
 const PreviewWrapper = styled.div`
   width: ${({ width }) => width}px;
   height: ${({ height }) => height}px;
   position: absolute;
 `;
+PreviewWrapper.propTypes = {
+  width: PropTypes.number.isRequired,
+  height: PropTypes.number.isRequired,
+};
 
 export const Image = styled.img`
   height: 100%;

--- a/packages/story-editor/src/components/publishModal/stories/index.js
+++ b/packages/story-editor/src/components/publishModal/stories/index.js
@@ -59,6 +59,7 @@ export const _default = (args) => {
     }));
   }, []);
   return (
+    // todo: add config to grab publisher
     <StoryContext.Provider
       value={{
         actions: { updateStory: handleUpdateStory },
@@ -68,6 +69,16 @@ export const _default = (args) => {
             permalinkConfig: {
               prefix: 'http://sample.com/',
               suffix: '',
+            },
+            featuredMedia: {
+              url: 'http://placekitten.com/230/342',
+              height: 342,
+              width: 342,
+            },
+            publisherLogo: {
+              url: 'http://placekitten.com/158/96',
+              height: 96,
+              width: 158,
             },
           },
         },

--- a/packages/story-editor/src/components/publishModal/stories/index.js
+++ b/packages/story-editor/src/components/publishModal/stories/index.js
@@ -21,6 +21,7 @@ import { useCallback, useState } from '@googleforcreators/react';
  * Internal dependencies
  */
 import StoryContext from '../../../app/story/context';
+import { ConfigContext } from '../../../app/config';
 import { noop } from '../../../utils/noop';
 import { ChecklistCountProvider, CheckpointContext } from '../../checklist';
 import InspectorContext from '../../inspector/context';
@@ -38,6 +39,10 @@ export default {
   args: {
     isOpen: true,
     hasChecklist: true,
+    publisher: 'Gotham Bugle',
+    hasPublisherLogo: true,
+    hasFeaturedMedia: true,
+    hasUploadMediaAction: true,
   },
   argTypes: {
     onPublish: { action: 'onPublish clicked' },
@@ -46,6 +51,12 @@ export default {
 };
 
 export const _default = (args) => {
+  const {
+    hasUploadMediaAction,
+    hasFeaturedMedia,
+    hasPublisherLogo,
+    publisher,
+  } = args;
   const [inputValues, setInputValues] = useState({
     excerpt: '',
     title: '',
@@ -59,35 +70,37 @@ export const _default = (args) => {
     }));
   }, []);
   return (
-    // todo: add config to grab publisher
-    <StoryContext.Provider
+    <ConfigContext.Provider
       value={{
-        actions: { updateStory: handleUpdateStory },
-        state: {
-          story: {
-            ...inputValues,
-            permalinkConfig: {
-              prefix: 'http://sample.com/',
-              suffix: '',
-            },
-            featuredMedia: {
-              url: 'http://placekitten.com/230/342',
-              height: 342,
-              width: 342,
-            },
-            publisherLogo: {
-              url: 'http://placekitten.com/158/96',
-              height: 96,
-              width: 158,
-            },
-          },
+        metadata: {
+          publisher: publisher,
+        },
+        capabilities: {
+          hasUploadMediaAction: hasUploadMediaAction,
         },
       }}
     >
-      <CheckpointContext.Provider
+      <StoryContext.Provider
         value={{
-          actions: {
-            onPublishDialogChecklistRequest: noop,
+          actions: { updateStory: handleUpdateStory },
+          state: {
+            story: {
+              ...inputValues,
+              permalinkConfig: {
+                prefix: 'http://sample.com/',
+                suffix: '',
+              },
+              featuredMedia: {
+                url: hasFeaturedMedia ? 'http://placekitten.com/230/342' : '',
+                height: 333,
+                width: 250,
+              },
+              publisherLogo: {
+                url: hasPublisherLogo ? 'http://placekitten.com/158/96' : '',
+                height: 96,
+                width: 158,
+              },
+            },
           },
         }}
       >
@@ -111,8 +124,19 @@ export const _default = (args) => {
           <ChecklistCountProvider hasChecklist={args.hasChecklist}>
             <PublishModal {...args} />
           </ChecklistCountProvider>
+          <CheckpointContext.Provider
+            value={{
+              actions: {
+                onPublishDialogChecklistRequest: noop,
+              },
+            }}
+          >
+            <ChecklistCountProvider hasChecklist={args.hasChecklist}>
+              <PublishModal {...args} />
+            </ChecklistCountProvider>
+          </CheckpointContext.Provider>
         </InspectorContext.Provider>
-      </CheckpointContext.Provider>
-    </StoryContext.Provider>
+      </StoryContext.Provider>
+    </ConfigContext.Provider>
   );
 };

--- a/packages/story-editor/src/components/publishModal/stories/index.js
+++ b/packages/story-editor/src/components/publishModal/stories/index.js
@@ -52,6 +52,7 @@ export default {
 
 export const _default = (args) => {
   const {
+    hasChecklist,
     hasUploadMediaAction,
     hasFeaturedMedia,
     hasPublisherLogo,
@@ -121,7 +122,7 @@ export const _default = (args) => {
             },
           }}
         >
-          <ChecklistCountProvider hasChecklist={args.hasChecklist}>
+          <ChecklistCountProvider hasChecklist={hasChecklist}>
             <PublishModal {...args} />
           </ChecklistCountProvider>
           <CheckpointContext.Provider

--- a/packages/story-editor/src/components/publishModal/test/storyPreview.js
+++ b/packages/story-editor/src/components/publishModal/test/storyPreview.js
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+/**
+ * Internal dependencies
+ */
+import renderWithTheme from '../../../testUtils/renderWithTheme';
+import { StoryContext } from '../../../app/story';
+import { ConfigContext } from '../../../app/config';
+import StoryPreview from '../mainContent/storyPreview';
+
+describe('publishModal/storyPreview', () => {
+  const view = (props) => {
+    const {
+      storyTitle = '',
+      featuredMedia = '',
+      publisherLogo = '',
+      publisher = '',
+    } = props || {};
+
+    return renderWithTheme(
+      <ConfigContext.Provider
+        value={{
+          metadata: {
+            publisher: publisher,
+          },
+          capabilities: {
+            hasUploadMediaAction: false,
+          },
+        }}
+      >
+        <StoryContext.Provider
+          value={{
+            state: {
+              story: {
+                title: storyTitle,
+                featuredMedia: {
+                  url: featuredMedia,
+                  width: 250,
+                  height: 355,
+                },
+                publisherLogo: {
+                  url: publisherLogo,
+                  width: 25,
+                  height: 25,
+                },
+              },
+            },
+          }}
+        >
+          <StoryPreview />
+        </StoryContext.Provider>
+      </ConfigContext.Provider>
+    );
+  };
+
+  it('should have no accessibility issues', async () => {
+    const { container } = view({
+      storyTitle: 'Great books to read',
+      featuredMedia: 'http://placekitten.com/230/342',
+      publisherLogo: 'http://placekitten.com/158/96',
+      publisher: 'My Site Title',
+    });
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('should render the story title when present', () => {
+    view({ storyTitle: 'Great books to read' });
+    const storyTitle = screen.getByTestId('story_preview_title');
+
+    expect(storyTitle).toBeInTheDocument();
+  });
+
+  it('should render the site title when present', () => {
+    view({ publisher: 'My Site Title' });
+    const siteTitle = screen.getByTestId('story_preview_publisher');
+
+    expect(siteTitle).toBeInTheDocument();
+  });
+
+  it('should render the featured media image when present', () => {
+    view({ featuredMedia: 'http://placekitten.com/230/342' });
+    const featuredMedia = screen.getByTestId('story_preview_featured_media');
+
+    expect(featuredMedia).toBeInTheDocument();
+  });
+
+  it('should render the publisher logo when present', () => {
+    view({ publisherLogo: 'http://placekitten.com/158/96' });
+    const publisherLogo = screen.getByTestId('story_preview_logo');
+
+    expect(publisherLogo).toBeInTheDocument();
+  });
+
+  it('should not render the story title when not present', () => {
+    view();
+    const storyTitle = screen.queryByTestId('story_preview_title');
+
+    expect(storyTitle).not.toBeInTheDocument();
+  });
+
+  it('should not render the site title when not present', () => {
+    view();
+    const siteTitle = screen.queryByTestId('story_preview_publisher');
+
+    expect(siteTitle).not.toBeInTheDocument();
+  });
+
+  it('should not render the featured media image when not present', () => {
+    view();
+    const featuredMedia = screen.queryByTestId('story_preview_featured_media');
+
+    expect(featuredMedia).not.toBeInTheDocument();
+  });
+
+  it('should not render the publisher logo when not present', () => {
+    view();
+    const publisherLogo = screen.queryByTestId('story_preview_logo');
+
+    expect(publisherLogo).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Context

Part of the story details modal feature. 

## Summary

Gives the user a preview of what their story will show up as in Discover and Search results as part of the new story details modal that gets viewed when 'publish' is clicked in the editor. 

**Example of previews as seen in Chrome Search results**
<img width="394" alt="Screen Shot 2022-02-15 at 3 27 15 PM" src="https://user-images.githubusercontent.com/10720454/154160245-74264a1d-a58c-4a4a-b4e3-669125e42f53.png">


## Relevant Technical Choices

Mostly this is just a lot of css.
- Thought about sharing some styles with the dashboard since we're kind of copying the cover styles as seen in Search, but there's some extra info there that we don't need here that isn't consistent with the actual cover previews (who the author is, is it a draft, is it locked). So I opted for just putting all the styles in one place. 
- Set the base structure up for editing the featured media from the new 'edit' button that's overlayed on the cover preview in figma so that I knew I got all the variants right for styling it. Hooking up the functionality is more involved. Discussed possibly moving this to v2 of the modal with Andrew who was ok with it. Will circle back after everything else here is done. Already going to cut it close. 
  - Checking to see if user has `hasUploadMediaAction` capabilities before rendering 'edit' button, that functionality I'll do separate since it requires sharing code that's already in use, new ticket for that lives here: https://github.com/GoogleForCreators/web-stories-wp/issues/10584

## To-do

There's this, that I mentioned above - to add the [ability to edit the featured image](https://github.com/GoogleForCreators/web-stories-wp/issues/10584) from the cover preview

I found a few loose ends that I will take care of separately that are noticeable here:
- available users to set as author doesn't get fetched until the 'document' panel has been clicked on in the editor 
- discrepancy between onChange vs onBlur with story description in modal vs in panel - change that and title to also be on blur implementations 
- Checklist needs to be an icon w/ tooltip just like in the footer 
- There's a 1px discrepancy on the edge of the modal that has the document panels  

## User-facing changes

N/A All behind a feature flag 

## Testing Instructions

Storybook is helpful here, added some new knobs (thanks for that update, @BrookeGraham !!) 
- You can see different variants of the cover preview depending on what all the user's provided (featured media, publisher logo, site title, story title) 

In the editor, enable the new story details modal experiment and then hit 'publish'
- should see cover preview
- look at it with and without a featured image, publisher logo, site title, story title 
- repeat in RTL

| LTR | RTL |
|--- | --- |
| <img width="1005" alt="Screen Shot 2022-02-15 at 5 15 51 PM" src="https://user-images.githubusercontent.com/10720454/154172986-9df3b8ce-f606-440c-a2ad-47174e2fecdf.png"> | <img width="999" alt="Screen Shot 2022-02-15 at 5 15 37 PM" src="https://user-images.githubusercontent.com/10720454/154173002-9fc8184c-910d-426f-8535-426a703d81d7.png"> |

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Partially addresses #10115 
