### PR TITLE
PHPCS: Fix `ReturnTypeHint` sniff configuration

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -83,7 +83,7 @@
   <config name="testVersion" value="7.2-" />
   <rule ref="PHPCompatibilityWP" />
 
-  <!-- The main plugin file should be parsable by PHP < 7.0. -->
+  <!-- The main plugin file should be parsable by PHP 5.6. -->
   <rule ref="Generic.Arrays.DisallowLongArraySyntax.Found">
     <exclude-pattern>web-stories.php</exclude-pattern>
     <exclude-pattern
@@ -108,7 +108,7 @@
       name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification"
     />
 
-    <!-- The main plugin file should be parsable by PHP < 7.0. -->
+    <!-- The main plugin file should be parsable by PHP 5.6. -->
     <exclude-pattern>web-stories.php</exclude-pattern>
     <exclude-pattern
     >includes/compat/Web_Stories_Compatibility.php</exclude-pattern>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -95,17 +95,25 @@
     >tests/phpunit/integration/includes/REST_Setup.php</exclude-pattern>
   </rule>
 
-  <rule
-    ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint"
-  >
+  <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
     <properties>
       <property name="enableStaticTypeHint" value="false" />
       <property name="enableMixedTypeHint" value="false" />
       <property name="enableUnionTypeHint" value="false" />
     </properties>
+    <exclude
+      name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessAnnotation"
+    />
+    <exclude
+      name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification"
+    />
+
+    <!-- The main plugin file should be parsable by PHP < 7.0. -->
     <exclude-pattern>web-stories.php</exclude-pattern>
     <exclude-pattern
     >includes/compat/Web_Stories_Compatibility.php</exclude-pattern>
+
+    <!-- To ensure backward compatibility for developers using these. -->
     <exclude-pattern>includes/Interfaces/FieldState.php</exclude-pattern>
     <exclude-pattern>includes/Interfaces/FieldStateFactory.php</exclude-pattern>
     <exclude-pattern>includes/Renderer/Stories/*</exclude-pattern>

--- a/tests/phpunit/integration/includes/Fixture/DummyClassWithDependency.php
+++ b/tests/phpunit/integration/includes/Fixture/DummyClassWithDependency.php
@@ -11,7 +11,10 @@ final class DummyClassWithDependency implements DummyInterface {
 		$this->dummy = $dummy;
 	}
 
-	public function get_dummy() {
+	/**
+	 * @return DummyClass
+	 */
+	public function get_dummy(): DummyClass {
 		return $this->dummy;
 	}
 }

--- a/tests/phpunit/integration/includes/Fixture/DummyClassWithNamedArguments.php
+++ b/tests/phpunit/integration/includes/Fixture/DummyClassWithNamedArguments.php
@@ -15,10 +15,16 @@ final class DummyClassWithNamedArguments {
 		$this->argument_b = $argument_b;
 	}
 
+	/**
+	 * @return mixed
+	 */
 	public function get_argument_a() {
 		return $this->argument_a;
 	}
 
+	/**
+	 * @return mixed
+	 */
 	public function get_argument_b() {
 		return $this->argument_b;
 	}

--- a/tests/phpunit/integration/tests/Media/Types.php
+++ b/tests/phpunit/integration/tests/Media/Types.php
@@ -108,7 +108,7 @@ class Types extends TestCase {
 		$this->assertEqualSets( [ 'webm' ], $actual );
 	}
 
-	protected function supportsWebP() {
+	protected function supportsWebP(): bool {
 		$mime_type = array_values( wp_get_mime_types() );
 
 		return \in_array( 'image/webp', $mime_type, true );

--- a/tests/phpunit/integration/tests/REST_API/Stories_Users_Controller.php
+++ b/tests/phpunit/integration/tests/REST_API/Stories_Users_Controller.php
@@ -123,7 +123,7 @@ class Stories_Users_Controller extends DependencyInjectedRestTestCase {
 		);
 	}
 
-	public function filter_rest_user_collection_params( $query_params ) {
+	public function filter_rest_user_collection_params( array $query_params ): array {
 		$query_params['capabilities'] = [
 			'type'  => 'array',
 			'items' => [

--- a/tests/phpunit/integration/tests/Renderer/Feed.php
+++ b/tests/phpunit/integration/tests/Renderer/Feed.php
@@ -88,7 +88,7 @@ class Feed extends TestCase {
 	 *
 	 * @link https://github.com/WordPress/wordpress-develop/blob/ab9aee8af474ac512b31b012f3c7c44fab31a990/tests/phpunit/tests/feed/rss2.php#L78-L94
 	 */
-	protected function do_rss2() {
+	protected function do_rss2(): string {
 		ob_start();
 		// Nasty hack! In the future it would better to leverage do_feed( 'rss2' ).
 		try {

--- a/tests/phpunit/unit/tests/AMP/Story_Sanitizer.php
+++ b/tests/phpunit/unit/tests/AMP/Story_Sanitizer.php
@@ -284,7 +284,7 @@ class Story_Sanitizer extends TestCase {
 		$this->assertStringContainsString( ' lang="en-US"', $actual );
 	}
 
-	public function data_test_transform_a_tags() {
+	public function data_test_transform_a_tags(): array {
 		return [
 			'Link without rel or target attribute' => [
 				'<html><head></head><body><a href="https://www.google.com">Google</a></body></html>',


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

@timarney pointed out issues with the PHPCS configuration, where there were unexpected lint errors when running PHPCS on PHP 8+.

The reason for that is that https://github.com/slevomat/coding-standard has different defaults depending on the PHP version.

We were overriding those defaults in our config, however the config was wrong, so it didn't actually work.

## Summary

<!-- A brief description of what this PR does. -->

This PR fixes the PHPCS configuration so that it works again as expected, even on PHP 8.

In the process, this implicitly enabled the `SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint` rule which reported a few errors in our tests. This PR addresses those.

This disables some other rules that we don't need (yet) and haven't enabled before.

**Note:** I want to enable `SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessAnnotation` in a future PR. Makes our inline docs a bit cleaner by removing redundant information.

## Relevant Technical Choices

<!-- Please describe your changes. -->

Formats the XML file using Prettier.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Run PHPCS locally on PHP 8+ and see no lint errors.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
