### PR TITLE
New Story Details Modal: Consistent Input Updating

### DIFF
--- a/packages/story-editor/src/components/publishModal/karma/publishModal.karma.js
+++ b/packages/story-editor/src/components/publishModal/karma/publishModal.karma.js
@@ -70,12 +70,15 @@ describe('Publish Story Modal', () => {
       const storyTitle = await getPublishModalElement('textbox', 'Story Title');
       await fixture.events.focus(storyTitle);
       await fixture.events.keyboard.type('my test story');
+      await fixture.events.keyboard.press('tab');
+
       const storyDescription = await getPublishModalElement(
         'textbox',
         'Story Description'
       );
       await fixture.events.focus(storyDescription);
       await fixture.events.keyboard.type('my test description for my story');
+      await fixture.events.keyboard.press('tab');
 
       publishButton = await getPublishModalElement('button', 'Publish');
       expect(publishButton.getAttribute('disabled')).toBeNull();

--- a/packages/story-editor/src/components/publishModal/mainContent/index.js
+++ b/packages/story-editor/src/components/publishModal/mainContent/index.js
@@ -77,7 +77,6 @@ const Footer = styled.div`
 const MainContent = ({
   handleReviewChecklist,
   handleUpdateStoryInfo,
-  handleUpdateSlug,
   inputValues,
 }) => {
   const { DocumentPane, id: paneId } = useInspector(
@@ -93,7 +92,6 @@ const MainContent = ({
       <_MandatoryStoryInfo>
         <MandatoryStoryInfo
           handleUpdateStoryInfo={handleUpdateStoryInfo}
-          handleUpdateSlug={handleUpdateSlug}
           inputValues={inputValues}
         />
       </_MandatoryStoryInfo>
@@ -119,6 +117,5 @@ export default MainContent;
 MainContent.propTypes = {
   handleReviewChecklist: PropTypes.func,
   handleUpdateStoryInfo: PropTypes.func,
-  handleUpdateSlug: PropTypes.func,
-  inputValues: MANDATORY_INPUT_VALUE_TYPES, // update types when panel is figured out
+  inputValues: MANDATORY_INPUT_VALUE_TYPES,
 };

--- a/packages/story-editor/src/components/publishModal/mainContent/mandatoryStoryInfo.js
+++ b/packages/story-editor/src/components/publishModal/mainContent/mandatoryStoryInfo.js
@@ -16,6 +16,7 @@
 /**
  * External dependencies
  */
+import { useCallback, useState } from '@googleforcreators/react';
 import PropTypes from 'prop-types';
 import { TextArea } from '@googleforcreators/design-system';
 import styled from 'styled-components';
@@ -38,12 +39,19 @@ const _TextArea = styled(TextArea)`
 
 const MandatoryStoryInfo = ({
   handleUpdateStoryInfo,
-  handleUpdateSlug,
-  inputValues,
+  inputValues: _inputValues,
 }) => {
+  const [inputValues, setInputValues] = useState(_inputValues);
   const IsolatedStatusPanel = useInspector(
     ({ data }) => data?.modalInspectorTab?.IsolatedStatusPanel
   );
+
+  const onInputChange = ({ currentTarget }) => {
+    setInputValues((prev) => ({
+      ...prev,
+      [currentTarget.name]: currentTarget.value,
+    }));
+  };
   return (
     <>
       <FormSection>
@@ -57,8 +65,8 @@ const MandatoryStoryInfo = ({
           showCount
           maxLength={300}
           value={inputValues[INPUT_KEYS.TITLE]}
-          onChange={handleUpdateStoryInfo}
-          onBlur={handleUpdateSlug}
+          onChange={onInputChange}
+          onBlur={handleUpdateStoryInfo}
           aria-label={__('Story Title', 'web-stories')}
           placeholder={__('Add title', 'web-stories')}
         />
@@ -80,7 +88,8 @@ const MandatoryStoryInfo = ({
             'Stories with a description tend to do better on search and have a wider reach',
             'web-stories'
           )}
-          onChange={handleUpdateStoryInfo}
+          onChange={onInputChange}
+          onBlur={handleUpdateStoryInfo}
         />
       </FormSection>
       {IsolatedStatusPanel && <IsolatedStatusPanel />}

--- a/packages/story-editor/src/components/publishModal/mainContent/mandatoryStoryInfo.js
+++ b/packages/story-editor/src/components/publishModal/mainContent/mandatoryStoryInfo.js
@@ -16,7 +16,7 @@
 /**
  * External dependencies
  */
-import { useCallback, useState } from '@googleforcreators/react';
+import { useState } from '@googleforcreators/react';
 import PropTypes from 'prop-types';
 import { TextArea } from '@googleforcreators/design-system';
 import styled from 'styled-components';
@@ -101,6 +101,5 @@ export default MandatoryStoryInfo;
 
 MandatoryStoryInfo.propTypes = {
   handleUpdateStoryInfo: PropTypes.func,
-  handleUpdateSlug: PropTypes.func,
   inputValues: MANDATORY_INPUT_VALUE_TYPES,
 };

--- a/packages/story-editor/src/components/publishModal/publishModal.js
+++ b/packages/story-editor/src/components/publishModal/publishModal.js
@@ -76,7 +76,7 @@ function PublishModal({ isOpen, onPublish, onClose, publishButtonCopy }) {
         });
       }
     },
-    [updateStory, updateSlug, slug]
+    [updateStory, slug]
   );
 
   const isAllRequiredInputsFulfilled = useMemo(

--- a/packages/story-editor/src/components/publishModal/publishModal.js
+++ b/packages/story-editor/src/components/publishModal/publishModal.js
@@ -59,24 +59,25 @@ function PublishModal({ isOpen, onPublish, onClose, publishButtonCopy }) {
     }
   }, [isOpen]);
 
+  const slug = inputValues[INPUT_KEYS.SLUG];
   const handleUpdateStoryInfo = useCallback(
     ({ target }) => {
       const { value, name } = target;
       updateStory({
         properties: { [name]: value },
       });
-    },
-    [updateStory]
-  );
 
-  const handleUpdateSlug = useCallback(() => {
-    updateSlug({
-      currentSlug: inputValues.slug,
-      currentTitle: inputValues.title,
-      storyId,
-      updateStory,
-    });
-  }, [inputValues, storyId, updateStory]);
+      if (name === INPUT_KEYS.TITLE) {
+        updateSlug({
+          currentSlug: slug,
+          currentTitle: value,
+          storyId,
+          updateStory,
+        });
+      }
+    },
+    [updateStory, updateSlug, slug]
+  );
 
   const isAllRequiredInputsFulfilled = useMemo(
     () =>
@@ -118,7 +119,6 @@ function PublishModal({ isOpen, onPublish, onClose, publishButtonCopy }) {
             <MainContent
               inputValues={inputValues}
               handleUpdateStoryInfo={handleUpdateStoryInfo}
-              handleUpdateSlug={handleUpdateSlug}
               handleReviewChecklist={handleReviewChecklist}
             />
           </Container>

--- a/packages/story-editor/src/components/publishModal/publishModal.js
+++ b/packages/story-editor/src/components/publishModal/publishModal.js
@@ -76,7 +76,7 @@ function PublishModal({ isOpen, onPublish, onClose, publishButtonCopy }) {
         });
       }
     },
-    [updateStory, slug]
+    [updateStory, slug, storyId]
   );
 
   const isAllRequiredInputsFulfilled = useMemo(

--- a/packages/story-editor/src/components/publishModal/test/mainContent.js
+++ b/packages/story-editor/src/components/publishModal/test/mainContent.js
@@ -29,7 +29,6 @@ import MainContent from '../mainContent';
 
 describe('publishModal/mainContent', () => {
   const mockHandleUpdateStoryInfo = jest.fn();
-  const mockHandleUpdateSlug = jest.fn();
 
   const mockInputValues = {
     [INPUT_KEYS.EXCERPT]:
@@ -59,7 +58,6 @@ describe('publishModal/mainContent', () => {
         <ChecklistCountProvider hasChecklist>
           <MainContent
             handleUpdateStoryInfo={mockHandleUpdateStoryInfo}
-            handleUpdateSlug={mockHandleUpdateSlug}
             inputValues={mockInputValues}
           />
         </ChecklistCountProvider>
@@ -73,7 +71,7 @@ describe('publishModal/mainContent', () => {
     expect(results).toHaveNoViolations();
   });
 
-  it('should trigger handleUpdateStoryInfo on title input change', () => {
+  it('should trigger handleUpdateStoryInfo on title input blur', () => {
     view();
 
     const titleInput = screen.getByRole('textbox', { name: 'Story Title' });
@@ -82,11 +80,9 @@ describe('publishModal/mainContent', () => {
       target: { value: "David Bowman (and HAL's) Odyseey" },
     });
 
-    expect(mockHandleUpdateStoryInfo).toHaveBeenCalledTimes(1);
-
     fireEvent.blur(titleInput);
 
-    expect(mockHandleUpdateSlug).toHaveBeenCalledTimes(1);
+    expect(mockHandleUpdateStoryInfo).toHaveBeenCalledTimes(1);
   });
 
   it('should trigger handleUpdateStoryInfo on excerpt input change', () => {
@@ -99,6 +95,8 @@ describe('publishModal/mainContent', () => {
     fireEvent.change(descriptionInput, {
       target: { value: 'Lorem ipsum' },
     });
+
+    fireEvent.blur(descriptionInput);
 
     expect(mockHandleUpdateStoryInfo).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## Context

Part of the story details modal feature.

## Summary

Making save pattern of story title and description (excerpt) in modal consistent with updates in editor. I had thought inputs were updating on change but they should be on blur, this is correcting my error earlier in this feature.

## Relevant Technical Choices

Update modal inputs to pass changes on blur instead of on change.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

Now story title and story description (excerpt) update in the modal the same way that they do in the editor. I think this is really only noticeable if you update the story title and have the slug open in either the editor or the modal. 

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Partially addresses #10115 
