### PR TITLE
Design System: Tooltip fix stale placement

### DIFF
--- a/packages/design-system/src/components/popup/utils/getOffset.js
+++ b/packages/design-system/src/components/popup/utils/getOffset.js
@@ -145,5 +145,6 @@ export function getOffset({
     width: anchorRect.width,
     height: anchorRect.height,
     popupLeft: popupRect?.left,
+    popupHeight: popupRect?.height,
   };
 }

--- a/packages/design-system/src/components/popup/utils/getOffset.js
+++ b/packages/design-system/src/components/popup/utils/getOffset.js
@@ -144,7 +144,6 @@ export function getOffset({
       : Math.max(topOffset, Math.min(offsetY, maxOffsetY)),
     width: anchorRect.width,
     height: anchorRect.height,
-    bottom: popupRect?.bottom,
     popupLeft: popupRect?.left,
   };
 }

--- a/packages/design-system/src/components/tooltip/index.js
+++ b/packages/design-system/src/components/tooltip/index.js
@@ -37,7 +37,7 @@ import { THEME_CONSTANTS } from '../../theme';
 import { Text } from '../typography';
 import { RTL_PLACEMENT } from '../popup/constants';
 import { noop } from '../../utils';
-import { SvgForTail, Tail, SVG_TOOLTIP_TAIL_ID } from './tail';
+import { SvgForTail, Tail, SVG_TOOLTIP_TAIL_ID, TAIL_HEIGHT } from './tail';
 
 const SPACE_BETWEEN_TOOLTIP_AND_ELEMENT = 8;
 // For how many milliseconds is a delayed tooltip waiting to appear?
@@ -177,14 +177,13 @@ function Tooltip({
   const positionPlacement = useCallback(
     ({ offset }) => {
       // check to see if there's an overlap with the window's bottom edge
-      const neededVerticalSpace = offset.bottom;
+      const neededVerticalSpace = offset.y + offset.height + TAIL_HEIGHT;
       const shouldMoveToTop =
         dynamicPlacement.startsWith('bottom') &&
         neededVerticalSpace >= window.innerHeight;
       // check that the tooltip isn't cutoff on the left edge of the screen.
       // right-cutoff is already taken care of with `getOffset`
       const isOverFlowingLeft = offset.popupLeft < 0;
-
       if (shouldMoveToTop && !isOverFlowingLeft) {
         setDynamicPlacement(PLACEMENT.TOP);
       } else if (shouldMoveToTop && isOverFlowingLeft) {

--- a/packages/design-system/src/components/tooltip/index.js
+++ b/packages/design-system/src/components/tooltip/index.js
@@ -39,7 +39,7 @@ import { RTL_PLACEMENT } from '../popup/constants';
 import { noop } from '../../utils';
 import { SvgForTail, Tail, SVG_TOOLTIP_TAIL_ID, TAIL_HEIGHT } from './tail';
 
-const SPACE_BETWEEN_TOOLTIP_AND_ELEMENT = 8;
+const SPACE_BETWEEN_TOOLTIP_AND_ELEMENT = TAIL_HEIGHT;
 // For how many milliseconds is a delayed tooltip waiting to appear?
 const DELAY_MS = 1000;
 // For how many milliseconds will triggering another delayed tooltip show instantly?
@@ -176,8 +176,10 @@ function Tooltip({
   // cutoff the contents of the tooltip.
   const positionPlacement = useCallback(
     ({ offset }) => {
-      // check to see if there's an overlap with the window's bottom edge
-      const neededVerticalSpace = offset.y + offset.popupHeight + TAIL_HEIGHT;
+      //  In order to check if there's an overlap with the window's bottom edge we need the overall height of the tooltip
+      //  from the anchor's y position along with the amount of space between the anchor and the tooltip content.
+      const neededVerticalSpace =
+        offset.y + offset.popupHeight + SPACE_BETWEEN_TOOLTIP_AND_ELEMENT;
       const shouldMoveToTop =
         dynamicPlacement.startsWith('bottom') &&
         neededVerticalSpace >= window.innerHeight;

--- a/packages/design-system/src/components/tooltip/index.js
+++ b/packages/design-system/src/components/tooltip/index.js
@@ -177,13 +177,14 @@ function Tooltip({
   const positionPlacement = useCallback(
     ({ offset }) => {
       // check to see if there's an overlap with the window's bottom edge
-      const neededVerticalSpace = offset.y + offset.height + TAIL_HEIGHT;
+      const neededVerticalSpace = offset.y + offset.popupHeight + TAIL_HEIGHT;
       const shouldMoveToTop =
         dynamicPlacement.startsWith('bottom') &&
         neededVerticalSpace >= window.innerHeight;
       // check that the tooltip isn't cutoff on the left edge of the screen.
       // right-cutoff is already taken care of with `getOffset`
       const isOverFlowingLeft = offset.popupLeft < 0;
+
       if (shouldMoveToTop && !isOverFlowingLeft) {
         setDynamicPlacement(PLACEMENT.TOP);
       } else if (shouldMoveToTop && isOverFlowingLeft) {

--- a/packages/design-system/src/components/tooltip/tail.js
+++ b/packages/design-system/src/components/tooltip/tail.js
@@ -27,7 +27,7 @@ import { PLACEMENT } from '../popup';
 
 export const SVG_TOOLTIP_TAIL_ID = 'tooltip-tail';
 const TAIL_WIDTH = 34;
-const TAIL_HEIGHT = 8;
+export const TAIL_HEIGHT = 8;
 
 const getTailPosition = ({ placement, translateX }) => {
   switch (placement) {


### PR DESCRIPTION
## Context
When a `tooltip` is near the bottom of the screen and has a `placement` value of `BOTTOM` we update the placement via `dynamicPlacement` to be `TOP` this avoids the content of tooltip being cutoff by the bottom of the window. However, we weren't always getting the correct (most recent) values for whether or a not a tooltip was showing outside of the window. 
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
The dynamic placement for updating `bottom` to `top` was being calculated with `popupRect.bottom`. This was checked against `window.innerHeight` to determine whether the `tooltip` was being cutoff by the bottom of the window. This would get out of sync when the placement of the tooltip changes. 
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
Instead of basing the calculation on the `popupRect`'s `bottom` value we are now calculating the values ourselves using `offset.popupHeight` in conjunction with the anchor's `y` offset. This helps avoid stale values (ie the height of a popup will be the same regardless of where we place it) and allows the `offset.y` to utilize  `ignoreMaxOffsetY` and `Math.max(topOffset, Math.min(offsetY, maxOffsetY))`.

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
|Before|After|
|--|--|
|![before](https://user-images.githubusercontent.com/1820266/155025276-d5ce2309-5061-423e-a1a1-19f815a9b393.gif)|![after](https://user-images.githubusercontent.com/1820266/155025090-071e81ee-db36-4e8d-a6da-8cab9a309653.gif)|

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add background audio if one is not a part of the story
2. Position the `trash` icon and `play` icon just above the bottom edge of the window
3. Hover the `trash` icon or `play` icon and see that the tooltip is placed above the icons
4. Repeatedly hover to ensure the placement isn't  switching 
5. move the panel up so that there is enough space below the icons to see the full tooltip
6. Hover the `trash` icon or `play` icon and see that the tooltip is placed below the icons
7. Repeatedly hover to ensure the placement isn't  switching 
Note: there is still the issue of the editor crashing when in RTL and the tooltip is cutoff both at the bottom and on the left. Addressing in #10546 


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10544 
