### PR TITLE
Telemetry: track the WordPress environment

### DIFF
--- a/bin/local-env/docker-compose.yml
+++ b/bin/local-env/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       WORDPRESS_DB_USER: root
       WORDPRESS_DB_PASSWORD: example
       WORDPRESS_DB_NAME: wordpress
+      WP_ENVIRONMENT_TYPE: local
       ABSPATH: /usr/src/wordpress/
       WORDPRESS_DEBUG: 1
       WORDPRESS_CONFIG_EXTRA: |

--- a/includes/Tracking.php
+++ b/includes/Tracking.php
@@ -196,6 +196,7 @@ class Tracking extends Service_Base {
 			'wpVersion'          => get_bloginfo( 'version' ),
 			'phpVersion'         => PHP_VERSION,
 			'isMultisite'        => (int) is_multisite(),
+			'serverEnvironment'  => wp_get_environment_type(),
 			'adNetwork'          => $ad_network,
 			'analytics'          => $analytics,
 			'activePlugins'      => $active_plugins,

--- a/packages/tracking/src/enableTracking.js
+++ b/packages/tracking/src/enableTracking.js
@@ -85,6 +85,7 @@ async function loadTrackingScript(sendPageView = true) {
       dimension14: 'isMultisite',
       dimension15: 'name',
       dimension16: 'activePlugins',
+      dimension20: 'serverEnvironment',
     },
   });
 

--- a/tests/phpunit/integration/tests/Tracking.php
+++ b/tests/phpunit/integration/tests/Tracking.php
@@ -22,7 +22,7 @@ use Google\Web_Stories\Integrations\Site_Kit;
 /**
  * @coversDefaultClass \Google\Web_Stories\Tracking
  */
-class Tracking extends TestCase {
+class Tracking extends DependencyInjectedTestCase {
 	protected static $user_id;
 
 	/**
@@ -34,21 +34,6 @@ class Tracking extends TestCase {
 	 * @var \Google\Web_Stories\Experiments
 	 */
 	private $experiments;
-
-	/**
-	 * @var \Google\Web_Stories\Assets
-	 */
-	private $assets;
-
-	/**
-	 * @var \Google\Web_Stories\Settings
-	 */
-	private $settings;
-
-	/**
-	 * @var \Google\Web_Stories\User\Preferences
-	 */
-	private $preferences;
 
 	/**
 	 * @var \Google\Web_Stories\Tracking
@@ -68,10 +53,16 @@ class Tracking extends TestCase {
 
 		$this->experiments = $this->createMock( \Google\Web_Stories\Experiments::class );
 		$this->site_kit    = $this->createMock( \Google\Web_Stories\Integrations\Site_Kit::class );
-		$this->assets      = new \Google\Web_Stories\Assets();
-		$this->settings    = new \Google\Web_Stories\Settings();
-		$this->preferences = new \Google\Web_Stories\User\Preferences();
-		$this->instance    = new \Google\Web_Stories\Tracking( $this->experiments, $this->site_kit, $this->assets, $this->settings, $this->preferences );
+		$assets            = $this->injector->make( \Google\Web_Stories\Assets::class );
+		$settings          = $this->injector->make( \Google\Web_Stories\Settings::class );
+		$preferences       = $this->injector->make( \Google\Web_Stories\User\Preferences::class );
+		$this->instance    = new \Google\Web_Stories\Tracking(
+			$this->experiments,
+			$this->site_kit,
+			$assets,
+			$settings,
+			$preferences
+		);
 	}
 
 	/**
@@ -135,9 +126,11 @@ class Tracking extends TestCase {
 		$this->assertArrayHasKey( 'isMultisite', $settings['userProperties'] );
 		$this->assertArrayHasKey( 'adNetwork', $settings['userProperties'] );
 		$this->assertArrayHasKey( 'analytics', $settings['userProperties'] );
+		$this->assertArrayHasKey( 'serverEnvironment', $settings['userProperties'] );
 		$this->assertArrayHasKey( 'activePlugins', $settings['userProperties'] );
 		$this->assertSame( get_locale(), $settings['userProperties']['siteLocale'] );
 		$this->assertSame( get_user_locale(), $settings['userProperties']['userLocale'] );
+		$this->assertSame( wp_get_environment_type(), $settings['userProperties']['serverEnvironment'] );
 		$this->assertSame( PHP_VERSION, $settings['userProperties']['phpVersion'] );
 		$this->assertSame( get_bloginfo( 'version' ), $settings['userProperties']['wpVersion'] );
 		$this->assertSame( 'administrator', $settings['userProperties']['userRole'] );
@@ -148,6 +141,7 @@ class Tracking extends TestCase {
 		$this->assertIsString( $settings['userProperties']['adNetwork'] );
 		$this->assertIsString( $settings['userProperties']['analytics'] );
 		$this->assertIsString( $settings['userProperties']['activePlugins'] );
+		$this->assertIsString( $settings['userProperties']['serverEnvironment'] );
 	}
 
 	/**


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Add a new user property called `serverEnvoriment` that is submitted to the analytics. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<img width="1904" alt="Screenshot 2022-02-16 at 12 17 32" src="https://user-images.githubusercontent.com/237508/154263044-bca2515d-c3b7-4250-9350-29bb8ffc4c7e.png"/>

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10551
