### PR TITLE
Fonts: Add workaround for REST API call

### DIFF
--- a/packages/wp-story-editor/src/api/fonts.js
+++ b/packages/wp-story-editor/src/api/fonts.js
@@ -30,11 +30,15 @@ import apiFetch from '@wordpress/api-fetch';
  * Works around a bug in WordPress.
  *
  * @see https://github.com/GoogleForCreators/web-stories-wp/issues/10710
- * @param {string[]} include List of fonts to include.
+ * @param {string} include Comma-separated list of fonts to include.
  * @return {string} include query parameter with bracket notation.
  */
-function getIncludeQueryArgs(include) {
-  return include?.map((item) => `include[]=${encodeURI(item)}`).join('&');
+function getIncludeQueryArgs(include = '') {
+  return include
+    .split(',')
+    .filter(Boolean)
+    .map((item) => `include[]=${encodeURI(item)}`)
+    .join('&');
 }
 
 export function getFonts(config, { include: _include, search, service }) {
@@ -43,7 +47,7 @@ export function getFonts(config, { include: _include, search, service }) {
     service,
   });
   const include = getIncludeQueryArgs(_include);
-  if (include) {
+  if (include.length > 0) {
     path += path.includes('?') ? `&${include}` : `?${include}`;
   }
   return apiFetch({

--- a/packages/wp-story-editor/src/api/fonts.js
+++ b/packages/wp-story-editor/src/api/fonts.js
@@ -24,12 +24,29 @@ import { addQueryArgs } from '@googleforcreators/design-system';
  */
 import apiFetch from '@wordpress/api-fetch';
 
-export function getFonts(config, { include, search, service }) {
+/**
+ * Assembles the `&include` query parameter.
+ *
+ * Works around a bug in WordPress.
+ *
+ * @see https://github.com/GoogleForCreators/web-stories-wp/issues/10710
+ * @param {string[]} include List of fonts to include.
+ * @return {string} include query parameter with bracket notation.
+ */
+function getIncludeQueryArgs(include) {
+  return include?.map((item) => `include[]=${encodeURI(item)}`).join('&');
+}
+
+export function getFonts(config, { include: _include, search, service }) {
+  let path = addQueryArgs(`${config.api.fonts}`, {
+    search,
+    service,
+  });
+  const include = getIncludeQueryArgs(_include);
+  if (include) {
+    path += path.includes('?') ? `&${include}` : `?${include}`;
+  }
   return apiFetch({
-    path: addQueryArgs(`${config.api.fonts}`, {
-      include,
-      search,
-      service,
-    }),
+    path,
   });
 }

--- a/packages/wp-story-editor/src/api/test/fonts.js
+++ b/packages/wp-story-editor/src/api/test/fonts.js
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import getApiCallbacks from '../utils/getApiCallbacks';
+
+jest.mock('@wordpress/api-fetch');
+
+describe('Fonts API Callbacks', () => {
+  afterEach(() => {
+    apiFetch.mockReset();
+  });
+
+  it('should not add include param if not provided', () => {
+    const { getFonts } = getApiCallbacks({
+      api: { fonts: '/web-stories/v1/fonts/' },
+    });
+
+    getFonts({
+      service: 'fonts.google.com',
+    });
+
+    expect(apiFetch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: expect.not.stringContaining('include[]='),
+      })
+    );
+  });
+
+  it('should include fonts with square bracket notation', () => {
+    const { getFonts } = getApiCallbacks({
+      api: { fonts: '/web-stories/v1/fonts/' },
+    });
+
+    getFonts({
+      include: ['Roboto Mono', 'Roboto Serif'],
+    });
+
+    expect(apiFetch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: expect.stringContaining(
+          '?include[]=Roboto%20Mono&include[]=Roboto%20Serif'
+        ),
+      })
+    );
+  });
+
+  it('should include fonts with square bracket notation after other query params', () => {
+    const { getFonts } = getApiCallbacks({
+      api: { fonts: '/web-stories/v1/fonts/' },
+    });
+
+    getFonts({
+      service: 'fonts.google.com',
+      include: ['Roboto Mono', 'Roboto Serif'],
+    });
+
+    expect(apiFetch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: expect.stringContaining(
+          '&include[]=Roboto%20Mono&include[]=Roboto%20Serif'
+        ),
+      })
+    );
+  });
+});

--- a/packages/wp-story-editor/src/api/test/fonts.js
+++ b/packages/wp-story-editor/src/api/test/fonts.js
@@ -53,7 +53,7 @@ describe('Fonts API Callbacks', () => {
     });
 
     getFonts({
-      include: ['Roboto Mono', 'Roboto Serif'],
+      include: ['Roboto Mono', 'Roboto Serif'].join(','),
     });
 
     expect(apiFetch).toHaveBeenCalledWith(
@@ -72,7 +72,7 @@ describe('Fonts API Callbacks', () => {
 
     getFonts({
       service: 'fonts.google.com',
-      include: ['Roboto Mono', 'Roboto Serif'],
+      include: ['Roboto Mono', 'Roboto Serif'].join(','),
     });
 
     expect(apiFetch).toHaveBeenCalledWith(


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

See #10710

## Summary

<!-- A brief description of what this PR does. -->

This adds some WP-specific workaround for a limitation in how the WP REST API loads fonts.

This should ensure that the list of curated fonts is properly loaded in the font picker and includes _all curated fonts_ as defined in `CURATED_FONT_NAMES`.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Create a new story
2. Add a new text element
3. Notice an HTTP call being made to `/wp-json/web-stories/v1/fonts?include...`. The response should 43 entries, matching `CURATED_FONT_NAMES` — not just 23 entries.
4. All curated font names should be listed in the font picker


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10710
