### PR TITLE
Status Panel: Visibility dropdown styling updates

### DIFF
--- a/packages/e2e-tests/src/specs/editor/contributorUser.js
+++ b/packages/e2e-tests/src/specs/editor/contributorUser.js
@@ -35,12 +35,14 @@ describe('Contributor User', () => {
 
     await expect(page).toClick('li[role="tab"]', { text: 'Document' });
 
-    await expect(page).toMatchElement('button', { text: 'Public' });
-    await expect(page).not.toMatchElement('li[role="option"]', {
-      text: 'Private Visible to site admins & editors only',
+    await expect(page).toMatchElement('button[disabled]', {
+      text: /^Public/,
     });
     await expect(page).not.toMatchElement('li[role="option"]', {
-      text: 'Password Protected Visible only to those with the password.',
+      text: /^Private/,
+    });
+    await expect(page).not.toMatchElement('li[role="option"]', {
+      text: /^Password Protected/,
     });
   });
 });

--- a/packages/e2e-tests/src/specs/editor/contributorUser.js
+++ b/packages/e2e-tests/src/specs/editor/contributorUser.js
@@ -37,10 +37,10 @@ describe('Contributor User', () => {
 
     await expect(page).toMatchElement('button', { text: 'Public' });
     await expect(page).not.toMatchElement('li[role="option"]', {
-      text: 'Private',
+      text: 'Private Visible to site admins & editors only',
     });
     await expect(page).not.toMatchElement('li[role="option"]', {
-      text: 'Password Protected',
+      text: 'Password Protected Visible only to those with the password.',
     });
   });
 });

--- a/packages/e2e-tests/src/specs/editor/passwordProtected.js
+++ b/packages/e2e-tests/src/specs/editor/passwordProtected.js
@@ -34,7 +34,7 @@ describe('Password protected stories', () => {
     await expect(page).toClick('li[role="tab"]', { text: 'Document' });
     await expect(page).toClick('button', { text: 'Public' });
     await expect(page).toClick('li[role="option"]', {
-      text: 'Password Protected',
+      text: 'Password Protected Visible only to those with the password.',
     });
 
     await expect(page).toMatchElement('input[placeholder="Enter a password"]');

--- a/packages/e2e-tests/src/specs/editor/passwordProtected.js
+++ b/packages/e2e-tests/src/specs/editor/passwordProtected.js
@@ -34,7 +34,7 @@ describe('Password protected stories', () => {
     await expect(page).toClick('li[role="tab"]', { text: 'Document' });
     await expect(page).toClick('button', { text: 'Public' });
     await expect(page).toClick('li[role="option"]', {
-      text: 'Password Protected Visible only to those with the password.',
+      text: /^Password Protected/,
     });
 
     await expect(page).toMatchElement('input[placeholder="Enter a password"]');

--- a/packages/wp-story-editor/src/components/documentPane/status/status.js
+++ b/packages/wp-story-editor/src/components/documentPane/status/status.js
@@ -61,12 +61,16 @@ const StyledListItem = styled.li`
     background-color: ${theme.colors.border.defaultNormal};
   }
 `;
-const LabelText = styled.span`
+const LabelText = styled(Text).attrs({
+  as: 'span',
+})`
   font-size: 14px;
   color: ${theme.colors.fg.primary};
 `;
 
-const HelperText = styled.span`
+const HelperText = styled(Text).attrs({
+  as: 'span',
+})`
   color: ${theme.colors.fg.tertiary};
 `;
 

--- a/packages/wp-story-editor/src/components/documentPane/status/status.js
+++ b/packages/wp-story-editor/src/components/documentPane/status/status.js
@@ -18,9 +18,20 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useCallback, useEffect, useState } from '@googleforcreators/react';
+import {
+  useCallback,
+  useEffect,
+  useState,
+  forwardRef,
+} from '@googleforcreators/react';
 import { __ } from '@googleforcreators/i18n';
-import { Input, DropDown } from '@googleforcreators/design-system';
+import styled from 'styled-components';
+import {
+  Input,
+  DropDown,
+  themeHelpers,
+  theme,
+} from '@googleforcreators/design-system';
 import { trackEvent } from '@googleforcreators/tracking';
 import {
   Row,
@@ -37,6 +48,37 @@ import { useFeature } from 'flagged';
  * Internal dependencies
  */
 import { VISIBILITY, STATUS } from '../../../constants';
+
+const StyledListItem = styled.li`
+  position: relative;
+  padding: 6px 8px;
+  margin: 4px 8px;
+  align-items: center;
+  border-radius: 4px;
+  cursor: pointer;
+  ${themeHelpers.focusableOutlineCSS}
+  &:hover {
+    background-color: ${theme.colors.border.defaultNormal};
+  }
+`;
+const LabelText = styled.span`
+  font-size: 14px;
+  color: ${theme.colors.fg.primary};
+`;
+
+const HelperText = styled.span`
+  color: ${theme.colors.fg.tertiary};
+`;
+
+const RenderItemOverride = forwardRef(
+  ({ option, isSelected, ...rest }, ref) => (
+    <StyledListItem ref={ref} active={isSelected} {...rest}>
+      <LabelText>{option.label}</LabelText>
+      <br />
+      <HelperText>{option.helper}</HelperText>
+    </StyledListItem>
+  )
+);
 
 function StatusPanel({
   nameOverride,
@@ -250,11 +292,8 @@ function StatusPanel({
               selectedValue={visibility}
               onMenuItemClick={handleChangeVisibility}
               popupZIndex={popupZIndex}
-              hint={
-                visibilityOptions.find((option) => visibility === option.value)
-                  ?.helper
-              }
               disabled={visibilityOptions.length <= 1}
+              renderItem={RenderItemOverride}
             />
           </Row>
           {visibility === VISIBILITY.PASSWORD_PROTECTED && (

--- a/packages/wp-story-editor/src/components/documentPane/status/status.js
+++ b/packages/wp-story-editor/src/components/documentPane/status/status.js
@@ -294,6 +294,10 @@ function StatusPanel({
               popupZIndex={popupZIndex}
               disabled={visibilityOptions.length <= 1}
               renderItem={RenderItemOverride}
+              hint={
+                visibilityOptions.find((option) => visibility === option.value)
+                  ?.helper
+              }
             />
           </Row>
           {visibility === VISIBILITY.PASSWORD_PROTECTED && (

--- a/packages/wp-story-editor/src/components/documentPane/status/test/status.js
+++ b/packages/wp-story-editor/src/components/documentPane/status/test/status.js
@@ -101,17 +101,17 @@ describe('statusPanel', () => {
     expect(screen.getAllByRole('option')).toHaveLength(3);
     expect(
       screen.getByRole('option', {
-        name: 'Selected Public',
+        name: 'Public Visible to everyone',
       })
     ).toBeInTheDocument();
     expect(
       screen.getByRole('option', {
-        name: 'Private',
+        name: 'Private Visible to site admins & editors only',
       })
     ).toBeInTheDocument();
     expect(
       screen.getByRole('option', {
-        name: 'Password Protected',
+        name: 'Password Protected Visible only to those with the password.',
       })
     ).toBeInTheDocument();
   });
@@ -137,12 +137,12 @@ describe('statusPanel', () => {
 
     expect(
       screen.queryByRole('option', {
-        name: 'Private',
+        name: 'Private Visible to site admins & editors only',
       })
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole('option', {
-        name: 'Password Protected',
+        name: 'Password Protected Visible only to those with the password.',
       })
     ).not.toBeInTheDocument();
   });
@@ -153,7 +153,7 @@ describe('statusPanel', () => {
 
     fireEvent.click(
       screen.getByRole('option', {
-        name: 'Private',
+        name: 'Private Visible to site admins & editors only',
       })
     );
     expect(windowConfirm).toHaveBeenCalledWith(expect.any(String));
@@ -193,7 +193,7 @@ describe('statusPanel', () => {
 
     fireEvent.click(
       screen.getByRole('option', {
-        name: 'Public',
+        name: 'Public Visible to everyone',
       })
     );
     expect(updateStory).toHaveBeenCalledWith({


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
When selecting Private from the Visibility panel, you will never see the helper / hint text that describes what this selection means. We want to update the dropdown so that each item also contains that additional text as a second line.


## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do
n/a
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
||Open Modal|Hover|Focus|
|--|--|--|--|
|After|<img width="1043" alt="Screen Shot 2022-02-22 at 1 47 27 PM" src="https://user-images.githubusercontent.com/1820266/155233200-9b11fe6b-75b2-4f34-9f4d-4ad8ac7e6b9e.png">|<img width="392" alt="Screen Shot 2022-02-22 at 1 21 30 PM" src="https://user-images.githubusercontent.com/1820266/155232430-47796e38-2ad3-4060-b286-29499a3a724e.png">|<img width="390" alt="Screen Shot 2022-02-22 at 1 21 22 PM" src="https://user-images.githubusercontent.com/1820266/155232433-2d259bb9-529a-43c9-ae01-747dbd8c33f1.png">|
|Before|<img width="1023" alt="Screen Shot 2022-02-22 at 3 54 16 PM" src="https://user-images.githubusercontent.com/1820266/155233347-afa2da30-c763-4b77-b38e-f291ef681ac0.png">|<img width="333" alt="Screen Shot 2022-02-22 at 3 50 46 PM" src="https://user-images.githubusercontent.com/1820266/155232977-97c1f0ae-e4b5-4d36-8554-c8672e39d2cb.png">|<img width="348" alt="Screen Shot 2022-02-22 at 3 50 53 PM" src="https://user-images.githubusercontent.com/1820266/155233010-492ecffd-14ba-419b-a1fa-9e5991235453.png">|



<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10680
