### PR TITLE
New Story Details Modal: Sync Publish Button Text

### DIFF
--- a/packages/story-editor/src/components/header/buttons/publish.js
+++ b/packages/story-editor/src/components/header/buttons/publish.js
@@ -146,6 +146,7 @@ function PublishButton({ forceIsSaving }) {
           isOpen={showDialog}
           onPublish={publish}
           onClose={closeDialog}
+          publishButtonCopy={text}
         />
       ) : (
         <ReviewChecklistDialog

--- a/packages/story-editor/src/components/publishModal/header/index.js
+++ b/packages/story-editor/src/components/publishModal/header/index.js
@@ -54,7 +54,12 @@ const PublishButton = styled(Button)`
   margin: 6px 6px 5px auto;
 `;
 
-const Header = ({ isPublishEnabled, onClose, onPublish }) => {
+const Header = ({
+  isPublishEnabled,
+  onClose,
+  onPublish,
+  publishButtonCopy,
+}) => {
   return (
     <_Header>
       <CloseButton
@@ -79,7 +84,7 @@ const Header = ({ isPublishEnabled, onClose, onPublish }) => {
         disabled={!isPublishEnabled}
         onClick={onPublish}
       >
-        {__('Publish', 'web-stories')}
+        {publishButtonCopy}
       </PublishButton>
     </_Header>
   );
@@ -91,4 +96,5 @@ Header.propTypes = {
   isPublishEnabled: PropTypes.bool,
   onClose: PropTypes.func.isRequired,
   onPublish: PropTypes.func.isRequired,
+  publishButtonCopy: PropTypes.string.isRequired,
 };

--- a/packages/story-editor/src/components/publishModal/karma/publishModal.karma.js
+++ b/packages/story-editor/src/components/publishModal/karma/publishModal.karma.js
@@ -139,10 +139,6 @@ describe('Publish Story Modal', () => {
       expect(typeof autoInput.getAttribute('checked')).toBe('string');
       expect(manualInput.getAttribute('checked')).toBeNull();
     });
-    // TODO when visible panel update is done
-    // it('should update publish button copy from "Publish" to "Schedule" when future date is selected for publish', () => {
-
-    // })
   });
 
   describe('Keyboard navigation', () => {

--- a/packages/story-editor/src/components/publishModal/karma/publishModal.karma.js
+++ b/packages/story-editor/src/components/publishModal/karma/publishModal.karma.js
@@ -139,6 +139,10 @@ describe('Publish Story Modal', () => {
       expect(typeof autoInput.getAttribute('checked')).toBe('string');
       expect(manualInput.getAttribute('checked')).toBeNull();
     });
+    // TODO when visible panel update is done
+    // it('should update publish button copy from "Publish" to "Schedule" when future date is selected for publish', () => {
+
+    // })
   });
 
   describe('Keyboard navigation', () => {

--- a/packages/story-editor/src/components/publishModal/publishModal.js
+++ b/packages/story-editor/src/components/publishModal/publishModal.js
@@ -134,4 +134,5 @@ PublishModal.propTypes = {
   isOpen: PropTypes.bool,
   onPublish: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
+  publishButtonCopy: PropTypes.string.isRequired,
 };

--- a/packages/story-editor/src/components/publishModal/publishModal.js
+++ b/packages/story-editor/src/components/publishModal/publishModal.js
@@ -41,7 +41,7 @@ const Container = styled.div`
   border-radius: ${({ theme }) => theme.borders.radius.medium};
 `;
 
-function PublishModal({ isOpen, onPublish, onClose }) {
+function PublishModal({ isOpen, onPublish, onClose, publishButtonCopy }) {
   const storyId = useConfig(({ storyId }) => storyId);
   const updateStory = useStory(({ actions }) => actions.updateStory);
   const inputValues = useStory(({ state: { story } }) => ({
@@ -110,6 +110,7 @@ function PublishModal({ isOpen, onPublish, onClose }) {
         <DirectionAware>
           <Container>
             <Header
+              publishButtonCopy={publishButtonCopy}
               onClose={onClose}
               onPublish={onPublish}
               isPublishEnabled={isAllRequiredInputsFulfilled}

--- a/packages/story-editor/src/components/publishModal/stories/index.js
+++ b/packages/story-editor/src/components/publishModal/stories/index.js
@@ -37,6 +37,7 @@ const MockDocumentPane = () => (
 export default {
   title: 'Stories Editor/Components/Dialog/Publish Modal',
   args: {
+    publishButtonCopy: 'Publish',
     isOpen: true,
     hasChecklist: true,
     publisher: 'Gotham Bugle',

--- a/packages/story-editor/src/components/publishModal/test/header.js
+++ b/packages/story-editor/src/components/publishModal/test/header.js
@@ -38,6 +38,7 @@ describe('publishModal/header', () => {
         isPublishEnabled
         onClose={mockOnClose}
         onPublish={mockOnPublish}
+        publishButtonCopy="Publish"
       />
     );
 
@@ -51,6 +52,7 @@ describe('publishModal/header', () => {
         isPublishEnabled
         onClose={mockOnClose}
         onPublish={mockOnPublish}
+        publishButtonCopy="Publish"
       />
     );
 
@@ -66,6 +68,7 @@ describe('publishModal/header', () => {
         isPublishEnabled={false}
         onClose={mockOnClose}
         onPublish={mockOnPublish}
+        publishButtonCopy="Publish"
       />
     );
 
@@ -81,6 +84,7 @@ describe('publishModal/header', () => {
         isPublishEnabled
         onClose={mockOnClose}
         onPublish={mockOnPublish}
+        publishButtonCopy="Publish"
       />
     );
 


### PR DESCRIPTION
## Context

Part of the story details modal feature.

## Summary

Story Details Modal Publish button should say "Schedule" when publish date is in the future. 

## Relevant Technical Choices

pass publish button copy from header to modal to keep them in sync without duplicating checks


## To-do

## User-facing changes

| 👎  | 👍  |
| --- | --- | 
| <img width="426" alt="Screen Shot 2022-02-17 at 3 50 19 PM" src="https://user-images.githubusercontent.com/10720454/154584708-24744db4-b80d-4bcd-b54f-98c9f51c5ea4.png"> | <img width="471" alt="Screen Shot 2022-02-17 at 3 47 33 PM" src="https://user-images.githubusercontent.com/10720454/154584727-f4432863-2421-46bf-8886-aab260331eb3.png"> |

## Testing Instructions

Change a draft story's publish date to the future and see both dialog publish button and header publish button copy stay in sync. Reset the publish date and see that it remains in sync. 

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Partially addresses #10115 
