### PR TITLE
New Story Details Modal: Checklist Button Swap to Icon 

### DIFF
--- a/packages/story-editor/src/components/canvas/navLayer.js
+++ b/packages/story-editor/src/components/canvas/navLayer.js
@@ -27,24 +27,29 @@ import Footer from '../footer';
 import DirectionAware from '../directionAware';
 import PageSideMenu from './pageSideMenu';
 import { FooterArea, HeadArea, Layer, PageMenuArea, Z_INDEX } from './layout';
+import { ChecklistCountProvider } from '../checklist';
 
 function NavLayer({ header, footer }) {
   return (
-    <Layer
-      pointerEvents="none"
-      zIndex={Z_INDEX.NAV}
-      onMouseDown={(evt) => evt.stopPropagation()}
+    <ChecklistCountProvider
+      hasChecklist={Boolean(footer?.secondaryMenu?.checklist)}
     >
-      <HeadArea pointerEvents="initial">{header}</HeadArea>
-      <DirectionAware>
-        <PageMenuArea>
-          <PageSideMenu />
-        </PageMenuArea>
-      </DirectionAware>
-      <FooterArea pointerEvents="initial">
-        <Footer footer={footer} />
-      </FooterArea>
-    </Layer>
+      <Layer
+        pointerEvents="none"
+        zIndex={Z_INDEX.NAV}
+        onMouseDown={(evt) => evt.stopPropagation()}
+      >
+        <HeadArea pointerEvents="initial">{header}</HeadArea>
+        <DirectionAware>
+          <PageMenuArea>
+            <PageSideMenu />
+          </PageMenuArea>
+        </DirectionAware>
+        <FooterArea pointerEvents="initial">
+          <Footer footer={footer} />
+        </FooterArea>
+      </Layer>
+    </ChecklistCountProvider>
   );
 }
 

--- a/packages/story-editor/src/components/canvas/navLayer.js
+++ b/packages/story-editor/src/components/canvas/navLayer.js
@@ -23,11 +23,11 @@ import Proptypes from 'prop-types';
 /**
  * Internal dependencies
  */
+import { ChecklistCountProvider } from '../checklist';
 import Footer from '../footer';
 import DirectionAware from '../directionAware';
 import PageSideMenu from './pageSideMenu';
 import { FooterArea, HeadArea, Layer, PageMenuArea, Z_INDEX } from './layout';
-import { ChecklistCountProvider } from '../checklist';
 
 function NavLayer({ header, footer }) {
   return (

--- a/packages/story-editor/src/components/checklist/countContext/checkCountContext.js
+++ b/packages/story-editor/src/components/checklist/countContext/checkCountContext.js
@@ -38,8 +38,8 @@ const INITIAL_STATE = {
   [ISSUE_TYPES.DESIGN]: {},
   [ISSUE_TYPES.ACCESSIBILITY]: {},
 };
-function ChecklistCountProvider({ children }) {
-  const value = useState(INITIAL_STATE);
+function ChecklistCountProvider({ hasChecklist, children }) {
+  const value = useState({ ...INITIAL_STATE, hasChecklist });
   return (
     <CountContext.Provider value={value}>{children}</CountContext.Provider>
   );
@@ -116,10 +116,22 @@ function useCategoryCount(category) {
   ).length;
 }
 
+function useHasChecklist() {
+  const countContext = useContext(CountContext)?.[0];
+  if (!countContext) {
+    throw new Error(
+      'Cannot use `useHasChecklist` outside of `ChecklistCountProvider`'
+    );
+  }
+  const { hasChecklist } = countContext;
+  return hasChecklist;
+}
+
 export {
   ChecklistCountProvider,
   ChecklistCategoryProvider,
   useRegisterCheck,
   useIsChecklistEmpty,
   useCategoryCount,
+  useHasChecklist,
 };

--- a/packages/story-editor/src/components/checklist/countContext/checkCountContext.js
+++ b/packages/story-editor/src/components/checklist/countContext/checkCountContext.js
@@ -46,6 +46,7 @@ function ChecklistCountProvider({ hasChecklist, children }) {
 }
 ChecklistCountProvider.propTypes = {
   children: PropTypes.node,
+  hasChecklist: PropTypes.bool,
 };
 
 function ChecklistCategoryProvider({ children, category }) {

--- a/packages/story-editor/src/components/checklist/countContext/index.js
+++ b/packages/story-editor/src/components/checklist/countContext/index.js
@@ -19,4 +19,5 @@ export {
   useRegisterCheck,
   useIsChecklistEmpty,
   useCategoryCount,
+  useHasChecklist,
 } from './checkCountContext';

--- a/packages/story-editor/src/components/checklist/countContext/test/checkCountContext.js
+++ b/packages/story-editor/src/components/checklist/countContext/test/checkCountContext.js
@@ -42,7 +42,7 @@ describe('ChecklistCategoryProvider', () => {
 
   it('provides a method to add entries', () => {
     const ChecklistWrapper = ({ children }) => (
-      <ChecklistCountProvider>
+      <ChecklistCountProvider hasChecklist>
         <ChecklistCategoryProvider category={ISSUE_TYPES.PRIORITY}>
           {children}
         </ChecklistCategoryProvider>
@@ -65,6 +65,7 @@ describe('ChecklistCategoryProvider', () => {
       },
       [ISSUE_TYPES.DESIGN]: {},
       [ISSUE_TYPES.ACCESSIBILITY]: {},
+      hasChecklist: true,
     });
   });
 });
@@ -74,7 +75,7 @@ describe('useRegisterCheck', () => {
     const testKey = 'testKey';
 
     const ChecklistWrapper = ({ children }) => (
-      <ChecklistCountProvider>
+      <ChecklistCountProvider hasChecklist>
         <ChecklistCategoryProvider category={ISSUE_TYPES.PRIORITY}>
           {children}
         </ChecklistCategoryProvider>
@@ -98,6 +99,7 @@ describe('useRegisterCheck', () => {
       },
       [ISSUE_TYPES.DESIGN]: {},
       [ISSUE_TYPES.ACCESSIBILITY]: {},
+      hasChecklist: true,
     });
 
     rerender(false);
@@ -107,6 +109,7 @@ describe('useRegisterCheck', () => {
       },
       [ISSUE_TYPES.DESIGN]: {},
       [ISSUE_TYPES.ACCESSIBILITY]: {},
+      hasChecklist: true,
     });
   });
 });

--- a/packages/story-editor/src/components/checklist/index.js
+++ b/packages/story-editor/src/components/checklist/index.js
@@ -26,6 +26,7 @@ export {
   useRegisterCheck,
   useIsChecklistEmpty,
   useCategoryCount,
+  useHasChecklist,
 } from './countContext';
 
 export { Checklist } from './checklist';

--- a/packages/story-editor/src/components/footer/secondaryMenu.js
+++ b/packages/story-editor/src/components/footer/secondaryMenu.js
@@ -27,12 +27,7 @@ import PropTypes from 'prop-types';
 import KeyboardShortcutsMenu from '../keyboardShortcutsMenu';
 import { HelpCenter } from '../helpCenter';
 import { useCanvas, useHelpCenter } from '../../app';
-import {
-  Checklist,
-  ChecklistCountProvider,
-  useChecklist,
-  useCheckpoint,
-} from '../checklist';
+import { Checklist, useChecklist, useCheckpoint } from '../checklist';
 import { useKeyboardShortcutsMenu } from '../keyboardShortcutsMenu/keyboardShortcutsMenuContext';
 import { FOOTER_MENU_GAP, FOOTER_MARGIN } from './constants';
 
@@ -186,11 +181,7 @@ function SecondaryMenu({ menu }) {
     <Wrapper>
       <MenuItems>
         <HelpCenter components={menu?.helpCenter} />
-        {menu?.checklist && (
-          <ChecklistCountProvider>
-            <Checklist items={menu.checklist} />
-          </ChecklistCountProvider>
-        )}
+        {menu?.checklist && <Checklist items={menu.checklist} />}
         <KeyboardShortcutsMenu />
       </MenuItems>
     </Wrapper>

--- a/packages/story-editor/src/components/publishModal/mainContent/checklistButton.js
+++ b/packages/story-editor/src/components/publishModal/mainContent/checklistButton.js
@@ -22,19 +22,12 @@ import { __ } from '@googleforcreators/i18n';
  * Internal dependencies
  */
 import { ISSUE_TYPES } from '../../checklist/constants';
-import {
-  useCategoryCount,
-  useHasChecklist,
-} from '../../checklist/countContext';
+import { useCategoryCount } from '../../checklist/countContext';
 import { ToggleButton } from '../../toggleButton';
 
 const ChecklistButton = ({ handleReviewChecklist }) => {
-  const hasChecklist = useHasChecklist();
-  if (!hasChecklist) {
-    return null;
-  }
-
   const priorityCount = useCategoryCount(ISSUE_TYPES.PRIORITY);
+
   return (
     <ToggleButton
       MainIcon={Icons.Checkbox}

--- a/packages/story-editor/src/components/publishModal/mainContent/checklistButton.js
+++ b/packages/story-editor/src/components/publishModal/mainContent/checklistButton.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { Icons } from '@googleforcreators/design-system';
+import { __ } from '@googleforcreators/i18n';
+/**
+ * Internal dependencies
+ */
+import { ISSUE_TYPES } from '../../checklist/constants';
+import {
+  useCategoryCount,
+  useHasChecklist,
+} from '../../checklist/countContext';
+import { ToggleButton } from '../../toggleButton';
+
+const ChecklistButton = ({ handleReviewChecklist }) => {
+  const hasChecklist = useHasChecklist();
+  if (!hasChecklist) {
+    return null;
+  }
+
+  const priorityCount = useCategoryCount(ISSUE_TYPES.PRIORITY);
+  return (
+    <ToggleButton
+      MainIcon={Icons.Checkbox}
+      label={__('Checklist', 'web-stories')}
+      aria-label={__('Checklist', 'web-stories')}
+      popupZIndexOverride={10}
+      onClick={handleReviewChecklist}
+      notificationCount={priorityCount}
+    />
+  );
+};
+
+export default ChecklistButton;

--- a/packages/story-editor/src/components/publishModal/mainContent/checklistButton.js
+++ b/packages/story-editor/src/components/publishModal/mainContent/checklistButton.js
@@ -18,6 +18,7 @@
  */
 import { Icons } from '@googleforcreators/design-system';
 import { __ } from '@googleforcreators/i18n';
+import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
@@ -41,3 +42,7 @@ const ChecklistButton = ({ handleReviewChecklist }) => {
 };
 
 export default ChecklistButton;
+
+ChecklistButton.propTypes = {
+  handleReviewChecklist: PropTypes.func,
+};

--- a/packages/story-editor/src/components/publishModal/mainContent/index.js
+++ b/packages/story-editor/src/components/publishModal/mainContent/index.js
@@ -28,6 +28,7 @@ import { HEADER_BAR_HEIGHT, HEADER_BAR_MARGIN } from '../constants';
 import MandatoryStoryInfo from './mandatoryStoryInfo';
 import StoryPreview from './storyPreview';
 import ChecklistButton from './checklistButton';
+import { useHasChecklist } from '../../checklist';
 
 const Main = styled.div`
   display: grid;
@@ -82,6 +83,7 @@ const MainContent = ({
   const { DocumentPane, id: paneId } = useInspector(
     ({ data }) => data?.modalInspectorTab || {}
   );
+  const hasChecklist = useHasChecklist();
 
   return (
     <Main>
@@ -103,9 +105,11 @@ const MainContent = ({
           <DocumentPane />
         </PanelContainer>
       )}
-      <Footer>
-        <ChecklistButton handleReviewChecklist={handleReviewChecklist} />
-      </Footer>
+      {hasChecklist && (
+        <Footer>
+          <ChecklistButton handleReviewChecklist={handleReviewChecklist} />
+        </Footer>
+      )}
     </Main>
   );
 };

--- a/packages/story-editor/src/components/publishModal/mainContent/index.js
+++ b/packages/story-editor/src/components/publishModal/mainContent/index.js
@@ -17,7 +17,6 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { Icons } from '@googleforcreators/design-system';
 import styled from 'styled-components';
 import { __ } from '@googleforcreators/i18n';
 /**
@@ -28,7 +27,7 @@ import useInspector from '../../inspector/useInspector';
 import { HEADER_BAR_HEIGHT, HEADER_BAR_MARGIN } from '../constants';
 import MandatoryStoryInfo from './mandatoryStoryInfo';
 import StoryPreview from './storyPreview';
-import { ToggleButton } from '../../toggleButton';
+import ChecklistButton from './checklistButton';
 
 const Main = styled.div`
   display: grid;
@@ -105,13 +104,7 @@ const MainContent = ({
         </PanelContainer>
       )}
       <Footer>
-        <ToggleButton
-          MainIcon={Icons.Checkbox}
-          label={__('Checklist', 'web-stories')}
-          aria-label={__('Checklist', 'web-stories')}
-          popupZIndexOverride={10}
-          onClick={handleReviewChecklist}
-        />
+        <ChecklistButton handleReviewChecklist={handleReviewChecklist} />
       </Footer>
     </Main>
   );

--- a/packages/story-editor/src/components/publishModal/mainContent/index.js
+++ b/packages/story-editor/src/components/publishModal/mainContent/index.js
@@ -17,11 +17,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import {
-  Button,
-  BUTTON_SIZES,
-  BUTTON_TYPES,
-} from '@googleforcreators/design-system';
+import { Icons } from '@googleforcreators/design-system';
 import styled from 'styled-components';
 import { __ } from '@googleforcreators/i18n';
 /**
@@ -32,6 +28,7 @@ import useInspector from '../../inspector/useInspector';
 import { HEADER_BAR_HEIGHT, HEADER_BAR_MARGIN } from '../constants';
 import MandatoryStoryInfo from './mandatoryStoryInfo';
 import StoryPreview from './storyPreview';
+import { ToggleButton } from '../../toggleButton';
 
 const Main = styled.div`
   display: grid;
@@ -108,13 +105,13 @@ const MainContent = ({
         </PanelContainer>
       )}
       <Footer>
-        <Button
-          type={BUTTON_TYPES.PRIMARY}
-          size={BUTTON_SIZES.SMALL}
+        <ToggleButton
+          MainIcon={Icons.Checkbox}
+          label={__('Checklist', 'web-stories')}
+          aria-label={__('Checklist', 'web-stories')}
+          popupZIndexOverride={10}
           onClick={handleReviewChecklist}
-        >
-          {__('Checklist', 'web-stories')}
-        </Button>
+        />
       </Footer>
     </Main>
   );

--- a/packages/story-editor/src/components/publishModal/mainContent/index.js
+++ b/packages/story-editor/src/components/publishModal/mainContent/index.js
@@ -24,11 +24,11 @@ import { __ } from '@googleforcreators/i18n';
  */
 import { MANDATORY_INPUT_VALUE_TYPES } from '../types';
 import useInspector from '../../inspector/useInspector';
+import { useHasChecklist } from '../../checklist';
 import { HEADER_BAR_HEIGHT, HEADER_BAR_MARGIN } from '../constants';
 import MandatoryStoryInfo from './mandatoryStoryInfo';
 import StoryPreview from './storyPreview';
 import ChecklistButton from './checklistButton';
-import { useHasChecklist } from '../../checklist';
 
 const Main = styled.div`
   display: grid;

--- a/packages/story-editor/src/components/publishModal/stories/index.js
+++ b/packages/story-editor/src/components/publishModal/stories/index.js
@@ -22,7 +22,7 @@ import { useCallback, useState } from '@googleforcreators/react';
  */
 import StoryContext from '../../../app/story/context';
 import { noop } from '../../../utils/noop';
-import { CheckpointContext } from '../../checklist';
+import { ChecklistCountProvider, CheckpointContext } from '../../checklist';
 import InspectorContext from '../../inspector/context';
 import { PageAdvancementPanel, SlugPanel } from '../../panels/document';
 import PublishModal from '../publishModal';
@@ -37,6 +37,7 @@ export default {
   title: 'Stories Editor/Components/Dialog/Publish Modal',
   args: {
     isOpen: true,
+    hasChecklist: true,
   },
   argTypes: {
     onPublish: { action: 'onPublish clicked' },
@@ -96,7 +97,9 @@ export const _default = (args) => {
             },
           }}
         >
-          <PublishModal {...args} />
+          <ChecklistCountProvider hasChecklist={args.hasChecklist}>
+            <PublishModal {...args} />
+          </ChecklistCountProvider>
         </InspectorContext.Provider>
       </CheckpointContext.Provider>
     </StoryContext.Provider>

--- a/packages/story-editor/src/components/publishModal/test/mainContent.js
+++ b/packages/story-editor/src/components/publishModal/test/mainContent.js
@@ -22,6 +22,7 @@ import { axe } from 'jest-axe';
  * Internal dependencies
  */
 import renderWithTheme from '../../../testUtils/renderWithTheme';
+import { ChecklistCountProvider } from '../../checklist';
 import InspectorContext from '../../inspector/context';
 import { INPUT_KEYS } from '../constants';
 import MainContent from '../mainContent';
@@ -55,11 +56,13 @@ describe('publishModal/mainContent', () => {
   const view = () => {
     return renderWithTheme(
       <InspectorContext.Provider value={inspectorContextValue}>
-        <MainContent
-          handleUpdateStoryInfo={mockHandleUpdateStoryInfo}
-          handleUpdateSlug={mockHandleUpdateSlug}
-          inputValues={mockInputValues}
-        />
+        <ChecklistCountProvider hasChecklist>
+          <MainContent
+            handleUpdateStoryInfo={mockHandleUpdateStoryInfo}
+            handleUpdateSlug={mockHandleUpdateSlug}
+            inputValues={mockInputValues}
+          />
+        </ChecklistCountProvider>
       </InspectorContext.Provider>
     );
   };

--- a/packages/story-editor/src/components/toggleButton/index.js
+++ b/packages/story-editor/src/components/toggleButton/index.js
@@ -61,7 +61,15 @@ const NotificationCount = styled(Text).attrs({ as: 'span' })`
 
 export const ToggleButton = forwardRef(
   (
-    { isOpen = false, notificationCount, MainIcon, label, shortcut, ...rest },
+    {
+      isOpen = false,
+      notificationCount = 0,
+      MainIcon,
+      label,
+      shortcut,
+      popupZIndexOverride,
+      ...rest
+    },
     ref
   ) => {
     const hasNotifications = notificationCount > 0;
@@ -71,6 +79,7 @@ export const ToggleButton = forwardRef(
         title={label}
         placement={TOOLTIP_PLACEMENT.TOP}
         shortcut={shortcut}
+        popupZIndexOverride={popupZIndexOverride}
       >
         <Button
           ref={ref}
@@ -104,4 +113,5 @@ ToggleButton.propTypes = {
   MainIcon: PropTypes.object.isRequired,
   notificationCount: PropTypes.number,
   shortcut: PropTypes.string,
+  popupZIndexOverride: PropTypes.number,
 };


### PR DESCRIPTION
## Context

Part of the story details modal feature.

## Summary

Updates the button style that opens checklist from detail story modal. It should be an icon with a tooltip, not a button that says "checklist"

## Relevant Technical Choices

Use `ToggleButton` from footer for checklist button in modal, works the same just doesn't "toggle", the UI is what we want to match. Pass in optional popupZIndexOverride to account for our popup in a popup situation like other tooltips in modal.
- Move `ChecklistCountProvider` up out of footer and into canvas `NavLayer` - that is the nearest component to both header and footer - so that i can access checklist count in modal. 
- Add one new value to state in checklist count context called `hasChecklist`, I need to know if the checklist even exists in the header and i don't want to pass through the raw component as that is overkill - so by checking if the component is getting threaded through from `wp-story-editor` in `checklistCountProvider` I can call the new hook I wrote called `useHasChecklist` to grab a boolean that tells me if i should bother grabbing the checklist count and rendering the button in the modal. Will add e2e test separately.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

Detail story modal now has a checklist button that shows the checklist icon and a tooltip (see video) AND it is tracking the priority issues present in the story just like the checklist's toggle button. Figma doesn't show that, this was a change in design directive today verified in slack - I think it's good to have the continuity. 

https://user-images.githubusercontent.com/10720454/154359177-e379cf60-c406-478b-ac20-a8ff32b28509.mp4

<img width="488" alt="Screen Shot 2022-02-16 at 4 51 21 PM" src="https://user-images.githubusercontent.com/10720454/154377049-3a49096b-4152-4c2b-b741-5d96a7b26a45.png">


## Testing Instructions

Verify that the checklist button in the story details modal (experiment turned out) looks like the above. Clicking it closes the modal and opens the checklist.

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Partially addresses #10115 
