### PR TITLE
Karma Tests: Remove stale todo

### DIFF
--- a/packages/story-editor/src/karma/fixture/fixture.js
+++ b/packages/story-editor/src/karma/fixture/fixture.js
@@ -389,9 +389,6 @@ export class Fixture {
         }
       });
     });
-
-    // @todo: find a stable way to wait for the story to fully render. Can be
-    // implemented via `waitFor`.
   }
 
   /**


### PR DESCRIPTION
## Summary

Removes stale todo.

## Relevant Technical Choices

Empty canvas is already rendered fully in the fixture's `render` method.

First, the editor is rendered. The react testing library's [render](https://testing-library.com/docs/react-testing-library/api/#render) function is used, and is synchronous. If for some reason rendering the canvas is async, that promise (or multiple) will be added to the promise queue. Assuming all network requests are mocked, nothing should block the rendering. Therefore, the promise(s) should be resolved immediately. JS will work through those after running through all synchronous code.

The fixture's render function schedules a promise afterwards because the [gallery elements need to be loaded in](https://github.com/GoogleForCreators/web-stories-wp/blob/main/packages/story-editor/src/karma/fixture/fixture.js#L361-L391
). This will wait for all synchronous code to be run first before being resolved.

When JS comes around to the promise queue, it will work through the events that were scheduled first. If they're all resolved, the canvas will be rendered before the gallery elements are loaded in.

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10348 