### PR TITLE
Media: Reload video on canvas after replacing

### DIFF
--- a/packages/story-editor/src/elements/video/display.js
+++ b/packages/story-editor/src/elements/video/display.js
@@ -107,6 +107,9 @@ function VideoDisplay({ previewMode, box: { width, height }, element }) {
         // eslint-disable-next-line styled-components-a11y/media-has-caption,jsx-a11y/media-has-caption -- False positive.
         <Video
           id={`video-${id}`}
+          // Force React to update the video in the DOM, causing it to properly reload if the URL changes.
+          // See https://github.com/GoogleForCreators/web-stories-wp/issues/10678
+          key={url}
           poster={poster || resource.poster}
           style={style}
           {...videoProps}


### PR DESCRIPTION
## Context

When replacing a video on the canvas using the "Replace Media" quick action menu item, the video is not actually reloaded on the canvas.

See: https://github.com/GoogleForCreators/web-stories-wp/issues/10678#issue-1147381459

## Summary

Adds a [key](https://reactjs.org/docs/lists-and-keys.html#keys) attribute to the Video to ensure React get the update

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

Bug fix

## Testing Instructions

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1) Insert video on canvas
2) Use "Replace Media" quick action to replace video with another one
3) Still see new video on canvas


## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10678
