### PR TITLE
Design System: Tooltip add `ignoreMaxOffsetY`

### DIFF
--- a/packages/design-system/src/components/tooltip/index.js
+++ b/packages/design-system/src/components/tooltip/index.js
@@ -94,6 +94,10 @@ let lastVisibleDelayedTooltip = null;
  * @param {string} props.className Classname.
  * @param {string} props.isDelayed If this tooltip is to be displayed instantly on hover (default) or by a short delay.
  * @param {number} props.popupZIndexOverride If present, passes an override for z-index to popup
+ * @param {boolean} props.ignoreMaxOffsetY  Defaults to false. Sometimes, we want the popup to respect the y value
+ * as perceived by the page because of scroll. This is really only true of dropDowns that
+ * exist beyond the initial page scroll. Because the editor is a fixed view this only
+ * comes up in peripheral pages (dashboard, settings).
  * @return {import('react').Component} Tooltip element
  */
 function Tooltip({
@@ -111,6 +115,7 @@ function Tooltip({
   tooltipProps = null,
   className = null,
   popupZIndexOverride,
+  ignoreMaxOffsetY = false,
   ...props
 }) {
   const [shown, setShown] = useState(false);
@@ -288,6 +293,7 @@ function Tooltip({
         onPositionUpdate={positionArrow}
         zIndex={popupZIndexOverride}
         noOverFlow
+        ignoreMaxOffsetY={ignoreMaxOffsetY}
       >
         <TooltipContainer
           className={className}
@@ -333,6 +339,7 @@ const TooltipPropTypes = {
   className: PropTypes.string,
   isDelayed: PropTypes.bool,
   popupZIndexOverride: PropTypes.number,
+  ignoreMaxOffsetY: PropTypes.bool,
 };
 Tooltip.propTypes = TooltipPropTypes;
 

--- a/packages/wp-dashboard/src/components/editorSettings/customFonts/index.js
+++ b/packages/wp-dashboard/src/components/editorSettings/customFonts/index.js
@@ -290,7 +290,11 @@ function CustomFontsSettings({
                     <Divider />
                     <FontUrl>{url}</FontUrl>
                   </FontData>
-                  <Tooltip hasTail title={__('Delete font', 'web-stories')}>
+                  <Tooltip
+                    ignoreMaxOffsetY
+                    hasTail
+                    title={__('Delete font', 'web-stories')}
+                  >
                     <DeleteButton
                       aria-label={__('Remove font', 'web-stories')}
                       type={BUTTON_TYPES.TERTIARY}


### PR DESCRIPTION
## Context
For Tooltip in the wp-dashboard we need to be able to send `ignoreMaxOffsetY` to popup. This prevents the tooltip from appearing in the wrong location. 


<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Tooltips in Dashboard where showing in the wrong y offset.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do
n/a
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
|Before|After|
|--|--|
|![Screenshot 2022-02-22 at 22 03 25](https://user-images.githubusercontent.com/1820266/155231134-156e97b1-d475-42c8-bf58-1436e059b192.png)|<img width="745" alt="Screen Shot 2022-02-22 at 3 36 21 PM" src="https://user-images.githubusercontent.com/1820266/155231201-fc9eca61-5098-4df4-98d5-e752c94f6657.png">
|
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Hover the trash icon in dashboard setting -> add font.


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
