### PR TITLE
New Story Details Modal: Initial Design Tweaks

### DIFF
--- a/packages/design-system/src/components/textArea/index.js
+++ b/packages/design-system/src/components/textArea/index.js
@@ -47,7 +47,9 @@ const Label = styled(Text)`
   margin-bottom: 12px;
 `;
 
-const Hint = styled(Text)`
+const Hint = styled(Text).attrs({
+  size: THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL,
+})`
   margin-top: 12px;
   color: ${({ hasError, theme }) =>
     theme.colors.fg[hasError ? 'negative' : 'tertiary']};

--- a/packages/story-editor/src/components/publishModal/constants.js
+++ b/packages/story-editor/src/components/publishModal/constants.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export const REQUIRED_INPUTS = ['excerpt', 'title'];
+export const REQUIRED_INPUTS = ['title'];
 export const INPUT_KEYS = {
   EXCERPT: 'excerpt',
   SLUG: 'slug',

--- a/packages/story-editor/src/components/publishModal/karma/publishModal.karma.js
+++ b/packages/story-editor/src/components/publishModal/karma/publishModal.karma.js
@@ -63,21 +63,13 @@ describe('Publish Story Modal', () => {
   });
 
   describe('Functionality', () => {
-    it('should only allow publish of a Story when both title and description are not empty', async () => {
+    it('should only allow publish of a Story when title is not empty', async () => {
       let publishButton = await getPublishModalElement('button', 'Publish');
       expect(typeof publishButton.getAttribute('disabled')).toBe('string');
 
       const storyTitle = await getPublishModalElement('textbox', 'Story Title');
       await fixture.events.focus(storyTitle);
       await fixture.events.keyboard.type('my test story');
-      await fixture.events.keyboard.press('tab');
-
-      const storyDescription = await getPublishModalElement(
-        'textbox',
-        'Story Description'
-      );
-      await fixture.events.focus(storyDescription);
-      await fixture.events.keyboard.type('my test description for my story');
       await fixture.events.keyboard.press('tab');
 
       publishButton = await getPublishModalElement('button', 'Publish');

--- a/packages/story-editor/src/components/publishModal/mainContent/formLabel.js
+++ b/packages/story-editor/src/components/publishModal/mainContent/formLabel.js
@@ -17,6 +17,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import {
   Headline,
   PLACEMENT,
@@ -29,19 +30,26 @@ import { __ } from '@googleforcreators/i18n';
 import Tooltip from '../../tooltip';
 import { REQUIRED_INPUTS } from '../constants';
 
+const RequiredHeadline = styled(Headline)`
+  &:after {
+    content: '*';
+    color: ${({ theme }) => theme.colors.fg.tertiary};
+    padding-left: 0.25em;
+  }
+`;
 const FormLabel = ({ htmlFor, copy }) => {
   return REQUIRED_INPUTS.indexOf(htmlFor) > -1 ? (
     <Tooltip
       title={__('Required', 'web-stories')}
       placement={PLACEMENT.BOTTOM_START}
     >
-      <Headline
+      <RequiredHeadline
         as="label"
         size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.XX_SMALL}
         htmlFor={htmlFor}
       >
-        {`${copy} *`}
-      </Headline>
+        {copy}
+      </RequiredHeadline>
     </Tooltip>
   ) : (
     <Headline

--- a/packages/story-editor/src/components/publishModal/mainContent/index.js
+++ b/packages/story-editor/src/components/publishModal/mainContent/index.js
@@ -50,8 +50,6 @@ const _StoryPreview = styled.div`
 
 const _MandatoryStoryInfo = styled.div`
   grid-area: mandatory;
-  display: flex;
-  flex-direction: column;
   padding: 0 18px;
   overflow: scroll;
 

--- a/packages/story-editor/src/components/publishModal/mainContent/index.js
+++ b/packages/story-editor/src/components/publishModal/mainContent/index.js
@@ -52,11 +52,19 @@ const _MandatoryStoryInfo = styled.div`
   grid-area: mandatory;
   display: flex;
   flex-direction: column;
-  padding: 0 18px;
+  padding: 0 16px;
   overflow: scroll;
 
   & > section {
-    border: none; /* Override the default border that is part of the base panel structure since this is destructured */
+    border: none; // Override the default border that is part of the base panel structure since this is destructured
+    // overriding this way because of how isolated panel is inserted
+    & > h2 {
+      padding-top: 18px;
+      padding-bottom: 2px;
+      & > button {
+        height: 1em;
+      }
+    }
   }
 `;
 

--- a/packages/story-editor/src/components/publishModal/mainContent/index.js
+++ b/packages/story-editor/src/components/publishModal/mainContent/index.js
@@ -50,6 +50,8 @@ const _StoryPreview = styled.div`
 
 const _MandatoryStoryInfo = styled.div`
   grid-area: mandatory;
+  display: flex;
+  flex-direction: column;
   padding: 0 18px;
   overflow: scroll;
 

--- a/packages/story-editor/src/components/publishModal/mainContent/mandatoryStoryInfo.js
+++ b/packages/story-editor/src/components/publishModal/mainContent/mandatoryStoryInfo.js
@@ -30,6 +30,7 @@ import { MANDATORY_INPUT_VALUE_TYPES } from '../types';
 import FormLabel from './formLabel';
 
 const FormSection = styled.div`
+  padding: 0 4px;
   margin: 18px 0 8px;
   &:first-of-type {
     margin-top: 20px;

--- a/packages/story-editor/src/components/publishModal/mainContent/mandatoryStoryInfo.js
+++ b/packages/story-editor/src/components/publishModal/mainContent/mandatoryStoryInfo.js
@@ -30,7 +30,10 @@ import { MANDATORY_INPUT_VALUE_TYPES } from '../types';
 import FormLabel from './formLabel';
 
 const FormSection = styled.div`
-  margin: 20px 0 22px;
+  margin: 18px 0 8px;
+  &:first-of-type {
+    margin-top: 20px;
+  }
 `;
 
 const _TextArea = styled(TextArea)`

--- a/packages/story-editor/src/components/publishModal/mainContent/mandatoryStoryInfo.js
+++ b/packages/story-editor/src/components/publishModal/mainContent/mandatoryStoryInfo.js
@@ -30,10 +30,7 @@ import { MANDATORY_INPUT_VALUE_TYPES } from '../types';
 import FormLabel from './formLabel';
 
 const FormSection = styled.div`
-  margin: 18px 0 8px;
-  &:first-of-type {
-    margin-top: 20px;
-  }
+  margin: 20px 0 22px;
 `;
 
 const _TextArea = styled(TextArea)`

--- a/packages/story-editor/src/components/publishModal/publishModal.js
+++ b/packages/story-editor/src/components/publishModal/publishModal.js
@@ -19,7 +19,7 @@
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { __ } from '@googleforcreators/i18n';
-import { Modal } from '@googleforcreators/design-system';
+import { Modal, theme } from '@googleforcreators/design-system';
 import { trackEvent } from '@googleforcreators/tracking';
 import { useCallback, useEffect, useMemo } from '@googleforcreators/react';
 /**
@@ -105,6 +105,9 @@ function PublishModal({ isOpen, onPublish, onClose, publishButtonCopy }) {
         height: '66vh',
         minHeight: '580px',
         overflow: 'hidden',
+      }}
+      overlayStyles={{
+        backgroundColor: theme.colors.inverted.interactiveBg.modalScrim,
       }}
     >
       {isOpen && (

--- a/packages/story-editor/src/components/publishModal/publishModal.js
+++ b/packages/story-editor/src/components/publishModal/publishModal.js
@@ -35,10 +35,10 @@ import { INPUT_KEYS, REQUIRED_INPUTS } from './constants';
 
 const Container = styled.div`
   height: 100%;
-  color: ${({ theme }) => theme.colors.fg.primary};
-  background-color: ${({ theme }) => theme.colors.bg.primary};
-  border: ${({ theme }) => `1px solid ${theme.colors.divider.primary}`};
-  border-radius: ${({ theme }) => theme.borders.radius.medium};
+  color: ${theme.colors.fg.primary};
+  background-color: ${theme.colors.bg.primary};
+  border: ${`1px solid ${theme.colors.divider.primary}`};
+  border-radius: ${theme.borders.radius.medium};
 `;
 
 function PublishModal({ isOpen, onPublish, onClose, publishButtonCopy }) {

--- a/packages/wp-story-editor/src/components/documentPane/index.js
+++ b/packages/wp-story-editor/src/components/documentPane/index.js
@@ -63,7 +63,7 @@ export function PublishModalDocumentPane() {
 // based on other implementations that have default name
 
 const IsolatedPanel = styled(StatusPanel)`
-  padding: 0;
+  padding: 4px 4px 8px;
 `;
 
 export function IsolatedStatusPanel() {


### PR DESCRIPTION
## Context

Part of the story details modal feature.

## Summary

Implementing feedback from @agingoldseco after initial walk through of new story details modal. 

## Relevant Technical Choices

- add an overlay bg that matches the rest of the modals. Since this one is custom it doesn't use the inverted theme like the others so we need to give it the inverted overlay that should be present here and still use dark theme.
- update hint text size on TextArea to size 14 rather than default 16. The hint is only used in the new story description so this text size wasn't ever noticed as an issue. no regressions.
- required headline (label) should use `fg.tertiary` gray for asterisk 
- only title is required, not also description (avoid having to update copy for description helper by being less opinionated)
- more space between story title and description and visibility (34px)

## To-do

The[ spacing isn't _quite_ right on the middle pane re visibility, it's a bit of a time suck so will come back](https://github.com/GoogleForCreators/web-stories-wp/issues/10618) to that as well as a [discrepancy in scrollbar visibility](https://github.com/GoogleForCreators/web-stories-wp/issues/10619) in the document pane in the modal vs in the editor (one in modal should stick around the same as editor when there's overflow) - want to get feature flag PR prepped for QA ahead of that. 

## User-facing changes

N/A - Still behind feature flag

## Testing Instructions

Verify the small tweaks listed above. 

| Before | After | 
| --- | --- | 
| <img width="1051" alt="Screen Shot 2022-02-18 at 1 06 47 PM" src="https://user-images.githubusercontent.com/10720454/154754176-2b91e2fd-dc89-4886-813a-0fbd1450f261.png"> | <img width="1239" alt="Screen Shot 2022-02-18 at 1 05 46 PM" src="https://user-images.githubusercontent.com/10720454/154754191-69698129-28f2-409a-a414-32497f50cdd6.png"> | 

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Partially addresses #10115 
