### PR TITLE
Code Quality: Remove useless `@return` PHPDoc annotations

### DIFF
--- a/includes/AMP/Canonical_Sanitizer.php
+++ b/includes/AMP/Canonical_Sanitizer.php
@@ -53,8 +53,6 @@ class Canonical_Sanitizer extends AMP_Base_Sanitizer {
 	 * Sanitize the HTML contained in the DOMDocument received by the constructor.
 	 *
 	 * @since 1.1.0
-	 *
-	 * @return void
 	 */
 	public function sanitize(): void {
 		$canonical_url = $this->args['canonical_url'];

--- a/includes/AMP/Integration/AMP_Story_Sanitizer.php
+++ b/includes/AMP/Integration/AMP_Story_Sanitizer.php
@@ -45,8 +45,6 @@ class AMP_Story_Sanitizer extends AMP_Base_Sanitizer {
 	 * Sanitize the HTML contained in the DOMDocument received by the constructor.
 	 *
 	 * @since 1.1.0
-	 *
-	 * @return void
 	 */
 	public function sanitize(): void {
 		$this->transform_html_start_tag( $this->dom );

--- a/includes/AMP/Meta_Sanitizer.php
+++ b/includes/AMP/Meta_Sanitizer.php
@@ -56,8 +56,6 @@ class Meta_Sanitizer extends AMP_Meta_Sanitizer {
 	 *
 	 * @link https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate/?format=websites
 	 * @link https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/optimize_amp/#optimize-the-amp-runtime-loading
-	 *
-	 * @return void
 	 */
 	protected function ensure_boilerplate_is_present(): void {
 		$style  = null;

--- a/includes/AMP/Optimization.php
+++ b/includes/AMP/Optimization.php
@@ -58,7 +58,6 @@ class Optimization {
 	 * @since 1.1.0
 	 *
 	 * @param Document $document Document instance.
-	 * @return void
 	 */
 	public function optimize_document( Document $document ): void {
 		$errors = new ErrorCollection();

--- a/includes/AMP/Output_Buffer.php
+++ b/includes/AMP/Output_Buffer.php
@@ -90,8 +90,6 @@ class Output_Buffer extends Service_Base implements Conditional {
 	 * Runs on instantiation.
 	 *
 	 * @since 1.10.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		/*
@@ -153,8 +151,6 @@ class Output_Buffer extends Service_Base implements Conditional {
 	 * @since 1.10.0
 	 *
 	 * @see Sanitization::finish_output_buffering()
-	 *
-	 * @return void
 	 */
 	public function start_output_buffering(): void {
 		if ( ! $this->context->is_web_story() ) {

--- a/includes/AMP/Sanitization.php
+++ b/includes/AMP/Sanitization.php
@@ -89,7 +89,6 @@ class Sanitization {
 	 * @since 1.1.0
 	 *
 	 * @param Document $document Document instance.
-	 * @return void
 	 */
 	public function sanitize_document( Document $document ): void {
 		$sanitizers = $this->get_sanitizers();
@@ -111,7 +110,6 @@ class Sanitization {
 	 *
 	 * @param Document $document Document instance.
 	 * @param array    $scripts List of found scripts.
-	 * @return void
 	 */
 	protected function ensure_required_markup( $document, array $scripts ): void {
 		/**

--- a/includes/AMP/Story_Sanitizer.php
+++ b/includes/AMP/Story_Sanitizer.php
@@ -43,8 +43,6 @@ class Story_Sanitizer extends AMP_Base_Sanitizer {
 	 * Sanitize the HTML contained in the DOMDocument received by the constructor.
 	 *
 	 * @since 1.1.0
-	 *
-	 * @return void
 	 */
 	public function sanitize(): void {
 		$this->transform_html_start_tag( $this->dom );

--- a/includes/AMP/Traits/Sanitization_Utils.php
+++ b/includes/AMP/Traits/Sanitization_Utils.php
@@ -43,7 +43,6 @@ trait Sanitization_Utils {
 	 * @since 1.1.0
 	 *
 	 * @param Document|AMP_Document $document Document instance.
-	 * @return void
 	 */
 	private function transform_html_start_tag( &$document ): void {
 		$document->html->setAttribute( 'amp', '' );
@@ -71,7 +70,6 @@ trait Sanitization_Utils {
 	 * @since 1.1.0
 	 *
 	 * @param Document|AMP_Document $document Document instance.
-	 * @return void
 	 */
 	private function transform_a_tags( &$document ): void {
 		$links = $document->getElementsByTagName( 'a' );
@@ -126,7 +124,6 @@ trait Sanitization_Utils {
 	 *
 	 * @param Document|AMP_Document $document   Document instance.
 	 * @param bool                  $is_enabled Whether the feature is enabled.
-	 * @return void
 	 */
 	private function use_semantic_heading_tags( &$document, bool $is_enabled ): void {
 		if ( ! $is_enabled ) {
@@ -166,7 +163,6 @@ trait Sanitization_Utils {
 	 * @since 1.18.0
 	 *
 	 * @param DOMNodeList $text_elements List of text elements.
-	 * @return void
 	 */
 	private function use_semantic_heading_tags_for_elements( $text_elements ): void {
 		// Matches PAGE_HEIGHT in the editor, as also seen in amp-story-grid-layer[aspect-ratio].
@@ -214,7 +210,6 @@ trait Sanitization_Utils {
 	 *
 	 * @param DOMElement $node     Element whose tag name should be changed.
 	 * @param string     $tag_name Desired new tag name, e.g. h1 or h2.
-	 * @return void
 	 */
 	private function change_tag_name( DOMElement $node, string $tag_name ): void {
 		/**
@@ -256,7 +251,6 @@ trait Sanitization_Utils {
 	 * @since 1.13.0
 	 *
 	 * @param Document|AMP_Document $document Document instance.
-	 * @return void
 	 */
 	private function sanitize_amp_story_page_outlink( &$document ): void {
 		$outlink_elements = $document->getElementsByTagName( 'amp-story-page-outlink' );
@@ -287,7 +281,6 @@ trait Sanitization_Utils {
 	 *
 	 * @param Document|AMP_Document $document       Document instance.
 	 * @param string                $publisher_logo Publisher logo.
-	 * @return void
 	 */
 	private function add_publisher_logo( &$document, $publisher_logo ): void {
 		/**
@@ -323,7 +316,6 @@ trait Sanitization_Utils {
 	 *
 	 * @param Document|AMP_Document $document       Document instance.
 	 * @param string                $publisher Publisher logo.
-	 * @return void
 	 */
 	private function add_publisher( &$document, $publisher ): void {
 		/**
@@ -349,7 +341,6 @@ trait Sanitization_Utils {
 	 *
 	 * @param Document|AMP_Document $document      Document instance.
 	 * @param string[]              $poster_images List of poster images, keyed by type.
-	 * @return void
 	 */
 	private function add_poster_images( &$document, $poster_images ): void {
 		/**
@@ -385,7 +376,6 @@ trait Sanitization_Utils {
 	 * @since 1.8.0
 	 *
 	 * @param Document|AMP_Document $document Document instance.
-	 * @return void
 	 */
 	private function deduplicate_inline_styles( $document ): void {
 		$elements_by_inline_style = [];
@@ -447,7 +437,6 @@ trait Sanitization_Utils {
 	 *
 	 * @param Document|AMP_Document $document Document instance.
 	 * @param bool                  $video_cache_enabled Whether video cache is enabled.
-	 * @return void
 	 */
 	private function add_video_cache( &$document, $video_cache_enabled ): void {
 		if ( ! $video_cache_enabled ) {
@@ -484,7 +473,6 @@ trait Sanitization_Utils {
 	 * @since 1.9.0
 	 *
 	 * @param Document|AMP_Document $document Document instance.
-	 * @return void
 	 */
 	private function remove_blob_urls( &$document ): void {
 		/**
@@ -537,7 +525,6 @@ trait Sanitization_Utils {
 	 * @since 1.10.0
 	 *
 	 * @param Document|AMP_Document $document Document instance.
-	 * @return void
 	 */
 	private function sanitize_srcset( &$document ): void {
 		/**
@@ -589,7 +576,6 @@ trait Sanitization_Utils {
 	 * @link https://github.com/googleforcreators/web-stories-wp/issues/9530
 	 *
 	 * @param Document|AMP_Document $document Document instance.
-	 * @return void
 	 */
 	private function remove_page_template_placeholder_images( &$document ): void {
 		// Catches "assets/images/editor/grid-placeholder.png" as well as

--- a/includes/AMP_Story_Player_Assets.php
+++ b/includes/AMP_Story_Player_Assets.php
@@ -44,8 +44,6 @@ class AMP_Story_Player_Assets implements Service, Registerable {
 	 * Runs on instantiation.
 	 *
 	 * @since 1.8.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_action( 'wp_default_styles', [ $this, 'register_style' ] );
@@ -58,7 +56,6 @@ class AMP_Story_Player_Assets implements Service, Registerable {
 	 * @since 1.8.0
 	 *
 	 * @param WP_Styles $wp_styles WP_Styles instance.
-	 * @return void
 	 */
 	public function register_style( WP_Styles $wp_styles ): void {
 		$wp_styles->add(
@@ -75,7 +72,6 @@ class AMP_Story_Player_Assets implements Service, Registerable {
 	 * @since 1.8.0
 	 *
 	 * @param WP_Scripts $wp_scripts WP_Scripts instance.
-	 * @return void
 	 */
 	public function register_script( WP_Scripts $wp_scripts ): void {
 		$wp_scripts->add(

--- a/includes/AdSense.php
+++ b/includes/AdSense.php
@@ -55,8 +55,6 @@ class AdSense extends Service_Base implements HasRequirements {
 	 * Initializes all hooks.
 	 *
 	 * @since 1.3.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_action( 'web_stories_print_analytics', [ $this, 'print_adsense_tag' ] );
@@ -113,8 +111,6 @@ class AdSense extends Service_Base implements HasRequirements {
 	 * Returns if Google AdSense is enabled.
 	 *
 	 * @since 1.3.0
-	 *
-	 * @return bool
 	 */
 	private function is_enabled(): bool {
 		return ( 'adsense' === $this->settings->get_setting( $this->settings::SETTING_NAME_AD_NETWORK, 'none' ) );
@@ -124,8 +120,6 @@ class AdSense extends Service_Base implements HasRequirements {
 	 * Prints the <amp-story-auto-ads> tag for single stories.
 	 *
 	 * @since 1.3.0
-	 *
-	 * @return void
 	 */
 	public function print_adsense_tag(): void {
 		$publisher = $this->get_publisher_id();

--- a/includes/Ad_Manager.php
+++ b/includes/Ad_Manager.php
@@ -55,8 +55,6 @@ class Ad_Manager extends Service_Base implements HasRequirements {
 	 * Initializes all hooks.
 	 *
 	 * @since 1.3.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_action( 'web_stories_print_analytics', [ $this, 'print_ad_manager_tag' ] );
@@ -96,8 +94,6 @@ class Ad_Manager extends Service_Base implements HasRequirements {
 	 * Returns if Google manager is enabled.
 	 *
 	 * @since 1.3.0
-	 *
-	 * @return bool
 	 */
 	private function is_enabled(): bool {
 		return ( 'admanager' === $this->settings->get_setting( $this->settings::SETTING_NAME_AD_NETWORK, 'none' ) );
@@ -107,8 +103,6 @@ class Ad_Manager extends Service_Base implements HasRequirements {
 	 * Prints the <amp-story-auto-ads> tag for single stories.
 	 *
 	 * @since 1.3.0
-	 *
-	 * @return void
 	 */
 	public function print_ad_manager_tag(): void {
 		$slot    = $this->get_slot_id();

--- a/includes/Admin/Activation_Notice.php
+++ b/includes/Admin/Activation_Notice.php
@@ -71,8 +71,6 @@ class Activation_Notice implements ServiceInterface, Registerable, PluginActivat
 	 * Initializes the plugin activation notice.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
@@ -86,7 +84,6 @@ class Activation_Notice implements ServiceInterface, Registerable, PluginActivat
 	 * @since 1.13.0
 	 *
 	 * @param bool $network_wide Whether the activation was done network-wide.
-	 * @return void
 	 */
 	public function on_plugin_activation( $network_wide ): void {
 		$this->set_activation_flag( $network_wide );
@@ -98,7 +95,6 @@ class Activation_Notice implements ServiceInterface, Registerable, PluginActivat
 	 * @since 1.13.0
 	 *
 	 * @param bool $network_wide Whether the deactivation was done network-wide.
-	 * @return void
 	 */
 	public function on_plugin_deactivation( $network_wide ): void {
 		$this->delete_activation_flag( $network_wide );
@@ -110,7 +106,6 @@ class Activation_Notice implements ServiceInterface, Registerable, PluginActivat
 	 * @since 1.0.0
 	 *
 	 * @param string $hook_suffix The current admin page.
-	 * @return void
 	 */
 	public function enqueue_assets( string $hook_suffix ): void {
 		if ( ! $this->is_plugins_page( $hook_suffix ) || ! $this->get_activation_flag( is_network_admin() ) ) {
@@ -189,8 +184,6 @@ class Activation_Notice implements ServiceInterface, Registerable, PluginActivat
 	 * Renders the plugin activation notice.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return void
 	 */
 	public function render_notice(): void {
 		global $hook_suffix;
@@ -232,7 +225,6 @@ class Activation_Notice implements ServiceInterface, Registerable, PluginActivat
 	 * @since 1.13.0
 	 *
 	 * @param bool $network_wide Whether the plugin is being activated network-wide.
-	 * @return bool
 	 */
 	protected function set_activation_flag( bool $network_wide = false ): bool {
 		if ( $network_wide ) {

--- a/includes/Admin/Admin.php
+++ b/includes/Admin/Admin.php
@@ -59,8 +59,6 @@ class Admin extends Service_Base {
 	 * Initialize admin-related functionality.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_filter( 'admin_body_class', [ $this, 'admin_body_class' ], 99 );

--- a/includes/Admin/Cross_Origin_Isolation.php
+++ b/includes/Admin/Cross_Origin_Isolation.php
@@ -66,8 +66,6 @@ class Cross_Origin_Isolation extends Service_Base implements HasRequirements {
 
 	/**
 	 * Init
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		if ( ! $this->context->is_story_editor() ) {
@@ -156,8 +154,6 @@ class Cross_Origin_Isolation extends Service_Base implements HasRequirements {
 	 * Start output buffer to add headers and `crossorigin` attribute everywhere.
 	 *
 	 * @since 1.6.0
-	 *
-	 * @return void
 	 */
 	public function admin_header(): void {
 		if ( $this->needs_isolation() ) {
@@ -335,8 +331,6 @@ class Cross_Origin_Isolation extends Service_Base implements HasRequirements {
 	 * Unhook wp_print_media_templates and replace with custom media templates.
 	 *
 	 * @since 1.8.0
-	 *
-	 * @return void
 	 */
 	public function override_media_templates(): void {
 		remove_action( 'admin_footer', 'wp_print_media_templates' );
@@ -347,8 +341,6 @@ class Cross_Origin_Isolation extends Service_Base implements HasRequirements {
 	 * Add crossorigin attribute to all tags that could have assets loaded from a different domain.
 	 *
 	 * @since 1.8.0
-	 *
-	 * @return void
 	 */
 	public function custom_print_media_templates(): void {
 		ob_start();
@@ -374,7 +366,6 @@ class Cross_Origin_Isolation extends Service_Base implements HasRequirements {
 	 *
 	 * @param string $string       String to search.
 	 * @param string $start_string String to search with.
-	 * @return bool
 	 */
 	private function starts_with( string $string, string $start_string ): bool {
 		return 0 === strpos( $string, $start_string );

--- a/includes/Admin/Customizer.php
+++ b/includes/Admin/Customizer.php
@@ -111,8 +111,6 @@ class Customizer extends Service_Base implements Conditional {
 	 * Initializes the customizer logic.
 	 *
 	 * @since 1.5.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_action( 'customize_register', [ $this, 'register_customizer_settings' ] );
@@ -139,7 +137,6 @@ class Customizer extends Service_Base implements Conditional {
 	 * @since 1.5.0
 	 *
 	 * @param WP_Customize_Manager $wp_customize WP_Customize_Manager instance.
-	 * @return void
 	 */
 	public function register_customizer_settings( WP_Customize_Manager $wp_customize ): void {
 		$this->wp_customize = $wp_customize;
@@ -537,7 +534,6 @@ class Customizer extends Service_Base implements Conditional {
 	 *
 	 * @param WP_Error $validity WP_Error object.
 	 * @param int      $value    Value to be validated.
-	 * @return WP_Error
 	 */
 	public function validate_number_of_stories( $validity, $value ): WP_Error {
 		$value = (int) $value;
@@ -555,7 +551,6 @@ class Customizer extends Service_Base implements Conditional {
 	 *
 	 * @param WP_Error $validity WP_Error object.
 	 * @param int      $value Value to be validated.
-	 * @return WP_Error
 	 */
 	public function validate_number_of_columns( $validity, $value ): WP_Error {
 		$value = (int) $value;
@@ -573,8 +568,6 @@ class Customizer extends Service_Base implements Conditional {
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 *
 	 * @since 1.5.0
-	 *
-	 * @return string
 	 */
 	public function render_stories(): string {
 		$options = (array) $this->settings->get_setting( self::STORY_OPTION );

--- a/includes/Admin/Dashboard.php
+++ b/includes/Admin/Dashboard.php
@@ -173,8 +173,6 @@ class Dashboard extends Service_Base {
 	 * Initializes the dashboard logic.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_action( 'admin_menu', [ $this, 'add_menu_page' ] );
@@ -200,8 +198,6 @@ class Dashboard extends Service_Base {
 	 * Registers the dashboard admin menu page.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return void
 	 */
 	public function add_menu_page(): void {
 		$parent = 'edit.php?post_type=' . $this->story_post_type->get_slug();
@@ -247,8 +243,6 @@ class Dashboard extends Service_Base {
 	 * @codeCoverageIgnore
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return void
 	 */
 	public function redirect_menu_page(): void {
 		global $pagenow;
@@ -279,8 +273,6 @@ class Dashboard extends Service_Base {
 	 * Important: keep in sync with usage & definition in React app.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return void
 	 */
 	public function load_stories_dashboard(): void {
 		$rest_url = trailingslashit( $this->story_post_type->get_rest_url() );
@@ -362,8 +354,6 @@ class Dashboard extends Service_Base {
 	 * Renders the dashboard page.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return void
 	 */
 	public function render(): void {
 		require_once WEBSTORIES_PLUGIN_DIR_PATH . 'includes/templates/admin/dashboard.php';
@@ -375,7 +365,6 @@ class Dashboard extends Service_Base {
 	 * @since 1.0.0
 	 *
 	 * @param string $hook_suffix The current admin page.
-	 * @return void
 	 */
 	public function enqueue_assets( $hook_suffix ): void {
 		if ( $this->get_hook_suffix( 'stories-dashboard' ) !== $hook_suffix ) {
@@ -471,8 +460,6 @@ class Dashboard extends Service_Base {
 	 * Displays a link to the Web Stories dashboard on the WordPress list table view.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return void
 	 */
 	public function display_link_to_dashboard(): void {
 		if ( ! $this->context->is_story_editor() ) {

--- a/includes/Admin/Editor.php
+++ b/includes/Admin/Editor.php
@@ -182,8 +182,6 @@ class Editor extends Service_Base implements HasRequirements {
 	 * Initializes the Editor logic.
 	 *
 	 * @since 1.7.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
@@ -262,7 +260,6 @@ class Editor extends Service_Base implements HasRequirements {
 	 * @since 1.0.0
 	 *
 	 * @param string $hook The current admin page.
-	 * @return void
 	 */
 	public function admin_enqueue_scripts( $hook ): void {
 		if ( ! $this->context->is_story_editor() ) {
@@ -431,7 +428,6 @@ class Editor extends Service_Base implements HasRequirements {
 	 * @since 1.5.0
 	 *
 	 * @param int $story_id Post id of story.
-	 * @return void
 	 */
 	protected function setup_lock( int $story_id ): void {
 		if ( ! $this->experiments->is_experiment_enabled( 'enablePostLocking' ) ) {

--- a/includes/Admin/Google_Fonts.php
+++ b/includes/Admin/Google_Fonts.php
@@ -59,8 +59,6 @@ class Google_Fonts implements Conditional, Service, Registerable {
 	 * Runs on instantiation.
 	 *
 	 * @since 1.8.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_action( 'wp_default_styles', [ $this, 'register_style' ] );
@@ -72,7 +70,6 @@ class Google_Fonts implements Conditional, Service, Registerable {
 	 * @since 1.8.0
 	 *
 	 * @param WP_Styles $wp_styles WP_Styles instance.
-	 * @return void
 	 */
 	public function register_style( WP_Styles $wp_styles ): void {
 		// so we need to avoid specifying a version at all.

--- a/includes/Admin/ImgAreaSelect_Patch.php
+++ b/includes/Admin/ImgAreaSelect_Patch.php
@@ -84,8 +84,6 @@ class ImgAreaSelect_Patch implements Conditional, Service, Registerable {
 	 * Runs on instantiation.
 	 *
 	 * @since 1.10.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_filter( 'script_loader_tag', [ $this, 'script_loader_tag' ], 10, 3 );

--- a/includes/Admin/Meta_Boxes.php
+++ b/includes/Admin/Meta_Boxes.php
@@ -47,8 +47,6 @@ class Meta_Boxes extends Service_Base {
 	 * Init.
 	 *
 	 * @since 1.2.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_action( 'add_meta_boxes_' . Story_Post_Type::POST_TYPE_SLUG, [ $this, 'remove_meta_boxes' ], PHP_INT_MAX );
@@ -65,8 +63,6 @@ class Meta_Boxes extends Service_Base {
 	 * @since 1.2.0
 	 *
 	 * @see do_meta_boxes()
-	 *
-	 * @return void
 	 */
 	public function remove_meta_boxes(): void {
 		global $wp_meta_boxes;

--- a/includes/Admin/PluginActionLinks.php
+++ b/includes/Admin/PluginActionLinks.php
@@ -39,8 +39,6 @@ class PluginActionLinks extends Service_Base {
 	 * Runs on instantiation.
 	 *
 	 * @since 1.6.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		$basename = plugin_basename( WEBSTORIES_PLUGIN_FILE );

--- a/includes/Admin/PluginRowMeta.php
+++ b/includes/Admin/PluginRowMeta.php
@@ -39,8 +39,6 @@ class PluginRowMeta extends Service_Base {
 	 * Runs on instantiation.
 	 *
 	 * @since 1.6.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_filter( 'plugin_row_meta', [ $this, 'get_plugin_row_meta' ], 10, 2 );

--- a/includes/Admin/Site_Health.php
+++ b/includes/Admin/Site_Health.php
@@ -81,8 +81,6 @@ class Site_Health extends Service_Base implements Conditional {
 	 * Adds the filters.
 	 *
 	 * @since 1.8.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_filter( 'debug_information', [ $this, 'add_debug_information' ] );
@@ -171,7 +169,6 @@ class Site_Health extends Service_Base implements Conditional {
 	 * @since 1.8.0
 	 *
 	 * @param mixed $value Value to formatted.
-	 * @return string
 	 */
 	protected function get_formatted_output( $value ): string {
 		return $value ? __( 'Enabled', 'web-stories' ) : __( 'Disabled', 'web-stories' );

--- a/includes/Admin/TinyMCE.php
+++ b/includes/Admin/TinyMCE.php
@@ -82,8 +82,6 @@ class TinyMCE extends Service_Base {
 	 * Initialization actions.
 	 *
 	 * @since 1.5.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		if ( $this->context->is_block_editor() || $this->context->is_story_editor() ) {
@@ -148,8 +146,6 @@ class TinyMCE extends Service_Base {
 	 * Enqueue related scripts.
 	 *
 	 * @since 1.5.0
-	 *
-	 * @return void
 	 */
 	public function register_assets(): void {
 		$this->assets->enqueue_style( 'wp-components' );
@@ -190,8 +186,6 @@ class TinyMCE extends Service_Base {
 	 * Enqueue related scripts.
 	 *
 	 * @since 1.5.0
-	 *
-	 * @return void
 	 */
 	public function enqueue_assets(): void {
 		$this->assets->enqueue_style( 'wp-components' );
@@ -203,8 +197,6 @@ class TinyMCE extends Service_Base {
 	 * This is useful for performing some react operations.
 	 *
 	 * @since 1.5.0
-	 *
-	 * @return void
 	 */
 	public function web_stories_tinymce_root_element(): void {
 		?>

--- a/includes/Analytics.php
+++ b/includes/Analytics.php
@@ -53,8 +53,6 @@ class Analytics extends Service_Base {
 	 * Initializes all hooks.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_action( 'web_stories_print_analytics', [ $this, 'print_analytics_tag' ] );
@@ -231,8 +229,6 @@ class Analytics extends Service_Base {
 	 * Prints the analytics tag for single stories.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return void
 	 */
 	public function print_analytics_tag(): void {
 		$tracking_id = $this->get_tracking_id();
@@ -254,7 +250,6 @@ class Analytics extends Service_Base {
 	 * @since 1.12.0
 	 *
 	 * @param string $tracking_id Tracking ID.
-	 * @return void
 	 */
 	private function print_amp_analytics_tag( $tracking_id ): void {
 		?>
@@ -272,7 +267,6 @@ class Analytics extends Service_Base {
 	 * @since 1.12.0
 	 *
 	 * @param string $tracking_id Tracking ID.
-	 * @return void
 	 */
 	private function print_amp_story_auto_analytics_tag( $tracking_id ): void {
 		?>

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -50,7 +50,6 @@ class Assets {
 	 * @since 1.8.0
 	 *
 	 * @param string $path Path.
-	 * @return string
 	 */
 	public function get_base_path( string $path ): string {
 		return WEBSTORIES_PLUGIN_DIR_PATH . $path;
@@ -62,7 +61,6 @@ class Assets {
 	 * @since 1.8.0
 	 *
 	 * @param string $path Path.
-	 * @return string
 	 */
 	public function get_base_url( string $path ): string {
 		return WEBSTORIES_PLUGIN_DIR_URL . $path;
@@ -110,7 +108,6 @@ class Assets {
 	 * @param string $script_handle Handle of script.
 	 * @param array  $script_dependencies Array of extra dependencies.
 	 * @param bool   $with_i18n Optional. Whether to setup i18n for this asset. Default true.
-	 * @return void
 	 */
 	public function register_script_asset( string $script_handle, array $script_dependencies = [], bool $with_i18n = true ): void {
 		if ( isset( $this->register_scripts[ $script_handle ] ) ) {
@@ -179,7 +176,6 @@ class Assets {
 	 * @param string $script_handle Handle of script.
 	 * @param array  $script_dependencies Array of extra dependencies.
 	 * @param bool   $with_i18n Optional. Whether to setup i18n for this asset. Default true.
-	 * @return void
 	 */
 	public function enqueue_script_asset( string $script_handle, array $script_dependencies = [], bool $with_i18n = true ): void {
 		$this->register_script_asset( $script_handle, $script_dependencies, $with_i18n );
@@ -193,7 +189,6 @@ class Assets {
 	 *
 	 * @param string $style_handle Handle of style.
 	 * @param array  $style_dependencies Array of extra dependencies.
-	 * @return void
 	 */
 	public function register_style_asset( string $style_handle, array $style_dependencies = [] ): void {
 		if ( isset( $this->register_styles[ $style_handle ] ) ) {
@@ -234,7 +229,6 @@ class Assets {
 	 *
 	 * @param string $style_handle Handle of style.
 	 * @param array  $style_dependencies Array of extra dependencies.
-	 * @return void
 	 */
 	public function enqueue_style_asset( string $style_handle, array $style_dependencies = [] ): void {
 		$this->register_style_asset( $style_handle, $style_dependencies );
@@ -319,7 +313,6 @@ class Assets {
 	 * @param string           $media  Optional. The media for which this stylesheet has been defined.
 	 *                                 Default 'all'. Accepts media types like 'all', 'print' and 'screen', or media queries like
 	 *                                 '(orientation: portrait)' and '(max-width: 640px)'.
-	 * @return void
 	 */
 	public function enqueue_style( string $style_handle, string $src = '', array $deps = [], $ver = false, string $media = 'all' ): void {
 		$this->register_style( $style_handle, $src, $deps, $ver, $media );
@@ -344,7 +337,6 @@ class Assets {
 	 * @param bool             $in_footer Optional. Whether to enqueue the script before </body> instead of in the <head>.
 	 *                                    Default 'false'.
 	 * @param bool             $with_i18n Optional. Whether to setup i18n for this asset. Default true.
-	 * @return void
 	 */
 	public function enqueue_script( string $script_handle, string $src = '', array $deps = [], $ver = false, bool $in_footer = false, bool $with_i18n = false ): void {
 		$this->register_script( $script_handle, $src, $deps, $ver, $in_footer, $with_i18n );
@@ -357,7 +349,6 @@ class Assets {
 	 * @since 1.8.0
 	 *
 	 * @param array $styles Array to style to be removed.
-	 * @return void
 	 */
 	public function remove_admin_style( array $styles ): void {
 		wp_styles()->registered['wp-admin']->deps = array_diff( wp_styles()->registered['wp-admin']->deps, $styles );

--- a/includes/Block/Web_Stories_Block.php
+++ b/includes/Block/Web_Stories_Block.php
@@ -97,8 +97,6 @@ class Web_Stories_Block extends Embed_Base {
 	 * Initializes the Web Stories embed block.
 	 *
 	 * @since 1.5.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		parent::register();
@@ -118,8 +116,6 @@ class Web_Stories_Block extends Embed_Base {
 	 * Registers a block type from metadata stored in the `block.json` file.
 	 *
 	 * @since 1.9.0
-	 *
-	 * @return void
 	 */
 	protected function register_block_type(): void {
 		$base_path = $this->assets->get_base_path( 'blocks/embed/block.json' );

--- a/includes/Context.php
+++ b/includes/Context.php
@@ -113,8 +113,6 @@ class Context {
 	 * Whether we're currently on a block editor screen.
 	 *
 	 * @since 1.15.0
-	 *
-	 * @return bool
 	 */
 	public function is_block_editor(): bool {
 		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;

--- a/includes/Database_Upgrader.php
+++ b/includes/Database_Upgrader.php
@@ -95,8 +95,6 @@ class Database_Upgrader implements Service, Registerable, PluginActivationAware,
 	 * Hooked into admin_init and walks through an array of upgrade methods.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_action( 'admin_init', [ $this, 'run_upgrades' ], 5 );
@@ -108,7 +106,6 @@ class Database_Upgrader implements Service, Registerable, PluginActivationAware,
 	 * @since 1.6.0
 	 *
 	 * @param bool $network_wide Whether the activation was done network-wide.
-	 * @return void
 	 */
 	public function on_plugin_activation( $network_wide ): void {
 		$this->run_upgrades();
@@ -120,7 +117,6 @@ class Database_Upgrader implements Service, Registerable, PluginActivationAware,
 	 * @since 1.11.0
 	 *
 	 * @param WP_Site $site The site being initialized.
-	 * @return void
 	 */
 	public function on_site_initialization( WP_Site $site ): void {
 		$this->run_upgrades();
@@ -130,8 +126,6 @@ class Database_Upgrader implements Service, Registerable, PluginActivationAware,
 	 * Run all upgrade routines in order.
 	 *
 	 * @since 1.11.0
-	 *
-	 * @return void
 	 */
 	public function run_upgrades(): void {
 		/**
@@ -158,7 +152,6 @@ class Database_Upgrader implements Service, Registerable, PluginActivationAware,
 	 * @param string $class           The Class to call.
 	 * @param string $version         The new version.
 	 * @param string $current_version The current set version.
-	 * @return void
 	 */
 	protected function run_upgrade_routine( string $class, string $version, string $current_version ): void {
 		if ( version_compare( $current_version, $version, '<' ) ) {
@@ -176,7 +169,6 @@ class Database_Upgrader implements Service, Registerable, PluginActivationAware,
 	 * @since 1.0.0
 	 *
 	 * @param string $previous_version The previous version.
-	 * @return void
 	 */
 	protected function finish_up( string $previous_version ): void {
 		update_option( self::PREVIOUS_OPTION, $previous_version );

--- a/includes/Demo_Content.php
+++ b/includes/Demo_Content.php
@@ -34,8 +34,6 @@ namespace Google\Web_Stories;
 class Demo_Content {
 	/**
 	 * Returns the title for the demo story.
-	 *
-	 * @return string
 	 */
 	public function get_title(): string {
 		return __( 'Tips to make the most of Web Stories', 'web-stories' );
@@ -43,8 +41,6 @@ class Demo_Content {
 
 	/**
 	 * Returns the content for the demo story.
-	 *
-	 * @return string
 	 */
 	public function get_content(): string {
 		$content = $this->load_demo_content_from_file();
@@ -164,8 +160,6 @@ class Demo_Content {
 
 	/**
 	 * Loads demo content from JSON file.
-	 *
-	 * @return string
 	 */
 	private function load_demo_content_from_file(): string {
 		$file = WEBSTORIES_PLUGIN_DIR_PATH . 'includes/data/stories/demo.json';

--- a/includes/Discovery.php
+++ b/includes/Discovery.php
@@ -71,8 +71,6 @@ class Discovery extends Service_Base implements HasRequirements {
 	 * Initialize discovery functionality.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_action( 'web_stories_story_head', [ $this, 'print_metadata' ] );
@@ -112,8 +110,6 @@ class Discovery extends Service_Base implements HasRequirements {
 	 * @since 1.0.0
 	 *
 	 * @see _wp_render_title_tag().
-	 *
-	 * @return void
 	 */
 	public function print_metadata(): void {
 		/**
@@ -137,8 +133,6 @@ class Discovery extends Service_Base implements HasRequirements {
 	 * Prints the schema.org metadata on the single story template.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return void
 	 */
 	public function print_schemaorg_metadata(): void {
 		/**
@@ -241,8 +235,6 @@ class Discovery extends Service_Base implements HasRequirements {
 	 * Prints Open Graph metadata.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return void
 	 */
 	public function print_open_graph_metadata(): void {
 		/**
@@ -316,8 +308,6 @@ class Discovery extends Service_Base implements HasRequirements {
 	 * Prints Twitter card metadata.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return void
 	 */
 	public function print_twitter_metadata(): void {
 		/**
@@ -381,8 +371,6 @@ class Discovery extends Service_Base implements HasRequirements {
 	 * Add RSS feed link for stories, if theme supports automatic-feed-links.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return void
 	 */
 	public function print_feed_link(): void {
 		if ( ! current_theme_supports( 'automatic-feed-links' ) ) {

--- a/includes/Embed_Base.php
+++ b/includes/Embed_Base.php
@@ -70,8 +70,6 @@ abstract class Embed_Base extends Service_Base {
 	 * Initializes the Web Stories embed block.
 	 *
 	 * @since 1.1.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		if ( wp_style_is( self::SCRIPT_HANDLE, 'registered' ) ) {
@@ -102,8 +100,6 @@ abstract class Embed_Base extends Service_Base {
 	 * Prints required inline CSS when using the AMP for WP plugin.
 	 *
 	 * @since 1.13.0
-	 *
-	 * @return void
 	 */
 	public function add_amp_post_template_css(): void {
 		$path = $this->assets->get_base_path( sprintf( 'assets/css/%s%s.css', self::SCRIPT_HANDLE, is_rtl() ? '-rtl' : '' ) );

--- a/includes/Exception/FailedToMakeInstance.php
+++ b/includes/Exception/FailedToMakeInstance.php
@@ -61,7 +61,6 @@ final class FailedToMakeInstance
 	 *                                                   reference.
 	 * @param InjectionChain $injection_chain    Injection chain that led to the
 	 *                                           circular reference.
-	 * @return self
 	 */
 	public static function for_circular_reference(
 		$interface_or_class,
@@ -87,7 +86,6 @@ final class FailedToMakeInstance
 	 * @since 1.6.0
 	 *
 	 * @param string $interface Interface that was left unresolved.
-	 * @return self
 	 */
 	public static function for_unresolved_interface( $interface ): self {
 		$message = \sprintf(
@@ -106,7 +104,6 @@ final class FailedToMakeInstance
 	 *
 	 * @param string $interface_or_class Interface or class that could not be
 	 *                                   reflected upon.
-	 * @return self
 	 */
 	public static function for_unreflectable_class( $interface_or_class ): self {
 		$message = \sprintf(
@@ -127,7 +124,6 @@ final class FailedToMakeInstance
 	 *                              resolved.
 	 * @param string $class         Class that had the argument in its
 	 *                              constructor.
-	 * @return self
 	 */
 	public static function for_unresolved_argument( $argument_name, $class ): self {
 		$message = \sprintf(
@@ -146,7 +142,6 @@ final class FailedToMakeInstance
 	 * @since 1.6.0
 	 *
 	 * @param string $class Class that was not yet instantiated.
-	 * @return self
 	 */
 	public static function for_uninstantiated_shared_instance( $class ): self {
 		$message = \sprintf(
@@ -164,7 +159,6 @@ final class FailedToMakeInstance
 	 * @since 1.6.0
 	 *
 	 * @param string $class Class for which there is no delegate.
-	 * @return self
 	 */
 	public static function for_invalid_delegate( $class ): self {
 		$message = \sprintf(

--- a/includes/Exception/InvalidEventProperties.php
+++ b/includes/Exception/InvalidEventProperties.php
@@ -46,7 +46,6 @@ final class InvalidEventProperties
 	 * @since 1.6.0
 	 *
 	 * @param mixed $properties Properties value that has the wrong type.
-	 * @return self
 	 */
 	public static function from_invalid_type( $properties ): self {
 		$type = \is_object( $properties )
@@ -68,7 +67,6 @@ final class InvalidEventProperties
 	 * @since 1.6.0
 	 *
 	 * @param mixed $property Property element that has the wrong type.
-	 * @return self
 	 */
 	public static function from_invalid_element_key_type( $property ): self {
 		$type = \is_object( $property )
@@ -88,7 +86,6 @@ final class InvalidEventProperties
 	 * the wrong value type for one or more of its elements.
 	 *
 	 * @param mixed $property Property element that has the wrong type.
-	 * @return self
 	 */
 	public static function from_invalid_element_value_type( $property ): self {
 		$type = \is_object( $property )

--- a/includes/Exception/InvalidService.php
+++ b/includes/Exception/InvalidService.php
@@ -47,7 +47,6 @@ final class InvalidService
 	 *
 	 * @param string|object $service Class name of the service that was not
 	 *                               recognized.
-	 * @return self
 	 */
 	public static function from_service( $service ): self {
 		$message = \sprintf(
@@ -66,7 +65,6 @@ final class InvalidService
 	 *
 	 * @param string $service_id Identifier of the service that is not being
 	 *                           recognized.
-	 * @return self
 	 */
 	public static function from_service_id( $service_id ): self {
 		$message = \sprintf(

--- a/includes/Exception/SanitizationException.php
+++ b/includes/Exception/SanitizationException.php
@@ -43,8 +43,6 @@ final class SanitizationException
 	 * Create a new instance of the exception for a document that cannot be parsed.
 	 *
 	 * @since 1.10.0
-	 *
-	 * @return self
 	 */
 	public static function from_document_parse_error(): self {
 		return new self( 'The markup could not be parsed into a DOMDocument.' );

--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -60,8 +60,6 @@ class Experiments extends Service_Base implements HasRequirements {
 
 	/**
 	 * Initializes experiments
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		if ( WEBSTORIES_DEV_MODE ) {
@@ -87,8 +85,6 @@ class Experiments extends Service_Base implements HasRequirements {
 	 * Registers the experiments admin menu page.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return void
 	 */
 	public function add_menu_page(): void {
 		add_submenu_page(
@@ -106,8 +102,6 @@ class Experiments extends Service_Base implements HasRequirements {
 	 * Renders the experiments page.
 	 *
 	 * @codeCoverageIgnore
-	 *
-	 * @return void
 	 */
 	public function render(): void {
 		require_once WEBSTORIES_PLUGIN_DIR_PATH . 'includes/templates/admin/experiments.php';
@@ -117,8 +111,6 @@ class Experiments extends Service_Base implements HasRequirements {
 	 * Initializes the experiments settings page.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return void
 	 */
 	public function initialize_settings(): void {
 		add_settings_section(
@@ -168,7 +160,6 @@ class Experiments extends Service_Base implements HasRequirements {
 	 *     @type string $label   Experiment label.
 	 *     @type bool   $default Whether the experiment is enabled by default.
 	 * }
-	 * @return void
 	 */
 	public function display_experiment_field( array $args ): void {
 		$is_enabled_by_default = ! empty( $args['default'] );
@@ -193,8 +184,6 @@ class Experiments extends Service_Base implements HasRequirements {
 	 * Display the experiments section.
 	 *
 	 * @codeCoverageIgnore
-	 *
-	 * @return void
 	 */
 	public function display_experiment_section(): void {
 		?>

--- a/includes/Font_Post_Type.php
+++ b/includes/Font_Post_Type.php
@@ -61,8 +61,6 @@ class Font_Post_Type extends Post_Type_Base implements HasRequirements {
 	 * Get post type slug.
 	 *
 	 * @since 1.16.0
-	 *
-	 * @return string
 	 */
 	public function get_slug(): string {
 		return self::POST_TYPE_SLUG;

--- a/includes/Infrastructure/HasMeta.php
+++ b/includes/Infrastructure/HasMeta.php
@@ -22,8 +22,6 @@ interface HasMeta {
 	 * Register meta
 	 *
 	 * @since 1.15.0
-	 *
-	 * @return void
 	 */
 	public function register_meta(): void;
 }

--- a/includes/Infrastructure/Injector.php
+++ b/includes/Infrastructure/Injector.php
@@ -64,7 +64,6 @@ interface Injector extends Service {
 	 *
 	 * @param string $from Interface or class to bind an implementation to.
 	 * @param string $to   Interface or class that provides the implementation.
-	 * @return Injector
 	 */
 	public function bind( $from, $to ): Injector;
 
@@ -77,7 +76,6 @@ interface Injector extends Service {
 	 *                                   for.
 	 * @param string $argument_name      Argument name to bind a value to.
 	 * @param mixed  $value              Value to bind the argument to.
-	 * @return Injector
 	 */
 	public function bind_argument(
 		$interface_or_class,
@@ -92,7 +90,6 @@ interface Injector extends Service {
 	 * @since 1.6.0
 	 *
 	 * @param string $interface_or_class Interface or class to reuse.
-	 * @return Injector
 	 */
 	public function share( $interface_or_class ): Injector;
 
@@ -104,7 +101,6 @@ interface Injector extends Service {
 	 * @param string   $interface_or_class Interface or class to delegate the
 	 *                                     instantiation of.
 	 * @param callable $callable           Callable to use for instantiation.
-	 * @return Injector
 	 */
 	public function delegate( $interface_or_class, callable $callable ): Injector;
 }

--- a/includes/Infrastructure/Injector/SimpleInjector.php
+++ b/includes/Infrastructure/Injector/SimpleInjector.php
@@ -144,7 +144,6 @@ final class SimpleInjector implements Injector {
 	 *
 	 * @param string $from Interface or class to bind an implementation to.
 	 * @param string $to   Interface or class that provides the implementation.
-	 * @return Injector
 	 */
 	public function bind( $from, $to ): Injector {
 		$this->mappings[ $from ] = $to;
@@ -161,7 +160,6 @@ final class SimpleInjector implements Injector {
 	 *                                   for.
 	 * @param string $argument_name      Argument name to bind a value to.
 	 * @param mixed  $value              Value to bind the argument to.
-	 * @return Injector
 	 */
 	public function bind_argument(
 		$interface_or_class,
@@ -180,7 +178,6 @@ final class SimpleInjector implements Injector {
 	 * @since 1.6.0
 	 *
 	 * @param string $interface_or_class Interface or class to reuse.
-	 * @return Injector
 	 */
 	public function share( $interface_or_class ): Injector {
 		$this->shared_instances[ $interface_or_class ] = null;
@@ -196,7 +193,6 @@ final class SimpleInjector implements Injector {
 	 * @param string   $interface_or_class Interface or class to delegate the
 	 *                                     instantiation of.
 	 * @param callable $callable           Callable to use for instantiation.
-	 * @return Injector
 	 */
 	public function delegate( $interface_or_class, callable $callable ): Injector {
 		$this->delegates[ $interface_or_class ] = $callable;
@@ -335,7 +331,6 @@ final class SimpleInjector implements Injector {
 	 * @throws FailedToMakeInstance If the interface could not be resolved.
 	 *
 	 * @param ReflectionClass $reflection Reflected class to check.
-	 * @return void
 	 */
 	private function ensure_is_instantiable( ReflectionClass $reflection ): void {
 		if ( ! $reflection->isInstantiable() ) {

--- a/includes/Infrastructure/PluginActivationAware.php
+++ b/includes/Infrastructure/PluginActivationAware.php
@@ -38,7 +38,6 @@ interface PluginActivationAware {
 	 * @since 1.6.0
 	 *
 	 * @param bool $network_wide Whether the activation was done network-wide.
-	 * @return void
 	 */
 	public function on_plugin_activation( $network_wide ): void;
 }

--- a/includes/Infrastructure/PluginDeactivationAware.php
+++ b/includes/Infrastructure/PluginDeactivationAware.php
@@ -38,7 +38,6 @@ interface PluginDeactivationAware {
 	 * @since 1.6.0
 	 *
 	 * @param bool $network_wide Whether the deactivation was done network-wide.
-	 * @return void
 	 */
 	public function on_plugin_deactivation( $network_wide ): void;
 }

--- a/includes/Infrastructure/Registerable.php
+++ b/includes/Infrastructure/Registerable.php
@@ -39,8 +39,6 @@ interface Registerable {
 	 * Register the service.
 	 *
 	 * @since 1.6.0
-	 *
-	 * @return void
 	 */
 	public function register(): void;
 }

--- a/includes/Infrastructure/ServiceBasedPlugin.php
+++ b/includes/Infrastructure/ServiceBasedPlugin.php
@@ -120,7 +120,6 @@ abstract class ServiceBasedPlugin implements Plugin {
 	 * @since 1.6.0
 	 *
 	 * @param bool $network_wide Whether the activation was done network-wide.
-	 * @return void
 	 */
 	public function on_plugin_activation( $network_wide ): void {
 		$this->register_services();
@@ -142,7 +141,6 @@ abstract class ServiceBasedPlugin implements Plugin {
 	 * @since 1.6.0
 	 *
 	 * @param bool $network_wide Whether the deactivation was done network-wide.
-	 * @return void
 	 */
 	public function on_plugin_deactivation( $network_wide ): void {
 		$this->register_services();
@@ -164,7 +162,6 @@ abstract class ServiceBasedPlugin implements Plugin {
 	 * @since 1.11.0
 	 *
 	 * @param WP_Site $site The site being initialized.
-	 * @return void
 	 */
 	public function on_site_initialization( WP_Site $site ): void {
 		$this->register_services();
@@ -193,7 +190,6 @@ abstract class ServiceBasedPlugin implements Plugin {
 	 * @since 1.11.0
 	 *
 	 * @param WP_Site $site The site being removed.
-	 * @return void
 	 */
 	public function on_site_removal( WP_Site $site ): void {
 		$this->register_services();
@@ -218,8 +214,6 @@ abstract class ServiceBasedPlugin implements Plugin {
 	 * @since 1.6.0
 	 *
 	 * @throws InvalidService If a service is not valid.
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		if ( false !== static::REGISTRATION_ACTION ) {
@@ -238,8 +232,6 @@ abstract class ServiceBasedPlugin implements Plugin {
 	 * @since 1.6.0
 	 *
 	 * @throws InvalidService If a service is not valid.
-	 *
-	 * @return void
 	 */
 	public function register_services(): void {
 		// Bail early so we don't instantiate services twice.
@@ -533,7 +525,6 @@ abstract class ServiceBasedPlugin implements Plugin {
 	 *
 	 * @param string                       $id ID of the service to register.
 	 * @param HasRequirements|class-string $class Class of the service to register.
-	 * @return void
 	 */
 	protected function schedule_potential_service_registration( $id, $class ): void {
 		if ( is_a( $class, Delayed::class, true ) ) {
@@ -563,7 +554,6 @@ abstract class ServiceBasedPlugin implements Plugin {
 	 *
 	 * @param string              $id ID of the service to register.
 	 * @param class-string|object $class Class of the service to register.
-	 * @return void
 	 */
 	protected function maybe_register_service( $id, $class ): void {
 		// Ensure we don't register the same service more than once.

--- a/includes/Infrastructure/ServiceContainer.php
+++ b/includes/Infrastructure/ServiceContainer.php
@@ -56,7 +56,6 @@ interface ServiceContainer extends Traversable, Countable, ArrayAccess {
 	 * @since 1.6.0
 	 *
 	 * @param string $id Identifier of the service to look for.
-	 * @return bool
 	 */
 	public function has( $id ): bool;
 
@@ -68,7 +67,6 @@ interface ServiceContainer extends Traversable, Countable, ArrayAccess {
 	 * @param string  $id      Identifier of the service to put into the
 	 *                         container.
 	 * @param Service $service Service to put into the container.
-	 * @return void
 	 */
 	public function put( $id, Service $service ): void;
 }

--- a/includes/Infrastructure/ServiceContainer/SimpleServiceContainer.php
+++ b/includes/Infrastructure/ServiceContainer/SimpleServiceContainer.php
@@ -69,7 +69,6 @@ final class SimpleServiceContainer
 	 * @since 1.6.0
 	 *
 	 * @param string $id Identifier of the service to look for.
-	 * @return bool
 	 */
 	public function has( $id ): bool {
 		return $this->offsetExists( $id );
@@ -83,7 +82,6 @@ final class SimpleServiceContainer
 	 * @param string  $id      Identifier of the service to put into the
 	 *                         container.
 	 * @param Service $service Service to put into the container.
-	 * @return void
 	 */
 	public function put( $id, Service $service ): void {
 		$this->offsetSet( $id, $service );

--- a/includes/Infrastructure/SiteInitializationAware.php
+++ b/includes/Infrastructure/SiteInitializationAware.php
@@ -30,7 +30,6 @@ interface SiteInitializationAware {
 	 * @since 1.11.0
 	 *
 	 * @param WP_Site $site The site being initialized.
-	 * @return void
 	 */
 	public function on_site_initialization( WP_Site $site ): void;
 }

--- a/includes/Infrastructure/SiteRemovalAware.php
+++ b/includes/Infrastructure/SiteRemovalAware.php
@@ -30,7 +30,6 @@ interface SiteRemovalAware {
 	 * @since 1.11.0
 	 *
 	 * @param WP_Site $site The site being removed.
-	 * @return void
 	 */
 	public function on_site_removal( WP_Site $site ): void;
 }

--- a/includes/Integrations/AMP.php
+++ b/includes/Integrations/AMP.php
@@ -103,8 +103,6 @@ class AMP extends Service_Base implements HasRequirements {
 	 * Initializes all hooks.
 	 *
 	 * @since 1.2.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_filter( 'option_amp-options', [ $this, 'filter_amp_options' ] );
@@ -331,8 +329,6 @@ class AMP extends Service_Base implements HasRequirements {
 	 * @SuppressWarnings(PHPMD.NPathComplexity)
 	 *
 	 * @since 1.2.0
-	 *
-	 * @return string|null
 	 */
 	protected function get_request_post_type(): ?string {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized

--- a/includes/Integrations/Conditional_Featured_Image.php
+++ b/includes/Integrations/Conditional_Featured_Image.php
@@ -56,8 +56,6 @@ class Conditional_Featured_Image extends Service_Base {
 	 * Initializes all hooks.
 	 *
 	 * @since 1.16.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_filter( 'cybocfi_enabled_for_post_type', [ $this, 'cybocfi_enabled_for_post_type' ], 99, 2 );
@@ -70,7 +68,6 @@ class Conditional_Featured_Image extends Service_Base {
 	 *
 	 * @param bool   $enabled If enabled or not.
 	 * @param string $post_type Post type name.
-	 * @return bool
 	 */
 	public function cybocfi_enabled_for_post_type( $enabled, $post_type ): bool {
 		if ( $this->story_post_type->get_slug() === $post_type ) {

--- a/includes/Integrations/Core_Themes_Support.php
+++ b/includes/Integrations/Core_Themes_Support.php
@@ -81,8 +81,6 @@ class Core_Themes_Support extends Service_Base {
 	 * options supported themes.
 	 *
 	 * @since 1.5.0
-	 *
-	 * @return void
 	 */
 	public function extend_theme_support(): void {
 		add_theme_support( 'web-stories' );
@@ -94,8 +92,6 @@ class Core_Themes_Support extends Service_Base {
 	 * Embeds web stories with default customizer settings.
 	 *
 	 * @since 1.5.0
-	 *
-	 * @return void
 	 */
 	public function embed_web_stories(): void {
 		$stylesheet = get_stylesheet();
@@ -130,8 +126,6 @@ class Core_Themes_Support extends Service_Base {
 	 * Adds theme support and hook to embed the web stories.
 	 *
 	 * @since 1.5.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 

--- a/includes/Integrations/Jetpack.php
+++ b/includes/Integrations/Jetpack.php
@@ -104,8 +104,6 @@ class Jetpack extends Service_Base {
 	 * Initializes all hooks.
 	 *
 	 * @since 1.2.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		// See https://github.com/Automattic/jetpack/blob/4b85be883b3c584c64eeb2fb0f3fcc15dabe2d30/modules/custom-post-types/portfolios.php#L80.
@@ -262,7 +260,6 @@ class Jetpack extends Service_Base {
 	 *
 	 * @param WP_REST_Response $response The response object.
 	 * @param WP_Post          $post     The original attachment post.
-	 * @return WP_REST_Response
 	 */
 	public function filter_rest_api_response( WP_REST_Response $response, WP_Post $post ): WP_REST_Response {
 		if ( self::VIDEOPRESS_MIME_TYPE !== $post->post_mime_type ) {
@@ -319,7 +316,6 @@ class Jetpack extends Service_Base {
 	 * @since 1.7.2
 	 *
 	 * @param int $milliseconds Milliseconds to converted to minutes and seconds.
-	 * @return string
 	 */
 	protected function format_milliseconds( $milliseconds ): string {
 		$seconds = floor( $milliseconds / 1000 );
@@ -343,7 +339,6 @@ class Jetpack extends Service_Base {
 	 * @param int    $mid         The meta ID after successful update.
 	 * @param int    $object_id   ID of the object metadata is for.
 	 * @param string $meta_key    Metadata key.
-	 * @return void
 	 */
 	public function add_term( $mid, $object_id, $meta_key ): void {
 		if ( self::VIDEOPRESS_POSTER_META_KEY !== $meta_key ) {

--- a/includes/Integrations/New_Relic.php
+++ b/includes/Integrations/New_Relic.php
@@ -56,8 +56,6 @@ class New_Relic extends Service_Base implements Conditional {
 	 * Runs on instantiation.
 	 *
 	 * @since 1.10.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		$this->disable_autorum();
@@ -110,8 +108,6 @@ class New_Relic extends Service_Base implements Conditional {
 	 * https://docs.newrelic.com/docs/browser/new-relic-browser/installation/monitor-amp-pages-new-relic-browser
 	 *
 	 * @since 1.10.0
-	 *
-	 * @return void
 	 */
 	public function disable_autorum(): void {
 		if ( ! $this->context->is_web_story() ) {

--- a/includes/Integrations/NextGen_Gallery.php
+++ b/includes/Integrations/NextGen_Gallery.php
@@ -37,8 +37,6 @@ class NextGen_Gallery extends Service_Base {
 	 * Initializes all hooks.
 	 *
 	 * @since 1.2.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_filter( 'run_ngg_resource_manager', [ $this, 'filter_run_ngg_resource_manager' ], PHP_INT_MAX );

--- a/includes/Integrations/Site_Kit.php
+++ b/includes/Integrations/Site_Kit.php
@@ -63,8 +63,6 @@ class Site_Kit extends Service_Base {
 	 * Initializes all hooks.
 	 *
 	 * @since 1.2.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_filter( 'googlesitekit_amp_gtag_opt', [ $this, 'filter_site_kit_gtag_opt' ] );

--- a/includes/Interfaces/Field.php
+++ b/includes/Interfaces/Field.php
@@ -19,8 +19,6 @@ interface Field {
 	 * Whether to display the field.
 	 *
 	 * @since 1.5.0
-	 *
-	 * @return bool
 	 */
 	public function show(): bool;
 
@@ -28,8 +26,6 @@ interface Field {
 	 * Label for current field.
 	 *
 	 * @since 1.5.0
-	 *
-	 * @return string
 	 */
 	public function label(): string;
 
@@ -37,8 +33,6 @@ interface Field {
 	 * Whether the field is hidden.
 	 *
 	 * @since 1.5.0
-	 *
-	 * @return bool
 	 */
 	public function hidden(): bool;
 }

--- a/includes/Interfaces/Migration.php
+++ b/includes/Interfaces/Migration.php
@@ -35,8 +35,6 @@ interface Migration {
 	 * Migrate
 	 *
 	 * @since 1.7.0
-	 *
-	 * @return void
 	 */
 	public function migrate(): void;
 }

--- a/includes/Interfaces/Renderer.php
+++ b/includes/Interfaces/Renderer.php
@@ -38,8 +38,6 @@ interface Renderer {
 	 * adding hooks and setting up states.
 	 *
 	 * @since 1.5.0
-	 *
-	 * @return void
 	 */
 	public function init(): void;
 

--- a/includes/KSES.php
+++ b/includes/KSES.php
@@ -59,8 +59,6 @@ class KSES extends Service_Base implements HasRequirements {
 	 * Initializes KSES filters for stories.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_filter( 'wp_insert_post_data', [ $this, 'filter_insert_post_data' ], 10, 3 );

--- a/includes/Media/Base_Color.php
+++ b/includes/Media/Base_Color.php
@@ -43,8 +43,6 @@ class Base_Color extends Service_Base implements HasMeta {
 	 * Init.
 	 *
 	 * @since 1.15.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		$this->register_meta();
@@ -56,8 +54,6 @@ class Base_Color extends Service_Base implements HasMeta {
 	 * Register meta
 	 *
 	 * @since 1.15.0
-	 *
-	 * @return void
 	 */
 	public function register_meta(): void {
 		register_meta(

--- a/includes/Media/Blurhash.php
+++ b/includes/Media/Blurhash.php
@@ -43,8 +43,6 @@ class Blurhash extends Service_Base implements HasMeta {
 	 * Init.
 	 *
 	 * @since 1.16.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		$this->register_meta();
@@ -56,8 +54,6 @@ class Blurhash extends Service_Base implements HasMeta {
 	 * Register meta
 	 *
 	 * @since 1.16.0
-	 *
-	 * @return void
 	 */
 	public function register_meta(): void {
 		register_meta(

--- a/includes/Media/Image_Sizes.php
+++ b/includes/Media/Image_Sizes.php
@@ -67,8 +67,6 @@ class Image_Sizes extends Service_Base {
 	 * Init.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		$this->add_image_sizes();
@@ -81,8 +79,6 @@ class Image_Sizes extends Service_Base {
 	 * @since 1.10.0
 	 *
 	 * @link https://amp.dev/documentation/components/amp-story/#poster-guidelines-for-poster-portrait-src-poster-landscape-src-and-poster-square-src.
-	 *
-	 * @return void
 	 */
 	protected function add_image_sizes(): void {
 		// Used for amp-story[poster-portrait-src]: The story poster in portrait format (3x4 aspect ratio).

--- a/includes/Media/Media_Source_Taxonomy.php
+++ b/includes/Media/Media_Source_Taxonomy.php
@@ -75,8 +75,6 @@ class Media_Source_Taxonomy extends Taxonomy_Base {
 	 * Init.
 	 *
 	 * @since 1.10.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		$this->register_taxonomy();
@@ -115,8 +113,6 @@ class Media_Source_Taxonomy extends Taxonomy_Base {
 	 * Registers additional REST API fields upon API initialization.
 	 *
 	 * @since 1.10.0
-	 *
-	 * @return void
 	 */
 	public function rest_api_init(): void {
 		// Custom field, as built in term update require term id and not slug.
@@ -168,7 +164,6 @@ class Media_Source_Taxonomy extends Taxonomy_Base {
 	 * @since 1.0.0
 	 *
 	 * @param array $prepared Prepared data before response.
-	 * @return string
 	 */
 	public function get_callback_media_source( $prepared ): string {
 		$id = $prepared['id'];
@@ -273,7 +268,6 @@ class Media_Source_Taxonomy extends Taxonomy_Base {
 	 * @since 1.10.0
 	 *
 	 * @param WP_Query $query WP_Query instance, passed by reference.
-	 * @return void
 	 */
 	public function filter_generated_media_attachments( &$query ): void {
 		if ( is_admin() && $query->is_main_query() && $this->context->is_upload_screen() ) {

--- a/includes/Media/SVG.php
+++ b/includes/Media/SVG.php
@@ -88,8 +88,6 @@ class SVG extends Service_Base {
 	 * Register filters and actions.
 	 *
 	 * @since 1.3.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		if ( ! $this->experiments->is_experiment_enabled( 'enableSVG' ) ) {
@@ -116,8 +114,6 @@ class SVG extends Service_Base {
 	 * Helper function to check if svg uploads are already enabled.
 	 *
 	 * @since 1.3.0
-	 *
-	 * @return bool
 	 */
 	private function svg_already_enabled(): bool {
 		$allowed_mime_types = get_allowed_mime_types();

--- a/includes/Media/Video/Captions.php
+++ b/includes/Media/Video/Captions.php
@@ -36,8 +36,6 @@ class Captions extends Service_Base {
 	 * Initializes the File_Type logic.
 	 *
 	 * @since 1.7.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_filter( 'site_option_upload_filetypes', [ $this, 'filter_list_of_allowed_filetypes' ] );

--- a/includes/Media/Video/Muting.php
+++ b/includes/Media/Video/Muting.php
@@ -54,8 +54,6 @@ class Muting extends Service_Base implements HasMeta {
 	 * Register.
 	 *
 	 * @since 1.10.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		$this->register_meta();
@@ -68,8 +66,6 @@ class Muting extends Service_Base implements HasMeta {
 	 * Register meta for attachment post type.
 	 *
 	 * @since 1.10.0
-	 *
-	 * @return void
 	 */
 	public function register_meta(): void {
 		register_meta(
@@ -103,8 +99,6 @@ class Muting extends Service_Base implements HasMeta {
 	 * Registers additional REST API fields upon API initialization.
 	 *
 	 * @since 1.10.0
-	 *
-	 * @return void
 	 */
 	public function rest_api_init(): void {
 		register_rest_field(
@@ -151,7 +145,6 @@ class Muting extends Service_Base implements HasMeta {
 	 * @since 1.10.0
 	 *
 	 * @param array $prepared Array of data to add to.
-	 * @return bool|null
 	 */
 	public function get_callback_is_muted( $prepared ): ?bool {
 		/**

--- a/includes/Media/Video/Optimization.php
+++ b/includes/Media/Video/Optimization.php
@@ -43,8 +43,6 @@ class Optimization extends Service_Base implements HasMeta {
 	 * Init.
 	 *
 	 * @since 1.10.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		$this->register_meta();
@@ -54,8 +52,6 @@ class Optimization extends Service_Base implements HasMeta {
 	 * Register meta
 	 *
 	 * @since 1.15.0
-	 *
-	 * @return void
 	 */
 	public function register_meta(): void {
 		register_meta(

--- a/includes/Media/Video/Poster.php
+++ b/includes/Media/Video/Poster.php
@@ -67,8 +67,6 @@ class Poster extends Service_Base implements HasMeta {
 	 * Init.
 	 *
 	 * @since 1.10.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		$this->register_meta();
@@ -81,8 +79,6 @@ class Poster extends Service_Base implements HasMeta {
 	 * Register meta for attachment post type.
 	 *
 	 * @since 1.10.0
-	 *
-	 * @return void
 	 */
 	public function register_meta(): void {
 		register_meta(
@@ -104,8 +100,6 @@ class Poster extends Service_Base implements HasMeta {
 	 * Registers additional REST API fields upon API initialization.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return void
 	 */
 	public function rest_api_init(): void {
 		register_rest_field(
@@ -223,7 +217,6 @@ class Poster extends Service_Base implements HasMeta {
 	 * @since 1.0.0
 	 *
 	 * @param int $attachment_id ID of the attachment to be deleted.
-	 * @return void
 	 */
 	public function delete_video_poster( int $attachment_id ): void {
 		/**
@@ -250,7 +243,6 @@ class Poster extends Service_Base implements HasMeta {
 	 * @since 1.2.1
 	 *
 	 * @param int $post_id Attachment ID.
-	 * @return bool
 	 */
 	protected function is_poster( int $post_id ): bool {
 		$terms = get_the_terms( $post_id, $this->media_source_taxonomy->get_taxonomy_slug() );

--- a/includes/Media/Video/Trimming.php
+++ b/includes/Media/Video/Trimming.php
@@ -48,8 +48,6 @@ class Trimming extends Service_Base implements HasMeta {
 	 * Register.
 	 *
 	 * @since 1.12.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		$this->register_meta();
@@ -61,8 +59,6 @@ class Trimming extends Service_Base implements HasMeta {
 	 * Register meta for attachment post type.
 	 *
 	 * @since 1.12.0
-	 *
-	 * @return void
 	 */
 	public function register_meta(): void {
 		register_meta(

--- a/includes/Migrations/Add_Media_Source.php
+++ b/includes/Migrations/Add_Media_Source.php
@@ -54,8 +54,6 @@ abstract class Add_Media_Source extends Migrate_Base {
 	 * Add the editor term, to make sure it exists.
 	 *
 	 * @since 1.9.0
-	 *
-	 * @return void
 	 */
 	public function migrate(): void {
 		wp_insert_term( $this->get_term(), $this->media_source_taxonomy->get_taxonomy_slug() );
@@ -65,8 +63,6 @@ abstract class Add_Media_Source extends Migrate_Base {
 	 * Override this method.
 	 *
 	 * @since 1.9.0
-	 *
-	 * @return string
 	 */
 	abstract protected function get_term(): string;
 }

--- a/includes/Migrations/Add_Media_Source_Editor.php
+++ b/includes/Migrations/Add_Media_Source_Editor.php
@@ -34,8 +34,6 @@ class Add_Media_Source_Editor extends Add_Media_Source {
 	 * Term name.
 	 *
 	 * @since 1.9.0
-	 *
-	 * @return string
 	 */
 	protected function get_term(): string {
 		return 'editor';

--- a/includes/Migrations/Add_Media_Source_Gif_Conversion.php
+++ b/includes/Migrations/Add_Media_Source_Gif_Conversion.php
@@ -34,8 +34,6 @@ class Add_Media_Source_Gif_Conversion extends Add_Media_Source {
 	 * Term name.
 	 *
 	 * @since 1.9.0
-	 *
-	 * @return string
 	 */
 	protected function get_term(): string {
 		return 'gif-conversion';

--- a/includes/Migrations/Add_Media_Source_Page_Template.php
+++ b/includes/Migrations/Add_Media_Source_Page_Template.php
@@ -34,8 +34,6 @@ class Add_Media_Source_Page_Template extends Add_Media_Source {
 	 * Term name.
 	 *
 	 * @since 1.14.0
-	 *
-	 * @return string
 	 */
 	protected function get_term(): string {
 		return 'page-template';

--- a/includes/Migrations/Add_Media_Source_Source_Image.php
+++ b/includes/Migrations/Add_Media_Source_Source_Image.php
@@ -34,8 +34,6 @@ class Add_Media_Source_Source_Image extends Add_Media_Source {
 	 * Term name.
 	 *
 	 * @since 1.9.0
-	 *
-	 * @return string
 	 */
 	protected function get_term(): string {
 		return 'source-image';

--- a/includes/Migrations/Add_Media_Source_Source_Video.php
+++ b/includes/Migrations/Add_Media_Source_Source_Video.php
@@ -34,8 +34,6 @@ class Add_Media_Source_Source_Video extends Add_Media_Source {
 	 * Term name.
 	 *
 	 * @since 1.9.0
-	 *
-	 * @return string
 	 */
 	protected function get_term(): string {
 		return 'source-video';

--- a/includes/Migrations/Add_Media_Source_Video_Optimization.php
+++ b/includes/Migrations/Add_Media_Source_Video_Optimization.php
@@ -34,8 +34,6 @@ class Add_Media_Source_Video_Optimization extends Add_Media_Source {
 	 * Term name.
 	 *
 	 * @since 1.9.0
-	 *
-	 * @return string
 	 */
 	protected function get_term(): string {
 		return 'video-optimization';

--- a/includes/Migrations/Add_Poster_Generation_Media_Source.php
+++ b/includes/Migrations/Add_Poster_Generation_Media_Source.php
@@ -37,8 +37,6 @@ class Add_Poster_Generation_Media_Source extends Migration_Meta_To_Term {
 	 * Migration media post meta to taxonomy term.
 	 *
 	 * @since 1.7.0
-	 *
-	 * @return void
 	 */
 	public function migrate(): void {
 		wp_insert_term( $this->get_term_name(), $this->media_source_taxonomy->get_taxonomy_slug() );
@@ -49,8 +47,6 @@ class Add_Poster_Generation_Media_Source extends Migration_Meta_To_Term {
 	 * Get name of meta key to be used in migration.
 	 *
 	 * @since 1.7.2
-	 *
-	 * @return string
 	 */
 	protected function get_post_meta_key(): string {
 		return Poster::POSTER_POST_META_KEY;

--- a/includes/Migrations/Add_Stories_Caps.php
+++ b/includes/Migrations/Add_Stories_Caps.php
@@ -54,8 +54,6 @@ class Add_Stories_Caps extends Migrate_Base {
 	 * Adds story capabilities to default user roles.
 	 *
 	 * @since 1.7.0
-	 *
-	 * @return void
 	 */
 	public function migrate(): void {
 		$this->capabilities->add_caps_to_roles();

--- a/includes/Migrations/Add_VideoPress_Poster_Generation_Media_Source.php
+++ b/includes/Migrations/Add_VideoPress_Poster_Generation_Media_Source.php
@@ -36,8 +36,6 @@ class Add_VideoPress_Poster_Generation_Media_Source extends Migration_Meta_To_Te
 	 * Get name of meta key to be used in migration.
 	 *
 	 * @since 1.7.2
-	 *
-	 * @return string
 	 */
 	protected function get_post_meta_key(): string {
 		return Jetpack::VIDEOPRESS_POSTER_META_KEY;

--- a/includes/Migrations/Migration_Meta_To_Term.php
+++ b/includes/Migrations/Migration_Meta_To_Term.php
@@ -57,8 +57,6 @@ abstract class Migration_Meta_To_Term extends Migrate_Base {
 	 * @since 1.7.2
 	 *
 	 * @global \wpdb $wpdb WordPress database abstraction object.
-	 *
-	 * @return void
 	 */
 	public function migrate(): void {
 		global $wpdb;
@@ -82,8 +80,6 @@ abstract class Migration_Meta_To_Term extends Migrate_Base {
 	 * This method is designed for overridden.
 	 *
 	 * @since 1.7.2
-	 *
-	 * @return string
 	 */
 	abstract protected function get_post_meta_key(): string;
 
@@ -92,8 +88,6 @@ abstract class Migration_Meta_To_Term extends Migrate_Base {
 	 * This method is designed for overridden.
 	 *
 	 * @since 1.7.2
-	 *
-	 * @return string
 	 */
 	protected function get_term_name(): string {
 		return 'poster-generation';

--- a/includes/Migrations/Remove_Broken_Text_Styles.php
+++ b/includes/Migrations/Remove_Broken_Text_Styles.php
@@ -36,8 +36,6 @@ class Remove_Broken_Text_Styles extends Migrate_Base {
 	 * Removes broken text styles (with color.r|g|b structure).
 	 *
 	 * @since 1.7.0
-	 *
-	 * @return void
 	 */
 	public function migrate(): void {
 		$style_presets = get_option( Story_Post_Type::STYLE_PRESETS_OPTION, false );

--- a/includes/Migrations/Remove_Unneeded_Attachment_Meta.php
+++ b/includes/Migrations/Remove_Unneeded_Attachment_Meta.php
@@ -38,8 +38,6 @@ class Remove_Unneeded_Attachment_Meta extends Migrate_Base {
 	 * @since 1.7.0
 	 *
 	 * @global \wpdb $wpdb WordPress database abstraction object.
-	 *
-	 * @return void
 	 */
 	public function migrate(): void {
 		delete_post_meta_by_key( Poster::POSTER_POST_META_KEY );

--- a/includes/Migrations/Replace_Conic_Style_Presets.php
+++ b/includes/Migrations/Replace_Conic_Style_Presets.php
@@ -36,8 +36,6 @@ class Replace_Conic_Style_Presets extends Migrate_Base {
 	 * Replaces conic color type with linear.
 	 *
 	 * @since 1.7.0
-	 *
-	 * @return void
 	 */
 	public function migrate(): void {
 		$style_presets = get_option( Story_Post_Type::STYLE_PRESETS_OPTION, false );

--- a/includes/Migrations/Rewrite_Flush.php
+++ b/includes/Migrations/Rewrite_Flush.php
@@ -37,8 +37,6 @@ class Rewrite_Flush extends Migrate_Base {
 	 * Flush rewrite rules.
 	 *
 	 * @since 1.7.0
-	 *
-	 * @return void
 	 */
 	public function migrate(): void {
 		if ( ! \defined( '\WPCOM_IS_VIP_ENV' ) || false === WPCOM_IS_VIP_ENV ) {

--- a/includes/Migrations/Set_Legacy_Analytics_Usage_Flag.php
+++ b/includes/Migrations/Set_Legacy_Analytics_Usage_Flag.php
@@ -55,8 +55,6 @@ class Set_Legacy_Analytics_Usage_Flag extends Migrate_Base {
 	 * Set legacy analytics usage flag.
 	 *
 	 * @since 1.12.0
-	 *
-	 * @return void
 	 */
 	public function migrate(): void {
 		$this->settings->update_setting(

--- a/includes/Migrations/Unify_Color_Presets.php
+++ b/includes/Migrations/Unify_Color_Presets.php
@@ -39,8 +39,6 @@ class Unify_Color_Presets extends Migrate_Base {
 	 * Color presets: Removes fillColor and textColor and unifies to one color.
 	 *
 	 * @since 1.7.0
-	 *
-	 * @return void
 	 */
 	public function migrate(): void {
 		$style_presets = get_option( Story_Post_Type::STYLE_PRESETS_OPTION, false );

--- a/includes/Migrations/Update_1.php
+++ b/includes/Migrations/Update_1.php
@@ -34,8 +34,6 @@ class Update_1 extends Migrate_Base {
 	 * First database migration.
 	 *
 	 * @since 1.7.0
-	 *
-	 * @return void
 	 */
 	public function migrate(): void {
 		// Do nothing.

--- a/includes/Migrations/Update_Publisher_Logos.php
+++ b/includes/Migrations/Update_Publisher_Logos.php
@@ -55,8 +55,6 @@ class Update_Publisher_Logos extends Migrate_Base {
 	 * Split publisher logos into two options.
 	 *
 	 * @since 1.7.0
-	 *
-	 * @return void
 	 */
 	public function migrate(): void {
 		$publisher_logo_id       = 0;

--- a/includes/Migrations/Yoast_Reindex_Stories.php
+++ b/includes/Migrations/Yoast_Reindex_Stories.php
@@ -37,8 +37,6 @@ class Yoast_Reindex_Stories extends Migrate_Base {
 	 * Re-index stories in Yoast SEO if permalinks are outdated.
 	 *
 	 * @since 1.7.0
-	 *
-	 * @return void
 	 */
 	public function migrate(): void {
 		if (

--- a/includes/Model/Story.php
+++ b/includes/Model/Story.php
@@ -146,7 +146,6 @@ class Story {
 	 * @since 1.0.0
 	 *
 	 * @param int|null|WP_Post $_post Post id or Post object.
-	 * @return bool
 	 */
 	public function load_from_post( $_post ): bool {
 		$this->publisher_name = get_bloginfo( 'name' );
@@ -204,8 +203,6 @@ class Story {
 	 * Getter for poster source set sizes.
 	 *
 	 * @since 1.18.0
-	 *
-	 * @return string
 	 */
 	public function get_poster_sizes(): string {
 		return (string) $this->poster_sizes;
@@ -215,8 +212,6 @@ class Story {
 	 * Getter for poster source set.
 	 *
 	 * @since 1.18.0
-	 *
-	 * @return string
 	 */
 	public function get_poster_srcset(): string {
 		return (string) $this->poster_srcset;
@@ -226,8 +221,6 @@ class Story {
 	 * Getter for title attribute.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return string
 	 */
 	public function get_title(): string {
 		return (string) $this->title;
@@ -235,8 +228,6 @@ class Story {
 
 	/**
 	 * Getter for excerpt attribute.
-	 *
-	 * @return string
 	 */
 	public function get_excerpt(): string {
 		return (string) $this->excerpt;
@@ -246,8 +237,6 @@ class Story {
 	 * Getter for url attribute.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return string
 	 */
 	public function get_url(): string {
 		return (string) $this->url;
@@ -257,8 +246,6 @@ class Story {
 	 * Getter for markup attribute.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return string
 	 */
 	public function get_markup(): string {
 		return (string) $this->markup;
@@ -268,8 +255,6 @@ class Story {
 	 * Getter for poster portrait attribute.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return string
 	 */
 	public function get_poster_portrait(): string {
 		return (string) $this->poster_portrait;
@@ -277,8 +262,6 @@ class Story {
 
 	/**
 	 * Get the story ID.
-	 *
-	 * @return int
 	 */
 	public function get_id(): int {
 		return (int) $this->id;
@@ -286,8 +269,6 @@ class Story {
 
 	/**
 	 * Get author of the story.
-	 *
-	 * @return string
 	 */
 	public function get_author(): string {
 		return (string) $this->author;
@@ -295,8 +276,6 @@ class Story {
 
 	/**
 	 * Date for the story.
-	 *
-	 * @return string
 	 */
 	public function get_date(): string {
 		return (string) $this->date;

--- a/includes/Page_Template_Post_Type.php
+++ b/includes/Page_Template_Post_Type.php
@@ -60,8 +60,6 @@ class Page_Template_Post_Type extends Post_Type_Base implements HasRequirements 
 
 	/**
 	 * Init
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		parent::register();
@@ -73,8 +71,6 @@ class Page_Template_Post_Type extends Post_Type_Base implements HasRequirements 
 	 * Get post type slug.
 	 *
 	 * @since 1.14.0
-	 *
-	 * @return string
 	 */
 	public function get_slug(): string {
 		return self::POST_TYPE_SLUG;
@@ -179,7 +175,6 @@ class Page_Template_Post_Type extends Post_Type_Base implements HasRequirements 
 	 * @since 1.14.0
 	 *
 	 * @param int $post_id Post ID.
-	 * @return void
 	 */
 	public function delete_poster_image( int $post_id ): void {
 		if ( get_post_type( $post_id ) !== $this->get_slug() ) {

--- a/includes/Post_Type_Base.php
+++ b/includes/Post_Type_Base.php
@@ -52,8 +52,6 @@ abstract class Post_Type_Base extends Service_Base implements PluginActivationAw
 	 * Registers the post type.
 	 *
 	 * @since 1.14.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		$this->register_post_type();
@@ -74,8 +72,6 @@ abstract class Post_Type_Base extends Service_Base implements PluginActivationAw
 	 * Unregister post type.
 	 *
 	 * @since 1.14.0
-	 *
-	 * @return void
 	 */
 	public function unregister_post_type(): void {
 		unregister_post_type( $this->get_slug() );
@@ -87,7 +83,6 @@ abstract class Post_Type_Base extends Service_Base implements PluginActivationAw
 	 * @since 1.14.0
 	 *
 	 * @param WP_Site $site The site being initialized.
-	 * @return void
 	 */
 	public function on_site_initialization( WP_Site $site ): void {
 		$this->register_post_type();
@@ -99,7 +94,6 @@ abstract class Post_Type_Base extends Service_Base implements PluginActivationAw
 	 * @since 1.14.0
 	 *
 	 * @param bool $network_wide Whether the activation was done network-wide.
-	 * @return void
 	 */
 	public function on_plugin_activation( $network_wide ): void {
 		$this->register_post_type();
@@ -111,7 +105,6 @@ abstract class Post_Type_Base extends Service_Base implements PluginActivationAw
 	 * @since 1.14.0
 	 *
 	 * @param bool $network_wide Whether the deactivation was done network-wide.
-	 * @return void
 	 */
 	public function on_plugin_deactivation( $network_wide ): void {
 		$this->unregister_post_type();
@@ -121,8 +114,6 @@ abstract class Post_Type_Base extends Service_Base implements PluginActivationAw
 	 * Post type slug.
 	 *
 	 * @since 1.14.0
-	 *
-	 * @return string
 	 */
 	abstract public function get_slug(): string;
 
@@ -139,8 +130,6 @@ abstract class Post_Type_Base extends Service_Base implements PluginActivationAw
 	 * Get post type object.
 	 *
 	 * @since 1.14.0
-	 *
-	 * @return WP_Post_Type|null
 	 */
 	protected function get_object(): ?WP_Post_Type {
 		return get_post_type_object( $this->get_slug() );
@@ -239,7 +228,6 @@ abstract class Post_Type_Base extends Service_Base implements PluginActivationAw
 	 * @since 1.14.0
 	 *
 	 * @param string $label Label name.
-	 * @return string
 	 */
 	public function get_label( string $label ): string {
 		$post_type_obj = $this->get_object();

--- a/includes/REST_API/Embed_Controller.php
+++ b/includes/REST_API/Embed_Controller.php
@@ -84,8 +84,6 @@ class Embed_Controller extends REST_Controller implements HasRequirements {
 	 * Registers routes for links.
 	 *
 	 * @see register_rest_route()
-	 *
-	 * @return void
 	 */
 	public function register_routes(): void {
 		register_rest_route(

--- a/includes/REST_API/Font_Controller.php
+++ b/includes/REST_API/Font_Controller.php
@@ -63,8 +63,6 @@ class Font_Controller extends WP_REST_Posts_Controller {
 	 * @since 1.16.0
 	 *
 	 * @see register_rest_route()
-	 *
-	 * @return void
 	 */
 	public function register_routes(): void {
 		register_rest_route(

--- a/includes/REST_API/Hotlinking_Controller.php
+++ b/includes/REST_API/Hotlinking_Controller.php
@@ -103,8 +103,6 @@ class Hotlinking_Controller extends REST_Controller implements HasRequirements {
 	 * @since 1.11.0
 	 *
 	 * @see register_rest_route()
-	 *
-	 * @return void
 	 */
 	public function register_routes(): void {
 		register_rest_route(
@@ -265,7 +263,6 @@ class Hotlinking_Controller extends REST_Controller implements HasRequirements {
 	 * @since 1.13.0
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 * @return void
 	 *
 	 * @todo Forward the Range request header.
 	 */
@@ -331,7 +328,6 @@ class Hotlinking_Controller extends REST_Controller implements HasRequirements {
 	 *
 	 * @param string $url  Request URL.
 	 * @param array  $args Request args.
-	 * @return void
 	 */
 	private function proxy_url_curl( $url, $args ): void {
 		add_action( 'http_api_curl', [ $this, 'modify_curl_configuration' ] );
@@ -353,7 +349,6 @@ class Hotlinking_Controller extends REST_Controller implements HasRequirements {
 	 *
 	 * @param string $url  Request URL.
 	 * @param array  $args Request args.
-	 * @return void
 	 */
 	private function proxy_url_fallback( $url, $args ): void {
 		$response = wp_safe_remote_get( $url, $args );
@@ -525,7 +520,6 @@ class Hotlinking_Controller extends REST_Controller implements HasRequirements {
 	 * @since 1.15.0
 	 *
 	 * @param resource $handle      The cURL handle returned by curl_init() (passed by reference).
-	 * @return void
 	 */
 	public function modify_curl_configuration( &$handle ): void {
 		// Just some safeguard in case cURL is not really available,

--- a/includes/REST_API/Link_Controller.php
+++ b/includes/REST_API/Link_Controller.php
@@ -82,8 +82,6 @@ class Link_Controller extends REST_Controller implements HasRequirements {
 	 * @since 1.0.0
 	 *
 	 * @see register_rest_route()
-	 *
-	 * @return void
 	 */
 	public function register_routes(): void {
 		register_rest_route(

--- a/includes/REST_API/Publisher_Logos_Controller.php
+++ b/includes/REST_API/Publisher_Logos_Controller.php
@@ -89,8 +89,6 @@ class Publisher_Logos_Controller extends REST_Controller implements HasRequireme
 	 * @since 1.12.0
 	 *
 	 * @see register_rest_route()
-	 *
-	 * @return void
 	 */
 	public function register_routes(): void {
 		register_rest_route(

--- a/includes/REST_API/REST_Controller.php
+++ b/includes/REST_API/REST_Controller.php
@@ -39,8 +39,6 @@ abstract class REST_Controller extends WP_REST_Controller implements Service, De
 	 * Register the service.
 	 *
 	 * @since 1.7.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		$this->register_routes();

--- a/includes/REST_API/Status_Check_Controller.php
+++ b/includes/REST_API/Status_Check_Controller.php
@@ -76,8 +76,6 @@ class Status_Check_Controller extends REST_Controller implements HasRequirements
 	 * Registers routes for links.
 	 *
 	 * @see register_rest_route()
-	 *
-	 * @return void
 	 */
 	public function register_routes(): void {
 		register_rest_route(

--- a/includes/REST_API/Stories_Autosaves_Controller.php
+++ b/includes/REST_API/Stories_Autosaves_Controller.php
@@ -85,8 +85,6 @@ class Stories_Autosaves_Controller extends WP_REST_Autosaves_Controller implemen
 	 * Register the service.
 	 *
 	 * @since 1.7.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		$this->register_routes();
@@ -135,8 +133,6 @@ class Stories_Autosaves_Controller extends WP_REST_Autosaves_Controller implemen
 	 * @since 1.0.0
 	 *
 	 * @see register_rest_route()
-	 *
-	 * @return void
 	 */
 	public function register_routes(): void {
 		parent::register_routes();

--- a/includes/REST_API/Stories_Base_Controller.php
+++ b/includes/REST_API/Stories_Base_Controller.php
@@ -369,8 +369,6 @@ class Stories_Base_Controller extends WP_REST_Posts_Controller {
 	 * Return namespace.
 	 *
 	 * @since 1.12.0
-	 *
-	 * @return string
 	 */
 	public function get_namespace(): string {
 		return $this->namespace;

--- a/includes/REST_API/Stories_Lock_Controller.php
+++ b/includes/REST_API/Stories_Lock_Controller.php
@@ -90,8 +90,6 @@ class Stories_Lock_Controller extends REST_Controller implements HasRequirements
 	 * @since 1.6.0
 	 *
 	 * @see register_rest_route()
-	 *
-	 * @return void
 	 */
 	public function register_routes(): void {
 		register_rest_route(

--- a/includes/REST_API/Stories_Media_Controller.php
+++ b/includes/REST_API/Stories_Media_Controller.php
@@ -67,8 +67,6 @@ class Stories_Media_Controller extends WP_REST_Attachments_Controller implements
 	 * Register the service.
 	 *
 	 * @since 1.7.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		$this->register_routes();

--- a/includes/REST_API/Stories_Settings_Controller.php
+++ b/includes/REST_API/Stories_Settings_Controller.php
@@ -51,8 +51,6 @@ class Stories_Settings_Controller extends WP_REST_Settings_Controller implements
 	 * Register the service.
 	 *
 	 * @since 1.7.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		$this->register_routes();

--- a/includes/REST_API/Stories_Taxonomies_Controller.php
+++ b/includes/REST_API/Stories_Taxonomies_Controller.php
@@ -87,8 +87,6 @@ class Stories_Taxonomies_Controller extends WP_REST_Taxonomies_Controller implem
 	 * Register the service.
 	 *
 	 * @since 1.12.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		$this->register_routes();

--- a/includes/REST_API/Stories_Terms_Controller.php
+++ b/includes/REST_API/Stories_Terms_Controller.php
@@ -55,8 +55,6 @@ class Stories_Terms_Controller extends WP_REST_Terms_Controller {
 	 * Return namespace.
 	 *
 	 * @since 1.12.0
-	 *
-	 * @return string
 	 */
 	public function get_namespace(): string {
 		return $this->namespace;

--- a/includes/REST_API/Stories_Users_Controller.php
+++ b/includes/REST_API/Stories_Users_Controller.php
@@ -66,8 +66,6 @@ class Stories_Users_Controller extends WP_REST_Users_Controller implements Servi
 	 * Register the service.
 	 *
 	 * @since 1.7.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		$this->register_routes();

--- a/includes/Register_Widget.php
+++ b/includes/Register_Widget.php
@@ -56,8 +56,6 @@ class Register_Widget implements Service, Registerable {
 	 * Register Widgets.
 	 *
 	 * @since 1.6.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_action( 'widgets_init', [ $this, 'register_widget' ] );
@@ -69,8 +67,6 @@ class Register_Widget implements Service, Registerable {
 	 * Register widget.
 	 *
 	 * @since 1.9.0
-	 *
-	 * @return void
 	 */
 	public function register_widget(): void {
 		register_widget( $this->stories );

--- a/includes/Renderer/Archives.php
+++ b/includes/Renderer/Archives.php
@@ -80,8 +80,6 @@ class Archives extends Service_Base {
 	 * Filter content and excerpt for search and post type archive.
 	 *
 	 * @since 1.7.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_filter( 'the_content', [ $this, 'embed_player' ], PHP_INT_MAX );

--- a/includes/Renderer/Feed.php
+++ b/includes/Renderer/Feed.php
@@ -41,8 +41,6 @@ class Feed extends Service_Base {
 	 * Filter RSS content fields.
 	 *
 	 * @since 1.7.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_filter( 'the_content_feed', [ $this, 'embed_image' ] );

--- a/includes/Renderer/Oembed.php
+++ b/includes/Renderer/Oembed.php
@@ -39,8 +39,6 @@ class Oembed extends Service_Base {
 	 * Filter to render oembed.
 	 *
 	 * @since 1.7.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_filter( 'embed_template', [ $this, 'filter_embed_template' ] );

--- a/includes/Renderer/Single.php
+++ b/includes/Renderer/Single.php
@@ -53,8 +53,6 @@ class Single extends Service_Base {
 	 * Initializes the Single logic.
 	 *
 	 * @since 1.7.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		// This is hooked to both the `template_include` and the `single_template` filters,

--- a/includes/Renderer/Story/HTML.php
+++ b/includes/Renderer/Story/HTML.php
@@ -201,7 +201,6 @@ class HTML {
 	 * @since 1.1.0
 	 *
 	 * @param string $content String to replace.
-	 * @return string
 	 */
 	protected function replace_url_scheme( string $content ): string {
 		if ( is_ssl() ) {
@@ -220,7 +219,6 @@ class HTML {
 	 * @since 1.2.0
 	 *
 	 * @param string $content String to replace.
-	 * @return string
 	 */
 	protected function print_analytics( string $content ): string {
 		ob_start();
@@ -245,7 +243,6 @@ class HTML {
 	 * @since 1.6.0
 	 *
 	 * @param string $content String to replace.
-	 * @return string
 	 */
 	protected function print_social_share( string $content ): string {
 		$share_providers = [

--- a/includes/Services.php
+++ b/includes/Services.php
@@ -44,7 +44,6 @@ final class Services {
 	 * @since 1.6.0
 	 *
 	 * @param string $service Service ID to retrieve.
-	 * @return Service
 	 */
 	public static function get( $service ): Service {
 		return self::get_container()->get( $service );
@@ -56,7 +55,6 @@ final class Services {
 	 * @since 1.6.0
 	 *
 	 * @param string $service Service ID to retrieve.
-	 * @return bool
 	 */
 	public static function has( $service ): bool {
 		return self::get_container()->has( $service );

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -108,8 +108,6 @@ class Settings extends Service_Base {
 	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		register_setting(

--- a/includes/Shortcode/Embed_Shortcode.php
+++ b/includes/Shortcode/Embed_Shortcode.php
@@ -41,8 +41,6 @@ class Embed_Shortcode extends Embed_Base {
 	 * Initializes the Web Stories embed shortcode.
 	 *
 	 * @since 1.1.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_shortcode( self::SHORTCODE_NAME, [ $this, 'render_shortcode' ] );

--- a/includes/Shortcode/Stories_Shortcode.php
+++ b/includes/Shortcode/Stories_Shortcode.php
@@ -43,8 +43,6 @@ class Stories_Shortcode extends Service_Base {
 	 * Initializes the Stories shortcode.
 	 *
 	 * @since 1.5.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_shortcode( self::SHORTCODE_NAME, [ $this, 'render_stories' ] );

--- a/includes/Story_Archive.php
+++ b/includes/Story_Archive.php
@@ -67,8 +67,6 @@ class Story_Archive extends Service_Base {
 	 * Registers Filters and actions
 	 *
 	 * @since 1.13.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		add_filter( 'pre_handle_404', [ $this, 'redirect_post_type_archive_urls' ], 10, 2 );
@@ -122,8 +120,6 @@ class Story_Archive extends Service_Base {
 	 * Clear rewrite rules on update on setting.
 	 *
 	 * @since 1.13.0
-	 *
-	 * @return void
 	 */
 	public function update_archive_setting(): void {
 		$this->story_post_type->unregister_post_type();
@@ -140,7 +136,6 @@ class Story_Archive extends Service_Base {
 	 * @since 1.13.0
 	 *
 	 * @param WP_Query $query Current query instance, passed by reference.
-	 * @return void
 	 */
 	public function pre_get_posts( WP_Query $query ): void {
 		if ( ! \is_string( $this->story_post_type->get_has_archive() ) ) {
@@ -171,7 +166,6 @@ class Story_Archive extends Service_Base {
 	 * @since 1.14.0
 	 *
 	 * @param int $postid Post ID.
-	 * @return void
 	 */
 	public function on_remove_archive_page( $postid ): void {
 		if ( 'page' !== get_post_type( $postid ) ) {

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -81,8 +81,6 @@ class Story_Post_Type extends Post_Type_Base implements HasRequirements, HasMeta
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return void
-	 *
 	 * @todo  refactor
 	 */
 	public function register(): void {
@@ -115,8 +113,6 @@ class Story_Post_Type extends Post_Type_Base implements HasRequirements, HasMeta
 	 * Get post type slug.
 	 *
 	 * @since 1.14.0
-	 *
-	 * @return string
 	 */
 	public function get_slug(): string {
 		return self::POST_TYPE_SLUG;
@@ -197,8 +193,6 @@ class Story_Post_Type extends Post_Type_Base implements HasRequirements, HasMeta
 	 * Register post meta.
 	 *
 	 * @since 1.12.0
-	 *
-	 * @return void
 	 */
 	public function register_meta(): void {
 		$active_publisher_logo_id = absint( $this->settings->get_setting( $this->settings::SETTING_NAME_ACTIVE_PUBLISHER_LOGO, 0 ) );
@@ -307,7 +301,6 @@ class Story_Post_Type extends Post_Type_Base implements HasRequirements, HasMeta
 	 *
 	 * @param int     $post_id Post ID.
 	 * @param WP_Post $post    Post object.
-	 * @return void
 	 */
 	public function clear_user_posts_count( $post_id, $post ): void {
 		if ( ! $post instanceof WP_Post || $this->get_slug() !== $post->post_type ) {

--- a/includes/Story_Query.php
+++ b/includes/Story_Query.php
@@ -149,8 +149,6 @@ class Story_Query {
 	 * Renders the stories output.
 	 *
 	 * @since 1.5.0
-	 *
-	 * @return string
 	 */
 	public function render(): string {
 		$this->renderer = $this->get_renderer();

--- a/includes/Taxonomy/Taxonomy_Base.php
+++ b/includes/Taxonomy/Taxonomy_Base.php
@@ -67,8 +67,6 @@ abstract class Taxonomy_Base extends Service_Base implements PluginActivationAwa
 	 * Register taxonomy on register service.
 	 *
 	 * @since 1.12.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		$this->register_taxonomy();
@@ -78,8 +76,6 @@ abstract class Taxonomy_Base extends Service_Base implements PluginActivationAwa
 	 * Register taxonomy.
 	 *
 	 * @since 1.12.0
-	 *
-	 * @return void
 	 */
 	public function register_taxonomy(): void {
 		register_taxonomy( $this->taxonomy_slug, $this->taxonomy_post_type, $this->taxonomy_args() );
@@ -89,8 +85,6 @@ abstract class Taxonomy_Base extends Service_Base implements PluginActivationAwa
 	 * Unregister taxonomy.
 	 *
 	 * @since 1.12.0
-	 *
-	 * @return void
 	 */
 	public function unregister_taxonomy(): void {
 		unregister_taxonomy( $this->taxonomy_slug );
@@ -111,7 +105,6 @@ abstract class Taxonomy_Base extends Service_Base implements PluginActivationAwa
 	 * @since 1.12.0
 	 *
 	 * @param WP_Site $site The site being initialized.
-	 * @return void
 	 */
 	public function on_site_initialization( WP_Site $site ): void {
 		$this->register_taxonomy();
@@ -123,7 +116,6 @@ abstract class Taxonomy_Base extends Service_Base implements PluginActivationAwa
 	 * @since 1.12.0
 	 *
 	 * @param bool $network_wide Whether the activation was done network-wide.
-	 * @return void
 	 */
 	public function on_plugin_activation( $network_wide ): void {
 		$this->register_taxonomy();
@@ -135,7 +127,6 @@ abstract class Taxonomy_Base extends Service_Base implements PluginActivationAwa
 	 * @since 1.12.0
 	 *
 	 * @param bool $network_wide Whether the deactivation was done network-wide.
-	 * @return void
 	 */
 	public function on_plugin_deactivation( $network_wide ): void {
 		$this->unregister_taxonomy();
@@ -145,8 +136,6 @@ abstract class Taxonomy_Base extends Service_Base implements PluginActivationAwa
 	 * Get taxonomy slug.
 	 *
 	 * @since 1.12.0
-	 *
-	 * @return string
 	 */
 	public function get_taxonomy_slug(): string {
 		return $this->taxonomy_slug;

--- a/includes/Tracking.php
+++ b/includes/Tracking.php
@@ -116,8 +116,6 @@ class Tracking extends Service_Base {
 	 * Registers the setting in WordPress.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		// By not passing an actual script src we can print only the inline script.

--- a/includes/User/Capabilities.php
+++ b/includes/User/Capabilities.php
@@ -45,7 +45,6 @@ class Capabilities implements Service, PluginActivationAware, SiteInitialization
 	 * @since 1.6.0
 	 *
 	 * @param bool $network_wide Whether the activation was done network-wide.
-	 * @return void
 	 */
 	public function on_plugin_activation( $network_wide ): void {
 		$this->add_caps_to_roles();
@@ -57,7 +56,6 @@ class Capabilities implements Service, PluginActivationAware, SiteInitialization
 	 * @since 1.11.0
 	 *
 	 * @param WP_Site $site The site being initialized.
-	 * @return void
 	 */
 	public function on_site_initialization( WP_Site $site ): void {
 		$this->add_caps_to_roles();
@@ -69,7 +67,6 @@ class Capabilities implements Service, PluginActivationAware, SiteInitialization
 	 * @since 1.11.0
 	 *
 	 * @param WP_Site $site The site being removed.
-	 * @return void
 	 */
 	public function on_site_removal( WP_Site $site ): void {
 		$this->remove_caps_from_roles();
@@ -82,8 +79,6 @@ class Capabilities implements Service, PluginActivationAware, SiteInitialization
 	 * as they can customize this to their liking.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return void
 	 */
 	public function add_caps_to_roles(): void {
 		$all_capabilities_raw = $this->get_all_capabilities();
@@ -137,8 +132,6 @@ class Capabilities implements Service, PluginActivationAware, SiteInitialization
 	 * Removes story capabilities from all user roles.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return void
 	 */
 	public function remove_caps_from_roles(): void {
 		$all_capabilities_raw = $this->get_all_capabilities();

--- a/includes/User/Preferences.php
+++ b/includes/User/Preferences.php
@@ -56,8 +56,6 @@ class Preferences extends Service_Base implements HasMeta {
 	 * Registers the setting in WordPress.
 	 *
 	 * @since 1.0.0
-	 *
-	 * @return void
 	 */
 	public function register(): void {
 		$this->register_meta();
@@ -67,8 +65,6 @@ class Preferences extends Service_Base implements HasMeta {
 	 * Register meta
 	 *
 	 * @since 1.15.0
-	 *
-	 * @return void
 	 */
 	public function register_meta(): void {
 		register_meta(
@@ -124,7 +120,6 @@ class Preferences extends Service_Base implements HasMeta {
 	 * @param string $meta_key Unused. The meta key.
 	 * @param int    $user_id ID of the user being edited.
 	 * @param int    $current_user_id The currently editing user's ID.
-	 * @return bool
 	 */
 	public function can_edit_current_user( $allowed, $meta_key, $user_id, $current_user_id ): bool {
 		return user_can( $current_user_id, 'edit_user', $user_id );

--- a/includes/Widgets/Stories.php
+++ b/includes/Widgets/Stories.php
@@ -101,7 +101,6 @@ class Stories extends WP_Widget {
 	 *
 	 * @param array $args Widget args.
 	 * @param array $instance Widget instance.
-	 * @return void
 	 *
      * phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 	 */
@@ -159,7 +158,6 @@ class Stories extends WP_Widget {
 	 * @since 1.5.0
 	 *
 	 * @param array $instance Widget instance.
-	 * @return string
 	 */
 	public function form( $instance ): string {
 		$this->enqueue_scripts();
@@ -459,8 +457,6 @@ class Stories extends WP_Widget {
 	 * Enqueue widget script.
 	 *
 	 * @since 1.5.0
-	 *
-	 * @return void
 	 */
 	public function enqueue_scripts(): void {
 		if ( wp_script_is( self::SCRIPT_HANDLE ) ) {
@@ -483,7 +479,6 @@ class Stories extends WP_Widget {
 	 * @since 1.5.0
 	 *
 	 * @param array $args Field args.
-	 * @return void
 	 */
 	private function dropdown( array $args ): void {
 		$args = wp_parse_args(
@@ -530,7 +525,6 @@ class Stories extends WP_Widget {
 	 * @since 1.5.0
 	 *
 	 * @param array $args Field args.
-	 * @return void
 	 */
 	private function radio( array $args ): void {
 		$args = wp_parse_args(
@@ -578,7 +572,6 @@ class Stories extends WP_Widget {
 	 * @since 1.5.0
 	 *
 	 * @param array $args Field args.
-	 * @return void
 	 */
 	private function input( array $args ): void {
 		$args = wp_parse_args(
@@ -642,7 +635,6 @@ class Stories extends WP_Widget {
 	 * @since 1.5.0
 	 *
 	 * @param array $args Label args.
-	 * @return string
 	 */
 	private function label( array $args ): string {
 		$args = wp_parse_args(

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -29,7 +29,6 @@ namespace Google\Web_Stories;
  *
  * @param array $attrs Arguments for displaying stories.
  * @param array $query_args Query arguments for stories.
- * @return void
  */
 function render_stories( array $attrs = [], array $query_args = [] ): void {
 	$stories_obj = new Story_Query( $attrs, $query_args );
@@ -56,8 +55,6 @@ function get_stories( array $attrs = [], array $query_args = [] ): array {
  * Render stories based on customizer settings.
  *
  * @since 1.5.0
- *
- * @return void
  */
 function render_theme_stories(): void {
 	$injector = Services::get_injector();

--- a/includes/namespace.php
+++ b/includes/namespace.php
@@ -38,7 +38,6 @@ use WP_Site;
  * @since 1.0.0
  *
  * @param bool $network_wide Whether to activate network-wide.
- * @return void
  */
 function activate( $network_wide = false ): void {
 	$network_wide = (bool) $network_wide;
@@ -63,7 +62,6 @@ register_activation_hook( WEBSTORIES_PLUGIN_FILE, __NAMESPACE__ . '\activate' );
  * @since 1.0.0
  *
  * @param int|WP_Site $site Site ID or object.
- * @return void
  */
 function new_site( $site ): void {
 	if ( ! is_multisite() ) {
@@ -90,7 +88,6 @@ add_action( 'wp_initialize_site', __NAMESPACE__ . '\new_site', PHP_INT_MAX );
  *
  * @param WP_Error    $error Unused.
  * @param int|WP_Site $site Site ID or object.
- * @return void
  */
 function remove_site( $error, $site ): void {
 	if ( ! is_multisite() ) {
@@ -116,7 +113,6 @@ add_action( 'wp_validate_site_deletion', __NAMESPACE__ . '\remove_site', PHP_INT
  * @since 1.0.0
  *
  * @param bool $network_wide Whether to deactivate network-wide.
- * @return void
  */
 function deactivate( $network_wide = false ): void {
 	$network_wide = (bool) $network_wide;
@@ -141,8 +137,6 @@ register_deactivation_hook( WEBSTORIES_PLUGIN_FILE, __NAMESPACE__ . '\deactivate
  * Loads a separate PHP file that allows defining functions in the global namespace.
  *
  * Runs on the 'wp' hook to ensure the WP environment has been fully set up,
- *
- * @return void
  */
 function load_amp_plugin_compat(): void {
 	require_once WEBSTORIES_PLUGIN_DIR_PATH . 'includes/compat/amp.php';
@@ -152,8 +146,6 @@ add_action( 'wp', __NAMESPACE__ . '\load_amp_plugin_compat' );
 
 /**
  * Load functions for use by plugin developers.
- *
- * @return void
  *
  * @todo Move to autoloader
  */
@@ -253,8 +245,6 @@ function rest_preload_api_request( $memo, $path ): array {
  *
  * Can be used by other plugins to integrate with the plugin
  * or to simply detect whether the plugin is active.
- *
- * @return Plugin
  */
 function get_plugin_instance(): Plugin {
 	return PluginFactory::create();
@@ -264,8 +254,6 @@ function get_plugin_instance(): Plugin {
  * Bootstrap the plugin.
  *
  * @since 1.11.0
- *
- * @return void
  */
 function bootstrap_plugin(): void {
 	PluginFactory::create()->register();

--- a/includes/uninstall.php
+++ b/includes/uninstall.php
@@ -43,8 +43,6 @@ use WP_Term_Query;
  * Deletes options and transients.
  *
  * @since 1.0.0
- *
- * @return void
  */
 function delete_options(): void {
 	global $wpdb;
@@ -82,8 +80,6 @@ function delete_options(): void {
  * Deletes options and transients on multisite.
  *
  * @since 1.0.0
- *
- * @return void
  */
 function delete_site_options(): void {
 	global $wpdb;
@@ -122,8 +118,6 @@ function delete_site_options(): void {
  * Deletes all associated post meta data.
  *
  * @since 1.0.0
- *
- * @return void
  */
 function delete_stories_post_meta(): void {
 	delete_post_meta_by_key( Base_Color::BASE_COLOR_POST_META_KEY );
@@ -140,8 +134,6 @@ function delete_stories_post_meta(): void {
  * Deletes all associated user meta data.
  *
  * @since 1.3.0
- *
- * @return void
  */
 function delete_stories_user_meta(): void {
 	delete_metadata( 'user', 0, Preferences::OPTIN_META_KEY, '', true );
@@ -153,8 +145,6 @@ function delete_stories_user_meta(): void {
  * Deletes all stories & templates.
  *
  * @since 1.0.0
- *
- * @return void
  */
 function delete_posts(): void {
 	// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_posts -- False positive.
@@ -179,8 +169,6 @@ function delete_posts(): void {
  * Deletes all media source terms.
  *
  * @since 1.10.0
- *
- * @return void
  */
 function delete_terms(): void {
 	$taxonomies = [];
@@ -215,8 +203,6 @@ function delete_terms(): void {
  * Remove user capabilities.
  *
  * @since 1.0.0
- *
- * @return void
  */
 function remove_caps(): void {
 	$capabilities = Services::get( 'user.capabilities' );
@@ -227,8 +213,6 @@ function remove_caps(): void {
  * Delete all data on a site.
  *
  * @since 1.0.0
- *
- * @return void
  */
 function delete_site(): void {
 	delete_options();

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -102,9 +102,6 @@
       <property name="enableUnionTypeHint" value="false" />
     </properties>
     <exclude
-      name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessAnnotation"
-    />
-    <exclude
       name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification"
     />
 

--- a/tests/phpunit/integration/includes/Fixture/DummyClassWithDependency.php
+++ b/tests/phpunit/integration/includes/Fixture/DummyClassWithDependency.php
@@ -12,7 +12,6 @@ final class DummyClassWithDependency implements DummyInterface {
 	}
 
 	/**
-	 * @return DummyClass
 	 */
 	public function get_dummy(): DummyClass {
 		return $this->dummy;

--- a/tests/phpunit/integration/includes/REST_Setup.php
+++ b/tests/phpunit/integration/includes/REST_Setup.php
@@ -65,7 +65,6 @@ trait REST_Setup {
 	 * @param string                    $code     Status code.
 	 * @param WP_REST_Response|WP_Error $response Response object.
 	 * @param int|null                  $status   Status code.
-	 * @return void
 	 */
 	protected function assertErrorResponse( $code, $response, $status = null ): void {
 

--- a/tests/phpunit/integration/tests/Renderer/Story/HTML.php
+++ b/tests/phpunit/integration/tests/Renderer/Story/HTML.php
@@ -255,7 +255,6 @@ class HTML extends TestCase {
 	 * Helper to setup renderer.
 	 *
 	 * @param WP_Post $post Post Object.
-	 * @return string
 	 */
 	protected function setup_renderer( $post ): string {
 		$story = new Story();

--- a/tests/phpunit/integration/tests/Widgets/Stories.php
+++ b/tests/phpunit/integration/tests/Widgets/Stories.php
@@ -35,8 +35,6 @@ class Stories extends DependencyInjectedTestCase {
 
 	/**
 	 * Runs before any method in class is run.
-	 *
-	 * @return void
 	 */
 	public function set_up(): void {
 		parent::set_up();


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

As mentioned on #10610, I want to remove redundant PHPDoc annotations from our code that are already documented using the actual return type hints.

## Summary

<!-- A brief description of what this PR does. -->

Enables the `SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessAnnotation` rule by default.

Makes our inline docs a bit cleaner by removing redundant information.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
