### PR TITLE
Design System: Update opacity for modal background

### DIFF
--- a/packages/design-system/src/theme/colors.js
+++ b/packages/design-system/src/theme/colors.js
@@ -115,6 +115,7 @@ const opacity = {
   white16: rgba(standard.white, 0.16),
   white8: rgba(standard.white, 0.08),
   black64: rgba(standard.black, 0.64),
+  black40: rgba(standard.black, 0.4),
   black32: rgba(standard.black, 0.32),
   black24: rgba(standard.black, 0.24),
   black10: rgba(standard.black, 0.1),
@@ -263,7 +264,7 @@ const lightTheme = {
     positiveHover: brand.green[30],
     positivePress: brand.green[40],
     previewOverlay: opacity.white16,
-    modalScrim: opacity.black32,
+    modalScrim: opacity.black40,
   },
   border: {
     focus: brand.blue[40],


### PR DESCRIPTION
## Context

<img width="403" alt="Screen Shot 2022-02-22 at 5 26 37 PM" src="https://user-images.githubusercontent.com/10720454/155242631-7fee4a7d-eac3-496e-9fef-78d47fa27adb.png">

## Summary

add a new opacity for black40, use that for editor modal background instead, design request via slack today.

This is in response to updated visibility dropdown here (https://github.com/GoogleForCreators/web-stories-wp/issues/10681)

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

Modals in the editor now have `rbga(0,0,0,0.4)` instead of `rgba(0,0,0,0.32)` as background overlay

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

See #10681
