### PR TITLE
Editor: Fix Saved Templates Karma test

### DIFF
--- a/packages/story-editor/src/components/library/panes/pageTemplates/karma/savedPageTemplates.karma.js
+++ b/packages/story-editor/src/components/library/panes/pageTemplates/karma/savedPageTemplates.karma.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { waitFor } from '@testing-library/react';
+import { waitFor, within } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -123,11 +123,15 @@ describe('CUJ: Page Templates: Custom Saved Templates', () => {
         fixture.editor.library.pageTemplatesPane.deleteBtnByIndex(0)
       );
 
-      expect(await fixture.screen.findByRole('dialog')).toBeTruthy();
+      const dialog = await fixture.screen.findByRole('dialog', {
+        name: 'Delete Page Template',
+        timeout: 9000,
+      });
 
-      const deleteButton = await fixture.screen.findByRole('button', {
+      const deleteButton = await within(dialog).findByRole('button', {
         name: 'Delete',
       });
+
       await fixture.events.click(deleteButton);
 
       await fixture.events.sleep(200);


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
The `CUJ: Page Templates: Custom Saved Templates Saved page templates should allow deleting a saved template` has been flakey resulting in the need to re-run test suite. 

## Summary

<!-- A brief description of what this PR does. -->
Turns out we can't always rely simply on grabbing an element byRole('dialog') because we can often mistake the checklist dialog as that one we are trying to target. 

## Relevant Technical Choices
Ensured we are waiting for the delete templates dialog by adding `name: 'Delete Page Template'` 
In my testing, this particular dialog can sometimes take an absurdly long time to render. 🤷  I got the most consistent results with this longer (then we tend to use) timeout flag. 
<!-- Please describe your changes. -->

## To-do
n/a
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10695 
