### PR TITLE
New Story Details Modal: Load Users

### DIFF
--- a/packages/story-editor/src/components/form/dateTime/datePicker.js
+++ b/packages/story-editor/src/components/form/dateTime/datePicker.js
@@ -163,7 +163,7 @@ function DatePicker({ currentDate, onChange, onViewChange }) {
 DatePicker.propTypes = {
   onChange: PropTypes.func.isRequired,
   onViewChange: PropTypes.func,
-  currentDate: PropTypes.string,
+  currentDate: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 export default DatePicker;

--- a/packages/story-editor/src/components/form/dateTime/dateTime.js
+++ b/packages/story-editor/src/components/form/dateTime/dateTime.js
@@ -116,7 +116,7 @@ DateTime.propTypes = {
   onChange: PropTypes.func.isRequired,
   onViewChange: PropTypes.func,
   onClose: PropTypes.func,
-  value: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   is12Hour: PropTypes.bool,
   forwardedRef: PropTypes.object,
   canReset: PropTypes.bool,

--- a/packages/wp-story-editor/src/components/documentPane/publish/author.js
+++ b/packages/wp-story-editor/src/components/documentPane/publish/author.js
@@ -55,10 +55,11 @@ function Author() {
   const [visibleOptions, setVisibleOptions] = useState(null);
 
   useEffect(() => {
-    if (tab === 'document') {
-      loadUsers();
+    if (users.length === 0 && !isUsersLoading) {
+      return loadUsers();
     }
-  }, [tab, loadUsers]);
+    return () => {};
+  }, [loadUsers, users, isUsersLoading]);
 
   const getAuthorsBySearch = useCallback(
     (search) => {

--- a/packages/wp-story-editor/src/components/documentPane/publish/author.js
+++ b/packages/wp-story-editor/src/components/documentPane/publish/author.js
@@ -32,7 +32,7 @@ function Author() {
     actions: { getAuthors },
   } = useAPI();
   const {
-    state: { tab, users, isUsersLoading },
+    state: { users, isUsersLoading },
     actions: { loadUsers },
   } = useInspector();
   const { isSaving, author, updateStory } = useStory(

--- a/packages/wp-story-editor/src/components/documentPane/publish/author.js
+++ b/packages/wp-story-editor/src/components/documentPane/publish/author.js
@@ -55,11 +55,8 @@ function Author() {
   const [visibleOptions, setVisibleOptions] = useState(null);
 
   useEffect(() => {
-    if (users.length === 0 && !isUsersLoading) {
-      return loadUsers();
-    }
-    return () => {};
-  }, [loadUsers, users, isUsersLoading]);
+    loadUsers();
+  }, [loadUsers]);
 
   const getAuthorsBySearch = useCallback(
     (search) => {


### PR DESCRIPTION
## Context

Part of the story details modal feature.

## Summary

Accidentally introduced a new bug on the new story details modal (so this is a preemptive fix since that's not in use yet). Missed where the users are being fetched from `wp-story-editor` and threaded through to assigning author in publish panel. 

## Relevant Technical Choices

Limiting request to load users based on users array being empty and isUsersLoading being false instead of the document tab. This means that users are only getting fetched once regardless of tab changes.

Also silencing 2 console warnings that were bumming me out while testing publish panel in the modal. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

Now users will populate for the story details modal regardless of if user has navigated to the document tab in the editor first. 

| Broken | Fixed | 
| --- | --- |
| https://user-images.githubusercontent.com/10720454/154348528-c61102a0-2cde-4115-bb92-2ad72edee859.mp4 | https://user-images.githubusercontent.com/10720454/154348580-1e0d90ed-338c-4515-92ff-e5a5469ef539.mp4 |

## Testing Instructions

Verify that users are getting fetched one time and both author dropdowns get populated.

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Partially addresses #10115 
