### PR TITLE
Insertion Library: Fix menu focus when using keyboard

### DIFF
--- a/packages/story-editor/src/components/library/panes/media/common/mediaElement.js
+++ b/packages/story-editor/src/components/library/panes/media/common/mediaElement.js
@@ -229,6 +229,8 @@ function Element({
           width={width}
           index={index}
           isLocal={providerType === 'local'}
+          setParentActive={makeActive}
+          setParentInactive={makeInactive}
         />
         {providerType === 'local' && canEditMedia && (
           <DropDownMenu
@@ -238,6 +240,7 @@ function Element({
             onMenuOpen={onMenuOpen}
             onMenuCancelled={onMenuCancelled}
             onMenuSelected={onMenuSelected}
+            setParentActive={makeActive}
           />
         )}
       </InnerContainer>


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
- When closing the menu or closing the Edit media / Delete media dialogues, the focus returns back to the button
- Tabbing inside the menu is the same as `Esc`, so it will behave the same way here, too -> returns the focus back to the button.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Open the local Media tab
2. Use the Insertion button (+ icon) and menu with keyboard.
3. Verify that when closing the menu (Esc or Tab), the focus returns back to the + icon.
4. Verify that when choosing an option from the menu, the focus does not return to the + icon (since an element gets inserted instead)
5. Use the "More" (three dots) icon and menu with keyboard
6. Verify that when closing the menu (Esc or Tab), the focus returns back to the three dots button.
7. Verify that when choosing either Edit/Delete options in the menu, and then Cancelling the dialogue, focus returns to the three dots button.


## Reviews

### Does this PR have a security-related impact?
No
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
No
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
No
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10607 
