### PR TITLE
Design System: Fix Tooltip infinite loop in RTL

### DIFF
--- a/packages/design-system/src/components/tooltip/index.js
+++ b/packages/design-system/src/components/tooltip/index.js
@@ -184,12 +184,13 @@ function Tooltip({
       // check that the tooltip isn't cutoff on the left edge of the screen.
       // right-cutoff is already taken care of with `getOffset`
       const isOverFlowingLeft = offset.popupLeft < 0;
-
-      if (shouldMoveToTop && !isOverFlowingLeft) {
-        setDynamicPlacement(PLACEMENT.TOP);
-      } else if (shouldMoveToTop && isOverFlowingLeft) {
-        setDynamicPlacement(PLACEMENT.TOP_START);
-      } else if (!shouldMoveToTop && isOverFlowingLeft) {
+      if (shouldMoveToTop) {
+        setDynamicPlacement(
+          dynamicPlacement.endsWith('-start')
+            ? PLACEMENT.TOP_START
+            : PLACEMENT.TOP
+        );
+      } else if (isOverFlowingLeft) {
         updatePlacement();
       }
     },

--- a/packages/design-system/src/components/tooltip/index.js
+++ b/packages/design-system/src/components/tooltip/index.js
@@ -185,11 +185,13 @@ function Tooltip({
       // right-cutoff is already taken care of with `getOffset`
       const isOverFlowingLeft = offset.popupLeft < 0;
       if (shouldMoveToTop) {
-        setDynamicPlacement(
-          dynamicPlacement.endsWith('-start')
-            ? PLACEMENT.TOP_START
-            : PLACEMENT.TOP
-        );
+        if (dynamicPlacement.endsWith('-start')) {
+          setDynamicPlacement(PLACEMENT.TOP_START);
+        } else if (dynamicPlacement.endsWith('-end')) {
+          setDynamicPlacement(PLACEMENT.TOP_END);
+        } else {
+          setDynamicPlacement(PLACEMENT.TOP);
+        }
       } else if (isOverFlowingLeft) {
         updatePlacement();
       }


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
The `dynamicPlacement` for `Tooltip` was getting confused when placed was in lower left corner of the window. 
## Summary

<!-- A brief description of what this PR does. -->

`dynamicPlacement` would get updated when the tooltip was cutoff either on the left or at the bottom and as a result the values of `shouldMoveToTop` and / or  `isOverFlowingLeft` would change between true and false. These caused a loop where we set the placement a number of times until react crashes. 

## Relevant Technical Choices
Because `TOOLTIP_RTL_PLACEMENT`  already handles start / end  switch for TOP and BOTTOM placements in RTL we can simplify `shouldMoveToTop`. By removing the extra conditional check `isOverFlowingLeft` we no longer are triggering the continuous updating loop. 
<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
|Before|After|
|--|--|
|![images](https://user-images.githubusercontent.com/1820266/153462358-55c2c2e5-7739-4c7e-bff5-df6ee8db7350.gif)|![after error](https://user-images.githubusercontent.com/1820266/155041712-c2d1477d-2179-4746-a99c-0d57eabd47ae.gif)|

<--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. In RTL mode, Open Layers panel and scroll until the duplicate and trash can icons are just in view.
2. Hover the duplicate icon and leave mouse positioned over icon.
3. Wait a few seconds and you should no longer get the exceeded max depth error.


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10546 
