### PR TITLE
Code Quality: prevent internal module imports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -83,6 +83,10 @@
     "import/no-useless-path-segments": ["error", {
       "noUselessIndex": true
     }],
+    "import/no-relative-packages": "error",
+    "import/no-internal-modules": [ "error", {
+      "forbid": [ "@googleforcreators/**/*" ]
+    } ],
     "jsx-a11y/label-has-for": "off",
     "jsx-a11y/media-has-caption": [ "error", {
       "audio": [ "Audio" ],

--- a/.storybook/stories/playground/story-editor/api/fonts.js
+++ b/.storybook/stories/playground/story-editor/api/fonts.js
@@ -16,7 +16,7 @@
 
 export async function getFonts(params) {
   let { default: fonts } = await import(
-    /* webpackChunkName: "chunk-fonts" */ '@googleforcreators/fonts/src/fonts.json'
+    /* webpackChunkName: "chunk-fonts" */ '@googleforcreators/fonts/src/fonts.json' //eslint-disable-line import/no-internal-modules -- TODO: Improve export in module.
   );
 
   fonts = fonts.map((font) => ({

--- a/packages/design-system/src/components/contextMenu/index.js
+++ b/packages/design-system/src/components/contextMenu/index.js
@@ -15,4 +15,4 @@
  */
 export { default as ContextMenu } from './contextMenu';
 export * as ContextMenuComponents from './components';
-export { MenuPropTypes } from './menu';
+export { MenuPropTypes, CONTEXT_MENU_WIDTH } from './menu';

--- a/packages/stories-block/src/block/block.js
+++ b/packages/stories-block/src/block/block.js
@@ -16,6 +16,7 @@
 /**
  * Internal dependencies
  */
+// eslint-disable-next-line import/no-relative-packages -- False positive because this is not another package.
 import metadata from '../../../../blocks/embed/block.json';
 
 export default metadata;

--- a/packages/story-editor/src/components/canvas/emptyStateLayer.js
+++ b/packages/story-editor/src/components/canvas/emptyStateLayer.js
@@ -27,6 +27,7 @@ import {
   THEME_CONSTANTS,
   theme,
   lightMode,
+  CONTEXT_MENU_WIDTH,
 } from '@googleforcreators/design-system';
 import { useTransform } from '@googleforcreators/transform';
 
@@ -34,7 +35,6 @@ import { useTransform } from '@googleforcreators/transform';
  * Internal dependencies
  */
 import { __ } from '@googleforcreators/i18n';
-import { CONTEXT_MENU_WIDTH } from '@googleforcreators/design-system/src/components/contextMenu/menu';
 import { useConfig, useRightClickMenu } from '../../app';
 import useStory from '../../app/story/useStory';
 import isEmptyStory from '../../app/story/utils/isEmptyStory';

--- a/packages/story-editor/src/components/form/hierarchical/test/hierarchical.js
+++ b/packages/story-editor/src/components/form/hierarchical/test/hierarchical.js
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * External dependencies
  */
 import { fireEvent, screen } from '@testing-library/react';
+// eslint-disable-next-line import/no-internal-modules -- Importing testUtils is OK.
 import { renderWithProviders } from '@googleforcreators/design-system/src/testUtils';
 
 /**

--- a/packages/story-editor/src/components/form/tags/test/input.js
+++ b/packages/story-editor/src/components/form/tags/test/input.js
@@ -17,6 +17,7 @@
  * External dependencies
  */
 import { fireEvent, screen } from '@testing-library/react';
+// eslint-disable-next-line import/no-internal-modules -- Importing testUtils is OK.
 import { renderWithProviders } from '@googleforcreators/design-system/src/testUtils';
 
 /**

--- a/packages/story-editor/src/components/helpCenter/toggle/test/index.js
+++ b/packages/story-editor/src/components/helpCenter/toggle/test/index.js
@@ -17,6 +17,7 @@
  * External dependencies
  */
 import { fireEvent, screen } from '@testing-library/react';
+// eslint-disable-next-line import/no-internal-modules -- Importing testUtils is OK.
 import { renderWithProviders } from '@googleforcreators/design-system/src/testUtils';
 
 /**


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

In #10261, an import was accidentally added that breaks usage of our decoupled packages.

## Summary

<!-- A brief description of what this PR does. -->

Imports like `@googleforcreators/design-system/src/components/contextMenu/menu` are forbidden, only directly importing from `@googleforcreators/design-system` is OK.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

None

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
