### PR TITLE
Quick actions: Fix RTL tooltip for `insert text`

### DIFF
--- a/packages/story-editor/src/app/highlights/quickActions/useQuickActions.js
+++ b/packages/story-editor/src/app/highlights/quickActions/useQuickActions.js
@@ -477,7 +477,7 @@ const useQuickActions = () => {
             element: 'none',
           });
         },
-        onMouseDown: handleMouseDown,
+        ...actionMenuProps,
       },
     ];
   }, [

--- a/packages/story-editor/src/app/highlights/quickActions/useQuickActions.js
+++ b/packages/story-editor/src/app/highlights/quickActions/useQuickActions.js
@@ -486,7 +486,6 @@ const useQuickActions = () => {
     handleFocusMediaPanel,
     handleFocusPageBackground,
     handleFocusTextSetsPanel,
-    handleMouseDown,
   ]);
 
   const resetProperties = useMemo(


### PR DESCRIPTION
## Context
Tooltip was being set to the wrong placement in RTL mode on the Insert Text quick action
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
`isRTL` wasn't being sent to the `tooltip` for quick action: Insert Text 

<!-- A brief description of what this PR does. -->
## Relevant Technical Choices
Spread `actionMenuProps` on Insert Text  since it contains both `isRTL` tooltip placement and `handleMouseDown`. This is consistent with all other Quick Action items. 
<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
|Before|After|
|--|--|
|<img width="254" alt="Screen Shot 2022-02-21 at 10 27 28 AM" src="https://user-images.githubusercontent.com/1820266/155003445-a19dbf7d-0834-4950-b678-ab850b1afb92.png">|<img width="245" alt="Screen Shot 2022-02-21 at 10 26 54 AM" src="https://user-images.githubusercontent.com/1820266/155003458-c45909ce-f7c6-4179-bdfa-b0032a7c5d69.png">|

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. in RTL mode see that all tooltips for Quick Actions are set in the correct placement. 


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10547 
