### PR TITLE
Fix: storybook broken persistence

### DIFF
--- a/.storybook/stories/playground/story-editor/api/story.js
+++ b/.storybook/stories/playground/story-editor/api/story.js
@@ -44,7 +44,7 @@ export const saveStoryById = ({
     excerpt: {
       raw: excerpt,
     },
-    story_data: {
+    storyData: {
       version: DATA_VERSION,
       pages,
       autoAdvance,
@@ -56,8 +56,8 @@ export const saveStoryById = ({
       id: 1,
       name: '',
     },
-    style_presets: globalStoryStyles,
-    permalink_template: 'https://example.org/web-stories/%pagename%/',
+    stylePresets: globalStoryStyles,
+    permalinkTemplate: 'https://example.org/web-stories/%pagename%/',
   };
 
   window.localStorage.setItem(


### PR DESCRIPTION
## Context

I forgot to update the storybook's `storySaveData` keys to camel case in https://github.com/GoogleForCreators/web-stories-wp/pull/10013 due to which the storybook persistence was broken. 

## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
