### PR TITLE
Links: Add special handling for Instagram when retrieving metadata

### DIFF
--- a/includes/REST_API/Link_Controller.php
+++ b/includes/REST_API/Link_Controller.php
@@ -165,7 +165,7 @@ class Link_Controller extends REST_Controller implements HasRequirements {
 		// See https://github.com/GoogleForCreators/web-stories-wp/issues/10451.
 		$matches      = [];
 		$query_string = wp_parse_url( $url, PHP_URL_QUERY );
-		$check_url    = str_replace( "?$query_string", '', $url );
+		$check_url    = \is_string( $query_string ) ? str_replace( "?$query_string", '', $url ) : $url;
 		if ( preg_match( '~^https?://(www\.)?instagram\.com/([^/]+)/?$~', $check_url, $matches ) ) {
 			$data['title'] = sprintf(
 				/* translators: %s: Instagram username. */

--- a/includes/REST_API/Link_Controller.php
+++ b/includes/REST_API/Link_Controller.php
@@ -161,10 +161,21 @@ class Link_Controller extends REST_Controller implements HasRequirements {
 			'description' => '',
 		];
 
+		// Do not request instagram.com, as it redirects to a login page.
+		// See https://github.com/GoogleForCreators/web-stories-wp/issues/10451.
+		$url_host = wp_parse_url( $url, PHP_URL_HOST );
+		if ( \is_string( $url_host ) && false !== strpos( $url_host, 'instagram.com' ) ) {
+			set_transient( $cache_key, wp_json_encode( $data ), $cache_ttl );
+			$response = $this->prepare_item_for_response( $data, $request );
+
+			return rest_ensure_response( $response );
+		}
+
 		$args = [
 			'limit_response_size' => 153600, // 150 KB.
 			'timeout'             => 7, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 		];
+
 
 		/**
 		 * Filters the HTTP request args for link data retrieval.

--- a/includes/REST_API/Link_Controller.php
+++ b/includes/REST_API/Link_Controller.php
@@ -163,22 +163,17 @@ class Link_Controller extends REST_Controller implements HasRequirements {
 
 		// Do not request instagram.com, as it redirects to a login page.
 		// See https://github.com/GoogleForCreators/web-stories-wp/issues/10451.
-		$parse_url = wp_parse_url( $url );
-		if ( \is_array( $parse_url ) ) {
-			$url_host    = (string) str_replace( 'www.', '', $parse_url['host'] ?? '' );
-			$path_pieces = explode( '/', $parse_url['path'] ?? '' );
-			$path_pieces = array_filter( $path_pieces );
-			if ( \count( $path_pieces ) === 1 && false !== strpos( $url_host, 'instagram.com' ) ) {
-				$data['title'] = sprintf(
-					/* translators: %s: Instagram username. */
-					__( 'Instagram - @%s', 'web-stories' ),
-					array_shift( $path_pieces )
-				);
-				set_transient( $cache_key, wp_json_encode( $data ), $cache_ttl );
-				$response = $this->prepare_item_for_response( $data, $request );
+		$matches = [];
+		if ( preg_match( '~^https?://(www\.)?instagram\.com/(.*)/?$~', $url, $matches ) ) {
+			$data['title'] = sprintf(
+				/* translators: %s: Instagram username. */
+				__( 'Instagram - @%s', 'web-stories' ),
+				$matches[2]
+			);
+			set_transient( $cache_key, wp_json_encode( $data ), $cache_ttl );
+			$response = $this->prepare_item_for_response( $data, $request );
 
-				return rest_ensure_response( $response );
-			}
+			return rest_ensure_response( $response );
 		}
 
 		$args = [

--- a/includes/REST_API/Link_Controller.php
+++ b/includes/REST_API/Link_Controller.php
@@ -164,7 +164,7 @@ class Link_Controller extends REST_Controller implements HasRequirements {
 		// Do not request instagram.com, as it redirects to a login page.
 		// See https://github.com/GoogleForCreators/web-stories-wp/issues/10451.
 		$matches = [];
-		if ( preg_match( '~^https?://(www\.)?instagram\.com/(.*)/?$~', $url, $matches ) ) {
+		if ( preg_match( '~^https?://(www\.)?instagram\.com/([^/]+)/?$~', $url, $matches ) ) {
 			$data['title'] = sprintf(
 				/* translators: %s: Instagram username. */
 				__( 'Instagram - @%s', 'web-stories' ),

--- a/includes/REST_API/Link_Controller.php
+++ b/includes/REST_API/Link_Controller.php
@@ -163,8 +163,10 @@ class Link_Controller extends REST_Controller implements HasRequirements {
 
 		// Do not request instagram.com, as it redirects to a login page.
 		// See https://github.com/GoogleForCreators/web-stories-wp/issues/10451.
-		$matches = [];
-		if ( preg_match( '~^https?://(www\.)?instagram\.com/([^/]+)/?$~', $url, $matches ) ) {
+		$matches      = [];
+		$query_string = wp_parse_url( $url, PHP_URL_QUERY );
+		$check_url    = str_replace( "?$query_string", '', $url );
+		if ( preg_match( '~^https?://(www\.)?instagram\.com/([^/]+)/?$~', $check_url, $matches ) ) {
 			$data['title'] = sprintf(
 				/* translators: %s: Instagram username. */
 				__( 'Instagram - @%s', 'web-stories' ),

--- a/includes/REST_API/Link_Controller.php
+++ b/includes/REST_API/Link_Controller.php
@@ -176,7 +176,6 @@ class Link_Controller extends REST_Controller implements HasRequirements {
 			'timeout'             => 7, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 		];
 
-
 		/**
 		 * Filters the HTTP request args for link data retrieval.
 		 *

--- a/tests/phpunit/integration/tests/REST_API/Link_Controller.php
+++ b/tests/phpunit/integration/tests/REST_API/Link_Controller.php
@@ -105,15 +105,6 @@ class Link_Controller extends DependencyInjectedRestTestCase {
 			];
 		}
 
-		if ( false !== strpos( $url, self::URL_INSTAGRAM ) ) {
-			return [
-				'response' => [
-					'code' => 200,
-				],
-				'body'     => '<html></html>',
-			];
-		}
-
 		if ( false !== strpos( $url, self::URL_CHARACTERS ) ) {
 			return [
 				'response' => [
@@ -302,7 +293,7 @@ class Link_Controller extends DependencyInjectedRestTestCase {
 		// Subsequent requests is cached and so it should not cause a request.
 		rest_get_server()->dispatch( $request );
 
-		$this->assertEquals( 1, $this->request_count );
+		$this->assertEquals( 0, $this->request_count );
 		$this->assertNotEmpty( $data );
 		$this->assertEqualSetsWithIndex( $expected, $data );
 	}

--- a/tests/phpunit/integration/tests/REST_API/Link_Controller.php
+++ b/tests/phpunit/integration/tests/REST_API/Link_Controller.php
@@ -24,6 +24,7 @@ class Link_Controller extends DependencyInjectedRestTestCase {
 	public const URL_EMPTY_DOCUMENT   = 'https://example.com/empty';
 	public const URL_VALID_TITLE_ONLY = 'https://example.com';
 	public const URL_VALID            = 'https://amp.dev';
+	public const URL_INSTAGRAM        = 'https://www.instagram.com/googleforcreators';
 
 	/**
 	 * Count of the number of requests attempted.
@@ -96,6 +97,15 @@ class Link_Controller extends DependencyInjectedRestTestCase {
 		}
 
 		if ( false !== strpos( $url, self::URL_EMPTY_DOCUMENT ) ) {
+			return [
+				'response' => [
+					'code' => 200,
+				],
+				'body'     => '<html></html>',
+			];
+		}
+
+		if ( false !== strpos( $url, self::URL_INSTAGRAM ) ) {
 			return [
 				'response' => [
 					'code' => 200,
@@ -193,6 +203,9 @@ class Link_Controller extends DependencyInjectedRestTestCase {
 		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 	}
 
+	/**
+	 * @covers ::parse_link
+	 */
 	public function test_url_returning_500(): void {
 		$this->controller->register();
 
@@ -204,6 +217,9 @@ class Link_Controller extends DependencyInjectedRestTestCase {
 		$this->assertErrorResponse( 'rest_invalid_url', $response, 404 );
 	}
 
+	/**
+	 * @covers ::parse_link
+	 */
 	public function test_url_returning_404(): void {
 		$this->controller->register();
 
@@ -224,6 +240,9 @@ class Link_Controller extends DependencyInjectedRestTestCase {
 		);
 	}
 
+	/**
+	 * @covers ::parse_link
+	 */
 	public function test_url_empty_string(): void {
 		$this->controller->register();
 
@@ -236,6 +255,9 @@ class Link_Controller extends DependencyInjectedRestTestCase {
 		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 	}
 
+	/**
+	 * @covers ::parse_link
+	 */
 	public function test_empty_url(): void {
 		$this->controller->register();
 
@@ -259,6 +281,35 @@ class Link_Controller extends DependencyInjectedRestTestCase {
 		$this->assertEqualSetsWithIndex( $expected, $data );
 	}
 
+	/**
+	 * @covers ::parse_link
+	 */
+	public function test_instagram_url(): void {
+		$this->controller->register();
+
+		wp_set_current_user( self::$editor );
+		$request = new WP_REST_Request( WP_REST_Server::READABLE, '/web-stories/v1/link' );
+		$request->set_param( 'url', self::URL_INSTAGRAM );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$expected = [
+			'title'       => '',
+			'image'       => '',
+			'description' => '',
+		];
+
+		// Subsequent requests is cached and so it should not cause a request.
+		rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 1, $this->request_count );
+		$this->assertNotEmpty( $data );
+		$this->assertEqualSetsWithIndex( $expected, $data );
+	}
+
+	/**
+	 * @covers ::parse_link
+	 */
 	public function test_characters_url(): void {
 		$this->controller->register();
 
@@ -282,6 +333,9 @@ class Link_Controller extends DependencyInjectedRestTestCase {
 		$this->assertEqualSetsWithIndex( $expected, $data );
 	}
 
+	/**
+	 * @covers ::parse_link
+	 */
 	public function test_example_url(): void {
 		$this->controller->register();
 
@@ -305,6 +359,9 @@ class Link_Controller extends DependencyInjectedRestTestCase {
 		$this->assertEqualSetsWithIndex( $expected, $data );
 	}
 
+	/**
+	 * @covers ::parse_link
+	 */
 	public function test_valid_url(): void {
 		$this->controller->register();
 
@@ -328,6 +385,9 @@ class Link_Controller extends DependencyInjectedRestTestCase {
 		$this->assertEqualSetsWithIndex( $expected, $data );
 	}
 
+	/**
+	 * @covers ::parse_link
+	 */
 	public function test_removes_trailing_slashes(): void {
 		$this->controller->register();
 

--- a/tests/phpunit/integration/tests/REST_API/Link_Controller.php
+++ b/tests/phpunit/integration/tests/REST_API/Link_Controller.php
@@ -287,7 +287,7 @@ class Link_Controller extends DependencyInjectedRestTestCase {
 	 * @covers ::parse_link
 	 * @dataProvider data_instagram_urls
 	 */
-	public function test_instagram_urls( $url, $expected, $num ): void {
+	public function test_instagram_urls( $url, $expected, $request_count ): void {
 		$this->controller->register();
 
 		wp_set_current_user( self::$editor );
@@ -299,7 +299,7 @@ class Link_Controller extends DependencyInjectedRestTestCase {
 		// Subsequent requests is cached and so it should not cause a request.
 		rest_get_server()->dispatch( $request );
 
-		$this->assertEquals( $num, $this->request_count );
+		$this->assertEquals( $request_count, $this->request_count );
 		$this->assertNotEmpty( $data );
 		$this->assertEqualSetsWithIndex( $expected, $data );
 	}
@@ -307,58 +307,67 @@ class Link_Controller extends DependencyInjectedRestTestCase {
 	public function data_instagram_urls(): array {
 		return [
 			'Instagram profile url'                   => [
-				'url'      => self::URL_INSTAGRAM,
-				'expected' => [
+				'url'           => self::URL_INSTAGRAM,
+				'expected'      => [
 					'title'       => 'Instagram - @googleforcreators',
 					'image'       => '',
 					'description' => '',
 				],
-				'num'      => 0,
+				'request_count' => 0,
 			],
 			'Instagram profile url with slash'        => [
-				'url'      => self::URL_INSTAGRAM . '/',
-				'expected' => [
+				'url'           => self::URL_INSTAGRAM . '/',
+				'expected'      => [
 					'title'       => 'Instagram - @googleforcreators',
 					'image'       => '',
 					'description' => '',
 				],
-				'num'      => 0,
+				'request_count' => 0,
 			],
 			'Instagram profile url with query string' => [
-				'url'      => self::URL_INSTAGRAM . '/?hl=en',
-				'expected' => [
+				'url'           => self::URL_INSTAGRAM . '/?hl=en',
+				'expected'      => [
 					'title'       => 'Instagram - @googleforcreators',
 					'image'       => '',
 					'description' => '',
 				],
-				'num'      => 0,
+				'request_count' => 0,
 			],
-			'Instagram profile url with query longer string' => [
-				'url'      => self::URL_INSTAGRAM . '/?hl=en&qs=2',
-				'expected' => [
+			'Instagram profile url with longer query string' => [
+				'url'           => self::URL_INSTAGRAM . '/?hl=en&qs=2',
+				'expected'      => [
 					'title'       => 'Instagram - @googleforcreators',
 					'image'       => '',
 					'description' => '',
 				],
-				'num'      => 0,
+				'request_count' => 0,
+			],
+			'Instagram profile url with double query string' => [
+				'url'           => self::URL_INSTAGRAM . '/?hl=en&qs=2?web=2',
+				'expected'      => [
+					'title'       => 'Instagram - @googleforcreators',
+					'image'       => '',
+					'description' => '',
+				],
+				'request_count' => 0,
 			],
 			'Instagram photo url'                     => [
-				'url'      => self::URL_INSTAGRAM_SINGLE,
-				'expected' => [
+				'url'           => self::URL_INSTAGRAM_SINGLE,
+				'expected'      => [
 					'title'       => '',
 					'image'       => '',
 					'description' => '',
 				],
-				'num'      => 1,
+				'request_count' => 1,
 			],
 			'Instagram subdomain'                     => [
-				'url'      => self::URL_INSTAGRAM_SUBDOMAIN,
-				'expected' => [
+				'url'           => self::URL_INSTAGRAM_SUBDOMAIN,
+				'expected'      => [
 					'title'       => '',
 					'image'       => '',
 					'description' => '',
 				],
-				'num'      => 1,
+				'request_count' => 1,
 			],
 		];
 	}

--- a/tests/phpunit/integration/tests/REST_API/Link_Controller.php
+++ b/tests/phpunit/integration/tests/REST_API/Link_Controller.php
@@ -285,106 +285,82 @@ class Link_Controller extends DependencyInjectedRestTestCase {
 
 	/**
 	 * @covers ::parse_link
+	 * @dataProvider data_instagram_urls
 	 */
-	public function test_instagram_url(): void {
+	public function test_instagram_urls( $url, $expected, $num ): void {
 		$this->controller->register();
 
 		wp_set_current_user( self::$editor );
 		$request = new WP_REST_Request( WP_REST_Server::READABLE, '/web-stories/v1/link' );
-		$request->set_param( 'url', self::URL_INSTAGRAM );
+		$request->set_param( 'url', $url );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
-
-		$expected = [
-			'title'       => 'Instagram - @googleforcreators',
-			'image'       => '',
-			'description' => '',
-		];
 
 		// Subsequent requests is cached and so it should not cause a request.
 		rest_get_server()->dispatch( $request );
 
-		$this->assertEquals( 0, $this->request_count );
+		$this->assertEquals( $num, $this->request_count );
 		$this->assertNotEmpty( $data );
 		$this->assertEqualSetsWithIndex( $expected, $data );
 	}
 
-	/**
-	 * @covers ::parse_link
-	 */
-	public function test_instagram_url_with_slash(): void {
-		$this->controller->register();
-
-		wp_set_current_user( self::$editor );
-		$request = new WP_REST_Request( WP_REST_Server::READABLE, '/web-stories/v1/link' );
-		$request->set_param( 'url', self::URL_INSTAGRAM . '/' );
-		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
-
-		$expected = [
-			'title'       => 'Instagram - @googleforcreators',
-			'image'       => '',
-			'description' => '',
+	public function data_instagram_urls(): array {
+		return [
+			'Instagram profile url'                   => [
+				'url'      => self::URL_INSTAGRAM,
+				'expected' => [
+					'title'       => 'Instagram - @googleforcreators',
+					'image'       => '',
+					'description' => '',
+				],
+				'num'      => 0,
+			],
+			'Instagram profile url with slash'        => [
+				'url'      => self::URL_INSTAGRAM . '/',
+				'expected' => [
+					'title'       => 'Instagram - @googleforcreators',
+					'image'       => '',
+					'description' => '',
+				],
+				'num'      => 0,
+			],
+			'Instagram profile url with query string' => [
+				'url'      => self::URL_INSTAGRAM . '/?hl=en',
+				'expected' => [
+					'title'       => 'Instagram - @googleforcreators',
+					'image'       => '',
+					'description' => '',
+				],
+				'num'      => 0,
+			],
+			'Instagram profile url with query longer string' => [
+				'url'      => self::URL_INSTAGRAM . '/?hl=en&qs=2',
+				'expected' => [
+					'title'       => 'Instagram - @googleforcreators',
+					'image'       => '',
+					'description' => '',
+				],
+				'num'      => 0,
+			],
+			'Instagram photo url'                     => [
+				'url'      => self::URL_INSTAGRAM_SINGLE,
+				'expected' => [
+					'title'       => '',
+					'image'       => '',
+					'description' => '',
+				],
+				'num'      => 1,
+			],
+			'Instagram subdomain'                     => [
+				'url'      => self::URL_INSTAGRAM_SUBDOMAIN,
+				'expected' => [
+					'title'       => '',
+					'image'       => '',
+					'description' => '',
+				],
+				'num'      => 1,
+			],
 		];
-
-		// Subsequent requests is cached and so it should not cause a request.
-		rest_get_server()->dispatch( $request );
-
-		$this->assertEquals( 0, $this->request_count );
-		$this->assertNotEmpty( $data );
-		$this->assertEqualSetsWithIndex( $expected, $data );
-	}
-
-	/**
-	 * @covers ::parse_link
-	 */
-	public function test_instagram_single_url(): void {
-		$this->controller->register();
-
-		wp_set_current_user( self::$editor );
-		$request = new WP_REST_Request( WP_REST_Server::READABLE, '/web-stories/v1/link' );
-		$request->set_param( 'url', self::URL_INSTAGRAM_SINGLE );
-		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
-
-		$expected = [
-			'title'       => '',
-			'image'       => '',
-			'description' => '',
-		];
-
-		// Subsequent requests is cached and so it should not cause a request.
-		rest_get_server()->dispatch( $request );
-
-		$this->assertEquals( 1, $this->request_count );
-		$this->assertNotEmpty( $data );
-		$this->assertEqualSetsWithIndex( $expected, $data );
-	}
-
-	/**
-	 * @covers ::parse_link
-	 */
-	public function test_instagram_subdomain_url(): void {
-		$this->controller->register();
-
-		wp_set_current_user( self::$editor );
-		$request = new WP_REST_Request( WP_REST_Server::READABLE, '/web-stories/v1/link' );
-		$request->set_param( 'url', self::URL_INSTAGRAM_SUBDOMAIN );
-		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
-
-		$expected = [
-			'title'       => '',
-			'image'       => '',
-			'description' => '',
-		];
-
-		// Subsequent requests is cached and so it should not cause a request.
-		rest_get_server()->dispatch( $request );
-
-		$this->assertEquals( 1, $this->request_count );
-		$this->assertNotEmpty( $data );
-		$this->assertEqualSetsWithIndex( $expected, $data );
 	}
 
 	/**


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Add a special workaround for instagram based urls in link preview. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Create a story. 
2. Insert a image element. 
3. Add an instagram link to image element. Example: https://www.instagram.com/googleforcreators
4. See title `Instagram - @googleforcreators` or and no link icon


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10451
