### PR TITLE
Publish Modal: Scrollbar consistency

### DIFF
--- a/packages/story-editor/src/components/publishModal/content/index.js
+++ b/packages/story-editor/src/components/publishModal/content/index.js
@@ -19,6 +19,7 @@
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { __ } from '@googleforcreators/i18n';
+import { themeHelpers } from '@googleforcreators/design-system';
 /**
  * Internal dependencies
  */
@@ -52,7 +53,9 @@ const _MainStoryInfo = styled.div`
   display: flex;
   flex-direction: column;
   padding: 0 16px;
-  overflow: scroll;
+  overflow-y: scroll;
+
+  ${themeHelpers.scrollbarCSS};
 
   & > section {
     border: none; // Override the default border that is part of the base panel structure since this is destructured
@@ -73,7 +76,9 @@ const PanelContainer = styled.div.attrs({ role: 'tabpanel' })`
   margin-left: 18px;
   background-color: ${({ theme }) => theme.colors.bg.secondary};
   border-bottom-right-radius: ${({ theme }) => theme.borders.radius.medium};
-  overflow: scroll;
+  overflow-y: scroll;
+
+  ${themeHelpers.scrollbarCSS};
 `;
 
 const Footer = styled.div`


### PR DESCRIPTION
## Context
Scroll bars on panels should always be present if the content is scrollable. Additionally if a user's settings have show scrollbars set to "always" we want to override those styles so that the scroll bar styling is consistent. 

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Add our scrollbar styles from theme to the publish panel.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
Changed the overflow to be in the y orientations specifically since we don't expect the content to be scrollable horizontally, only vertically. 
Added our scrollableCss from theme. 
<!-- Please describe your changes. -->

## To-do
n/a
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

||before|after|
|--|--|--|
|With browser scroll bars always on|![image](https://user-images.githubusercontent.com/1820266/155402421-06347ea6-ce6a-44b0-91da-bf47a5a9a592.png)|<img width="984" alt="Screen Shot 2022-02-23 at 1 28 59 PM" src="https://user-images.githubusercontent.com/1820266/155402926-d54bc615-4697-4752-996f-57fb24b3239a.png">
|highlighting both scrollable panels|![image](https://user-images.githubusercontent.com/1820266/155403097-9961191e-32d6-4264-8114-6c0703db4433.png)|<img width="352" alt="Screen Shot 2022-02-23 at 1 33 01 PM" src="https://user-images.githubusercontent.com/1820266/155403588-d2379634-650c-47c5-9ca5-f9b91e7404e2.png">



<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. In system setting (or browser settings) enable scrollbars to always show 
![image](https://user-images.githubusercontent.com/1820266/155403867-66755f52-006c-4b27-928c-6d47c5336edf.png)
2. open publish modal 
3. open all panels on the side
4. click outside the side panel and check that the scrollbar remains visible
5. ensure no weird default scrollbars are present  


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10619 
