### PR TITLE
Story Editor: Fix flakey keyboard shortcut add text karma test

### DIFF
--- a/packages/story-editor/src/elements/text/karma/edit.karma.js
+++ b/packages/story-editor/src/elements/text/karma/edit.karma.js
@@ -168,8 +168,6 @@ describe('TextEdit integration', () => {
           expect(fixture.querySelector('[data-testid="textEditor"]')).toBeNull()
         );
         // The element is still selected and updated.
-        // const storyContext = await fixture.renderHook(() => useStory());
-
         await waitFor(async () => {
           const story = await fixture.renderHook(() => useStory());
 

--- a/packages/story-editor/src/elements/text/karma/edit.karma.js
+++ b/packages/story-editor/src/elements/text/karma/edit.karma.js
@@ -168,10 +168,19 @@ describe('TextEdit integration', () => {
           expect(fixture.querySelector('[data-testid="textEditor"]')).toBeNull()
         );
         // The element is still selected and updated.
-        const storyContext = await fixture.renderHook(() => useStory());
-        expect(storyContext.state.selectedElements[0].content).toEqual(
-          'This is some test text.'
-        );
+        // const storyContext = await fixture.renderHook(() => useStory());
+
+        await waitFor(async () => {
+          const story = await fixture.renderHook(() => useStory());
+
+          if (!story.state.selectedElements.length) {
+            throw new Error('story not ready');
+          }
+
+          expect(story.state.selectedElements[0].content).toEqual(
+            'This is some test text.'
+          );
+        });
       });
     });
   });

--- a/packages/story-editor/src/elements/text/karma/edit.karma.js
+++ b/packages/story-editor/src/elements/text/karma/edit.karma.js
@@ -163,14 +163,10 @@ describe('TextEdit integration', () => {
 
         // Exit edit mode using the Esc key
         await fixture.events.keyboard.press('Esc');
-        await fixture.events.sleep(100);
-        await waitFor(() =>
-          expect(fixture.querySelector('[data-testid="textEditor"]')).toBeNull()
-        );
+
         // The element is still selected and updated.
         await waitFor(async () => {
           const story = await fixture.renderHook(() => useStory());
-
           if (!story.state.selectedElements.length) {
             throw new Error('story not ready');
           }


### PR DESCRIPTION
## Context
`TextEdit integration add a text shortcuts should enter/exit edit mode using the keyboard` has been flakey. 
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Sometimes we need to wait for the story before moving along. 
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
Added a waitFor check for when the story takes a little too long
<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10694 
