### PR TITLE
Semantic Headings: Remove feature flag code completely 

### DIFF
--- a/includes/AMP/Integration/AMP_Story_Sanitizer.php
+++ b/includes/AMP/Integration/AMP_Story_Sanitizer.php
@@ -49,7 +49,7 @@ class AMP_Story_Sanitizer extends AMP_Base_Sanitizer {
 	public function sanitize(): void {
 		$this->transform_html_start_tag( $this->dom );
 		$this->transform_a_tags( $this->dom );
-		$this->use_semantic_heading_tags( $this->dom, $this->args['semantic_headings'] ?? false );
+		$this->use_semantic_heading_tags( $this->dom );
 		$this->add_publisher_logo( $this->dom, $this->args['publisher_logo'] );
 		$this->add_publisher( $this->dom, $this->args['publisher'] );
 		$this->add_poster_images( $this->dom, $this->args['poster_images'] );

--- a/includes/AMP/Sanitization.php
+++ b/includes/AMP/Sanitization.php
@@ -27,7 +27,6 @@
 namespace Google\Web_Stories\AMP;
 
 use DOMElement;
-use Google\Web_Stories\Experiments;
 use Google\Web_Stories\Model\Story;
 use Google\Web_Stories\Settings;
 use Google\Web_Stories\Story_Post_Type;
@@ -63,24 +62,15 @@ class Sanitization {
 	private $settings;
 
 	/**
-	 * Experiments instance.
-	 *
-	 * @var Experiments Experiments instance.
-	 */
-	private $experiments;
-
-	/**
 	 * Analytics constructor.
 	 *
 	 * @since 1.12.0
 	 *
-	 * @param Settings    $settings    Settings instance.
-	 * @param Experiments $experiments Experiments instance.
+	 * @param Settings $settings    Settings instance.
 	 * @return void
 	 */
-	public function __construct( Settings $settings, Experiments $experiments ) {
-		$this->settings    = $settings;
-		$this->experiments = $experiments;
+	public function __construct( Settings $settings ) {
+		$this->settings = $settings;
 	}
 
 	/**
@@ -445,11 +435,10 @@ class Sanitization {
 			];
 
 			$sanitizers[ Story_Sanitizer::class ] = [
-				'publisher_logo'    => $story->get_publisher_logo_url(),
-				'publisher'         => $story->get_publisher_name(),
-				'poster_images'     => array_filter( $poster_images ),
-				'video_cache'       => $video_cache_enabled,
-				'semantic_headings' => $this->experiments->is_experiment_enabled( 'semanticHeadingTags' ),
+				'publisher_logo' => $story->get_publisher_logo_url(),
+				'publisher'      => $story->get_publisher_name(),
+				'poster_images'  => array_filter( $poster_images ),
+				'video_cache'    => $video_cache_enabled,
 			];
 		}
 

--- a/includes/AMP/Story_Sanitizer.php
+++ b/includes/AMP/Story_Sanitizer.php
@@ -47,7 +47,7 @@ class Story_Sanitizer extends AMP_Base_Sanitizer {
 	public function sanitize(): void {
 		$this->transform_html_start_tag( $this->dom );
 		$this->transform_a_tags( $this->dom );
-		$this->use_semantic_heading_tags( $this->dom, $this->args['semantic_headings'] ?? false );
+		$this->use_semantic_heading_tags( $this->dom );
 		$this->add_publisher_logo( $this->dom, $this->args['publisher_logo'] );
 		$this->add_publisher( $this->dom, $this->args['publisher'] );
 		$this->add_poster_images( $this->dom, $this->args['poster_images'] );

--- a/includes/AMP/Traits/Sanitization_Utils.php
+++ b/includes/AMP/Traits/Sanitization_Utils.php
@@ -125,7 +125,6 @@ trait Sanitization_Utils {
 	 * @param Document|AMP_Document $document   Document instance.
 	 */
 	private function use_semantic_heading_tags( &$document ): void {
-		
 		$pages = $document->getElementsByTagName( 'amp-story-page' );
 
 		/**

--- a/includes/AMP/Traits/Sanitization_Utils.php
+++ b/includes/AMP/Traits/Sanitization_Utils.php
@@ -123,13 +123,9 @@ trait Sanitization_Utils {
 	 * @since 1.18.0
 	 *
 	 * @param Document|AMP_Document $document   Document instance.
-	 * @param bool                  $is_enabled Whether the feature is enabled.
 	 */
-	private function use_semantic_heading_tags( &$document, bool $is_enabled ): void {
-		if ( ! $is_enabled ) {
-			return;
-		}
-
+	private function use_semantic_heading_tags( &$document ): void {
+		
 		$pages = $document->getElementsByTagName( 'amp-story-page' );
 
 		/**

--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -383,18 +383,6 @@ class Experiments extends Service_Base implements HasRequirements {
 				'group'       => 'editor',
 			],
 			/**
-			 * Author: @swissspidy
-			 * Issue: #10394
-			 * Creation date: 2022-01-32
-			 */
-			[
-				'name'        => 'semanticHeadingTags',
-				'label'       => __( 'Semantic Headings', 'web-stories' ),
-				'description' => __( 'Automatically use semantic heading tags for text elements', 'web-stories' ),
-				'group'       => 'editor',
-				'default'     => true,
-			],
-			/**
 			 * Author: @miina
 			 * Issue: #10113
 			 * Creation date: 2022-02-22

--- a/includes/Integrations/AMP.php
+++ b/includes/Integrations/AMP.php
@@ -29,7 +29,6 @@ namespace Google\Web_Stories\Integrations;
 use DOMElement;
 use Google\Web_Stories\AMP\Integration\AMP_Story_Sanitizer;
 use Google\Web_Stories\Context;
-use Google\Web_Stories\Experiments;
 use Google\Web_Stories\Infrastructure\HasRequirements;
 use Google\Web_Stories\Model\Story;
 use Google\Web_Stories\Service_Base;
@@ -70,13 +69,6 @@ class AMP extends Service_Base implements HasRequirements {
 	private $context;
 
 	/**
-	 * Experiments instance.
-	 *
-	 * @var Experiments Experiments instance.
-	 */
-	private $experiments;
-
-	/**
 	 * Analytics constructor.
 	 *
 	 * @since 1.12.0
@@ -84,19 +76,16 @@ class AMP extends Service_Base implements HasRequirements {
 	 * @param Settings        $settings        Settings instance.
 	 * @param Story_Post_Type $story_post_type Experiments instance.
 	 * @param Context         $context         Context instance.
-	 * @param Experiments     $experiments     Experiments instance.
 	 * @return void
 	 */
 	public function __construct(
 		Settings $settings,
 		Story_Post_Type $story_post_type,
-		Context $context,
-		Experiments $experiments
+		Context $context
 	) {
 		$this->settings        = $settings;
 		$this->story_post_type = $story_post_type;
 		$this->context         = $context;
-		$this->experiments     = $experiments;
 	}
 
 	/**
@@ -216,11 +205,10 @@ class AMP extends Service_Base implements HasRequirements {
 		}
 
 		$sanitizers[ AMP_Story_Sanitizer::class ] = [
-			'publisher_logo'    => $story->get_publisher_logo_url(),
-			'publisher'         => $story->get_publisher_name(),
-			'poster_images'     => array_filter( $poster_images ),
-			'video_cache'       => $video_cache_enabled,
-			'semantic_headings' => $this->experiments->is_experiment_enabled( 'semanticHeadingTags' ),
+			'publisher_logo' => $story->get_publisher_logo_url(),
+			'publisher'      => $story->get_publisher_name(),
+			'poster_images'  => array_filter( $poster_images ),
+			'video_cache'    => $video_cache_enabled,
 		];
 
 		return $sanitizers;

--- a/packages/story-editor/src/output/page.js
+++ b/packages/story-editor/src/output/page.js
@@ -41,7 +41,6 @@ function OutputPage({
   page,
   autoAdvance = DEFAULT_AUTO_ADVANCE,
   defaultPageDuration = DEFAULT_PAGE_DURATION,
-  flags,
 }) {
   const {
     id,
@@ -83,10 +82,8 @@ function OutputPage({
   const regularElements = otherElements.map((element) => {
     const { id: elementId, type, tagName = 'auto' } = element;
 
-    if (flags?.semanticHeadingTags) {
-      if ('text' === type && 'auto' === tagName) {
-        element.tagName = tagNamesMap.get(elementId);
-      }
+    if ('text' === type && 'auto' === tagName) {
+      element.tagName = tagNamesMap.get(elementId);
     }
 
     // Remove invalid links.

--- a/tests/phpunit/unit/tests/AMP/Story_Sanitizer.php
+++ b/tests/phpunit/unit/tests/AMP/Story_Sanitizer.php
@@ -543,11 +543,10 @@ class Story_Sanitizer extends TestCase {
 HTML;
 
 		$args = [
-			'publisher_logo'    => '',
-			'publisher'         => '',
-			'poster_images'     => [],
-			'video_cache'       => false,
-			'semantic_headings' => true,
+			'publisher_logo' => '',
+			'publisher'      => '',
+			'poster_images'  => [],
+			'video_cache'    => false,
 		];
 
 		$actual = $this->sanitize_and_get( $source, $args );
@@ -593,11 +592,10 @@ HTML;
 HTML;
 
 		$args = [
-			'publisher_logo'    => '',
-			'publisher'         => '',
-			'poster_images'     => [],
-			'video_cache'       => false,
-			'semantic_headings' => true,
+			'publisher_logo' => '',
+			'publisher'      => '',
+			'poster_images'  => [],
+			'video_cache'    => false,
 		];
 
 		$actual = $this->sanitize_and_get( $source, $args );
@@ -614,105 +612,4 @@ HTML;
 		$this->assertStringContainsString( 'Title 3B</h3>', $actual );
 		$this->assertStringContainsString( 'ParagraphB</p>', $actual );
 	}
-
-	/**
-	 * @covers \Google\Web_Stories\AMP\Traits\Sanitization_Utils::use_semantic_heading_tags
-	 */
-	public function test_use_semantic_heading_tags_not_enabled(): void {
-		$source = <<<'HTML'
-<html><head></head><body><amp-story>
-	<amp-story-page>
-		<amp-story-grid-layer>
-			<p class="text-wrapper" style="font-size:.582524em">Title 1</p>
-			<p class="text-wrapper" style="font-size:.582524em">Title 1</p>
-			<p class="text-wrapper" style="font-size:.436893em">Title 2</p>
-			<p class="text-wrapper" style="font-size:.339805em">Title 3</p>
-			<p class="text-wrapper" style="font-size:.291262em">Paragraph</p>
-		</amp-story-grid-layer>
-	</amp-story-page>
-	<amp-story-page>
-		<amp-story-grid-layer>
-			<p class="text-wrapper" style="font-size:.582524em">Title 1B</p>
-			<p class="text-wrapper" style="font-size:.339805em">Title 3B</p>
-			<p class="text-wrapper" style="font-size:.436893em">Title 2B</p>
-			<p class="text-wrapper" style="font-size:.582524em">Title 1B</p>
-			<p class="text-wrapper" style="font-size:.291262em">ParagraphB</p>
-		</amp-story-grid-layer>
-	</amp-story-page>
-</amp-story></body></html>
-HTML;
-
-		$args = [
-			'publisher_logo'    => '',
-			'publisher'         => '',
-			'poster_images'     => [],
-			'video_cache'       => false,
-			'semantic_headings' => false,
-		];
-
-		$actual = $this->sanitize_and_get( $source, $args );
-
-		$this->assertStringContainsString( 'Title 1</p>', $actual );
-		$this->assertStringContainsString( 'Title 1</p>', $actual );
-		$this->assertStringContainsString( 'Title 2</p>', $actual );
-		$this->assertStringContainsString( 'Title 3</p>', $actual );
-		$this->assertStringContainsString( 'Paragraph</p>', $actual );
-
-		$this->assertStringContainsString( 'Title 1B</p>', $actual );
-		$this->assertStringContainsString( 'Title 1B</p>', $actual );
-		$this->assertStringContainsString( 'Title 2B</p>', $actual );
-		$this->assertStringContainsString( 'Title 3B</p>', $actual );
-		$this->assertStringContainsString( 'ParagraphB</p>', $actual );
-	}
-
-	/**
-	 * @covers \Google\Web_Stories\AMP\Traits\Sanitization_Utils::use_semantic_heading_tags
-	 */
-	public function test_use_semantic_heading_tags_short_content(): void {
-		$source = <<<'HTML'
-<html><head></head><body><amp-story>
-	<amp-story-page>
-		<amp-story-grid-layer>
-			<p class="text-wrapper" style="font-size:.582524em">T 1</p>
-			<p class="text-wrapper" style="font-size:.582524em">T 1</p>
-			<p class="text-wrapper" style="font-size:.436893em">T 2</p>
-			<p class="text-wrapper" style="font-size:.339805em">T 3</p>
-			<p class="text-wrapper" style="font-size:.291262em">P</p>
-		</amp-story-grid-layer>
-	</amp-story-page>
-	<amp-story-page>
-		<amp-story-grid-layer>
-			<p class="text-wrapper" style="font-size:.582524em">T1B</p>
-			<p class="text-wrapper" style="font-size:.339805em">T3B</p>
-			<p class="text-wrapper" style="font-size:.436893em">T2B</p>
-			<p class="text-wrapper" style="font-size:.582524em">T1B</p>
-			<p class="text-wrapper" style="font-size:.291262em">PB</p>
-		</amp-story-grid-layer>
-	</amp-story-page>
-</amp-story></body></html>
-HTML;
-
-		$args = [
-			'publisher_logo'    => '',
-			'publisher'         => '',
-			'poster_images'     => [],
-			'video_cache'       => false,
-			'semantic_headings' => true,
-		];
-
-		$actual = $this->sanitize_and_get( $source, $args );
-
-		$this->assertStringContainsString( 'T 1</p>', $actual );
-		$this->assertStringContainsString( 'T 1</p>', $actual );
-		$this->assertStringContainsString( 'T 2</p>', $actual );
-		$this->assertStringContainsString( 'T 3</p>', $actual );
-		$this->assertStringContainsString( 'P</p>', $actual );
-
-		$this->assertStringContainsString( 'T1B</p>', $actual );
-		$this->assertStringContainsString( 'T1B</p>', $actual );
-		$this->assertStringContainsString( 'T2B</p>', $actual );
-		$this->assertStringContainsString( 'T3B</p>', $actual );
-		$this->assertStringContainsString( 'PB</p>', $actual );
-	}
-
 }

--- a/tests/phpunit/unit/tests/AMP/Story_Sanitizer.php
+++ b/tests/phpunit/unit/tests/AMP/Story_Sanitizer.php
@@ -612,4 +612,54 @@ HTML;
 		$this->assertStringContainsString( 'Title 3B</h3>', $actual );
 		$this->assertStringContainsString( 'ParagraphB</p>', $actual );
 	}
+
+	/**
+	 * @covers \Google\Web_Stories\AMP\Traits\Sanitization_Utils::use_semantic_heading_tags
+	 */
+	public function test_use_semantic_heading_tags_short_content(): void {
+		$source = <<<'HTML'
+<html><head></head><body><amp-story>
+	<amp-story-page>
+		<amp-story-grid-layer>
+			<p class="text-wrapper" style="font-size:.582524em">T 1</p>
+			<p class="text-wrapper" style="font-size:.582524em">T 1</p>
+			<p class="text-wrapper" style="font-size:.436893em">T 2</p>
+			<p class="text-wrapper" style="font-size:.339805em">T 3</p>
+			<p class="text-wrapper" style="font-size:.291262em">P</p>
+		</amp-story-grid-layer>
+	</amp-story-page>
+	<amp-story-page>
+		<amp-story-grid-layer>
+			<p class="text-wrapper" style="font-size:.582524em">T1B</p>
+			<p class="text-wrapper" style="font-size:.339805em">T3B</p>
+			<p class="text-wrapper" style="font-size:.436893em">T2B</p>
+			<p class="text-wrapper" style="font-size:.582524em">T1B</p>
+			<p class="text-wrapper" style="font-size:.291262em">PB</p>
+		</amp-story-grid-layer>
+	</amp-story-page>
+</amp-story></body></html>
+HTML;
+
+		$args = [
+			'publisher_logo'    => '',
+			'publisher'         => '',
+			'poster_images'     => [],
+			'video_cache'       => false,
+			'semantic_headings' => true,
+		];
+
+		$actual = $this->sanitize_and_get( $source, $args );
+
+		$this->assertStringContainsString( 'T 1</p>', $actual );
+		$this->assertStringContainsString( 'T 1</p>', $actual );
+		$this->assertStringContainsString( 'T 2</p>', $actual );
+		$this->assertStringContainsString( 'T 3</p>', $actual );
+		$this->assertStringContainsString( 'P</p>', $actual );
+
+		$this->assertStringContainsString( 'T1B</p>', $actual );
+		$this->assertStringContainsString( 'T1B</p>', $actual );
+		$this->assertStringContainsString( 'T2B</p>', $actual );
+		$this->assertStringContainsString( 'T3B</p>', $actual );
+		$this->assertStringContainsString( 'PB</p>', $actual );
+	}
 }


### PR DESCRIPTION
## Context

Semantic Headings we're turned on by default for 1.18.0 --- this updates removes the feature flag

## Summary

- Removes feature flag related code for semantic headings 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10688
