### PR TITLE
Semantic Headings: Enable feature by default

### DIFF
--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -402,6 +402,7 @@ class Experiments extends Service_Base implements HasRequirements {
 				'label'       => __( 'Semantic Headings', 'web-stories' ),
 				'description' => __( 'Automatically use semantic heading tags for text elements', 'web-stories' ),
 				'group'       => 'editor',
+				'default'     => true,
 			],
 		];
 	}


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

We want to automatically change the semantic HTML tag being used for text elements, depending on an element's font size.

## Summary

<!-- A brief description of what this PR does. -->

After initial development we want to enable this feature by default for the next release. So this PR does exactly that.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

**Text Sets and Text Presets**

1. Create a new story
2. In the left-hand panel, go to the "Text" tab and insert the text presets (Title 1, Title 2, etc.)
3. Preview the story
4. The HTML tags for the inserted text elements should correspond to their title, i.e. Title 1 should be wrapped in `<h1>`
5. Repeat the same for the _Cover_ text sets, where the title should also be wrapped in `<h1>`
6. Confirm that there is only ever a single `<h1>` element on an individual story page, even after inserting multiple presets or text sets

**Using the "Paragraph" text set**

1. Create a new story and insert a few pages with a few text elements on each, using the "Paragraph" preset
2. For each text element, change the font size to something larger or smaller, so you end up with all sorts of differently-sized text elements
3. Preview the story
4. The text elements should be wrapped in `<h1>`/`<h2>`/`<h3>`/`<p>` tags, depending on their font sizes.
5. Confirm that there is only ever a single `<h1>` element on an individual story page,

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10563
