### PR TITLE
Design System: Text area box shadow override

### DIFF
--- a/packages/design-system/src/components/textArea/index.js
+++ b/packages/design-system/src/components/textArea/index.js
@@ -91,6 +91,7 @@ const StyledTextArea = styled.textarea(
     outline: none;
     color: ${theme.colors.fg.primary};
     resize: none;
+    box-shadow: none;
     ${themeHelpers.scrollbarCSS};
 
     ${themeHelpers.expandPresetStyles({
@@ -100,6 +101,10 @@ const StyledTextArea = styled.textarea(
         ],
       theme,
     })};
+
+    :focus {
+      box-shadow: none;
+    }
 
     :disabled {
       color: ${theme.colors.fg.disable};

--- a/packages/design-system/src/components/textArea/stories/index.js
+++ b/packages/design-system/src/components/textArea/stories/index.js
@@ -90,8 +90,8 @@ export const _default = ({ onHandleChange, ...args }) => {
       <br />
       <Container>
         <Row>
-          <Text isBold>
-            {'Normal'}
+          <div>
+            <Text isBold>{'Normal'}</Text>
             <TextArea
               aria-label="input-one"
               id="one-light"
@@ -100,9 +100,9 @@ export const _default = ({ onHandleChange, ...args }) => {
               onChange={handleChange}
               {...args}
             />
-          </Text>
-          <Text isBold>
-            {'Error'}
+          </div>
+          <div>
+            <Text isBold>{'Error'}</Text>
             <TextArea
               aria-label="input-two"
               id="two-light"
@@ -112,9 +112,9 @@ export const _default = ({ onHandleChange, ...args }) => {
               {...args}
               hasError
             />
-          </Text>
-          <Text isBold>
-            {'Disabled'}
+          </div>
+          <div>
+            <Text isBold>{'Disabled'}</Text>
             <TextArea
               aria-label="disabled-input-one"
               id="three-light"
@@ -124,9 +124,9 @@ export const _default = ({ onHandleChange, ...args }) => {
               {...args}
               disabled
             />
-          </Text>
-          <Text isBold>
-            {'With Counter'}
+          </div>
+          <div>
+            <Text isBold>{'With Counter'}</Text>
             <TextArea
               aria-label="input-four"
               id="four-light"
@@ -137,7 +137,7 @@ export const _default = ({ onHandleChange, ...args }) => {
               showCount
               maxLength={20}
             />
-          </Text>
+          </div>
         </Row>
       </Container>
       <DarkThemeProvider>


### PR DESCRIPTION
## Context
Morten is seeing some wordpress specific styling come through on text fields in popup. This has occurred before in other areas (https://github.com/GoogleForCreators/web-stories-wp/pull/9312), we just need to set a css override.
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Let's remove box shadow from text area. 
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
Follow pattern from (https://github.com/GoogleForCreators/web-stories-wp/pull/9312)
<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
I wasn't able to repro this.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10676 
