### PR TITLE
Performance tracking: verify `events` entry type is supported

### DIFF
--- a/packages/story-editor/src/utils/usePerformanceTracking.js
+++ b/packages/story-editor/src/utils/usePerformanceTracking.js
@@ -22,11 +22,16 @@ import { trackTiming } from '@googleforcreators/tracking';
 
 const TRACES = {};
 const OBSERVED_EVENTS = ['click', 'pointerdown', 'pointerup'];
+const OBSERVED_ENTRY_TYPE = 'event';
 let performanceObserver;
 
 function usePerformanceTracking({ node, eventData, eventType = 'click' }) {
+  const supportsPerformanceObserving =
+    typeof PerformanceObserver !== 'undefined' &&
+    PerformanceObserver.supportedEntryTypes.includes(OBSERVED_ENTRY_TYPE);
+
   // Start observing all events if not doing so already.
-  if (!performanceObserver && typeof PerformanceObserver !== 'undefined') {
+  if (!performanceObserver && supportsPerformanceObserving) {
     performanceObserver = new PerformanceObserver((entries) => {
       for (const entry of entries.getEntries()) {
         if (
@@ -44,12 +49,12 @@ function usePerformanceTracking({ node, eventData, eventType = 'click' }) {
         }
       }
     });
-    performanceObserver.observe({ entryTypes: ['event'] });
+    performanceObserver.observe({ entryTypes: [OBSERVED_ENTRY_TYPE] });
   }
 
   const { label, category } = eventData;
   useEffect(() => {
-    if (!node) {
+    if (!node || !supportsPerformanceObserving) {
       return undefined;
     }
     const el = node;
@@ -64,7 +69,7 @@ function usePerformanceTracking({ node, eventData, eventType = 'click' }) {
     return () => {
       el.removeEventListener(eventType, traceEvent);
     };
-  }, [category, label, node, eventType]);
+  }, [category, label, node, eventType, supportsPerformanceObserving]);
 }
 
 export default usePerformanceTracking;


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
If the `PerformanceObserver` does not support `events` as entry type, skips the tracking entirely.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
N/A
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

Doing simple user actions (such as selecting elements, page menu actions, etc.) shouldn't cause errors.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
No
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
No
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10616 
