### PR TITLE
Editor: Added loop control to design menu

### DIFF
--- a/packages/story-editor/src/components/floatingMenu/elements/karma/loop.karma.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/karma/loop.karma.js
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { Fixture } from '../../../../karma';
+import { useStory } from '../../../../app/story';
+
+describe('Design Menu: Video loop toggle', () => {
+  let fixture;
+
+  beforeEach(async () => {
+    fixture = new Fixture();
+    fixture.setFlags({ floatingMenu: true });
+    try {
+      await fixture.render();
+    } catch {
+      // ignore
+    }
+
+    await fixture.collapseHelpCenter();
+
+    // Add a video to stage
+    await fixture.events.mouse.clickOn(
+      fixture.editor.library.media.item(5),
+      20,
+      20
+    );
+  });
+
+  afterEach(() => {
+    fixture.restore();
+  });
+
+  const getSelectedElementLoop = async () => {
+    const storyContext = await fixture.renderHook(() => useStory());
+    return storyContext.state.selectedElements[0].loop || false;
+  };
+
+  it('should render the checkbox as unchecked if the video is not set to loop', async () => {
+    expect(await getSelectedElementLoop()).toBe(false);
+
+    expect(fixture.editor.canvas.designMenu.loop.checked).toBe(false);
+  });
+
+  it('should render the checkbox as checked if the video is set to loop', async () => {
+    // Toggle the loop property using the design panel
+    await fixture.events.click(
+      fixture.editor.inspector.designPanel.videoOptions.loop
+    );
+
+    expect(await getSelectedElementLoop()).toBe(true);
+
+    expect(fixture.editor.canvas.designMenu.loop.checked).toBe(true);
+  });
+
+  it('should toggle the element loop flag when pressed', async () => {
+    expect(await getSelectedElementLoop()).toBe(false);
+    expect(fixture.editor.canvas.designMenu.loop.checked).toBe(false);
+
+    await fixture.events.click(fixture.editor.canvas.designMenu.loop);
+
+    expect(await getSelectedElementLoop()).toBe(true);
+    expect(fixture.editor.canvas.designMenu.loop.checked).toBe(true);
+
+    await fixture.events.click(fixture.editor.canvas.designMenu.loop);
+
+    expect(await getSelectedElementLoop()).toBe(false);
+    expect(fixture.editor.canvas.designMenu.loop.checked).toBe(false);
+  });
+});

--- a/packages/story-editor/src/components/floatingMenu/elements/loop.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/loop.js
@@ -17,22 +17,31 @@
 /**
  * External dependencies
  */
-import { Icons } from '@googleforcreators/design-system';
-import { __ } from '@googleforcreators/i18n';
+import styled from 'styled-components';
 
 /**
  * Internal dependencies
  */
-import { IconButton } from './shared';
+import { useStory } from '../../../app';
+import LoopPanelContent from '../../panels/shared/loopPanelContent';
+import { useProperties } from './shared';
+
+const StyledLoopContent = styled(LoopPanelContent)`
+  gap: 8px;
+`;
 
 function Loop() {
-  return (
-    <IconButton
-      Icon={Icons.ArrowLeftright}
-      title={__('Loop video', 'web-stories')}
-      onClick={() => {}}
-    />
+  const { loop } = useProperties(['loop']);
+  const updateSelectedElements = useStory(
+    (state) => state.actions.updateSelectedElements
   );
+
+  const handleChange = () =>
+    updateSelectedElements({
+      properties: ({ loop: oldLoop }) => ({ loop: !oldLoop }),
+    });
+
+  return <StyledLoopContent loop={loop} onChange={handleChange} />;
 }
 
 export default Loop;

--- a/packages/story-editor/src/components/panels/shared/loopPanelContent.js
+++ b/packages/story-editor/src/components/panels/shared/loopPanelContent.js
@@ -36,27 +36,29 @@ const StyledCheckbox = styled(Checkbox)`
   `}
 `;
 
-const Label = styled.label`
-  margin-left: 12px;
+const Wrapper = styled.div`
+  display: flex;
+  gap: 12px;
 `;
 
-function LoopPanelContent({ loop, onChange }) {
+function LoopPanelContent({ loop, className = '', onChange }) {
   const checkboxId = `cb-${uuidv4()}`;
 
   return (
-    <>
+    <Wrapper className={className}>
       <StyledCheckbox id={checkboxId} checked={loop} onChange={onChange} />
-      <Label htmlFor={checkboxId}>
+      <label htmlFor={checkboxId}>
         <Text as="span" size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}>
           {__('Loop', 'web-stories')}
         </Text>
-      </Label>
-    </>
+      </label>
+    </Wrapper>
   );
 }
 
 LoopPanelContent.propTypes = {
   onChange: PropTypes.func.isRequired,
+  className: PropTypes.string,
   loop: PropTypes.bool,
 };
 

--- a/packages/story-editor/src/karma/fixture/containers/designPanel/index.js
+++ b/packages/story-editor/src/karma/fixture/containers/designPanel/index.js
@@ -34,6 +34,7 @@ import { PageBackground } from './pageBackground';
 import { SizePosition } from './sizePosition';
 import { TextStyle } from './textStyle';
 import { VideoPoster } from './videoPoster';
+import { VideoOptions } from './videoOptions';
 import { Captions } from './captions';
 import { ShapeStyle } from './shapeStyle';
 
@@ -120,8 +121,11 @@ export class DesignPanel extends Container {
   }
 
   get videoOptions() {
-    // @todo: implement
-    return null;
+    return this._get(
+      this.getByRole('region', { name: /Video settings/i }),
+      'videoOptions',
+      VideoOptions
+    );
   }
 
   get captions() {

--- a/packages/story-editor/src/karma/fixture/containers/designPanel/videoOptions.js
+++ b/packages/story-editor/src/karma/fixture/containers/designPanel/videoOptions.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,39 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * Internal dependencies
  */
-import { Container } from './container';
-import { ToggleButton } from './common';
+import { AbstractPanel } from './abstractPanel';
 
-export class DesignMenu extends Container {
+/**
+ * The video options panel containing controls for loop, mute, and trim.
+ */
+export class VideoOptions extends AbstractPanel {
   constructor(node, path) {
     super(node, path);
-  }
-
-  get flipVertical() {
-    return this._get(
-      this.getByRole('menuitem', { name: 'Flip vertically' }),
-      'flipVertical',
-      ToggleButton
-    );
-  }
-
-  get flipHorizontal() {
-    return this._get(
-      this.getByRole('menuitem', { name: 'Flip horizontally' }),
-      'flipHorizontal',
-      ToggleButton
-    );
-  }
-
-  get borderRadius() {
-    return this.queryByRole('textbox', { name: 'Corner Radius' });
-  }
-
-  get swapMedia() {
-    return this.getByRole('menuitem', { name: 'Replace media' });
   }
 
   get loop() {


### PR DESCRIPTION
## Context

This reuses the loop control from the existing video options panel.

## To-do

- [x] Tests

## Non-user-facing changes

| Looping? | Screenshot |
|-|-|
| ❌  | ![Screen Shot 2022-03-02 at 17 07 01](https://user-images.githubusercontent.com/637548/156457787-95627cc6-639d-40a6-89e5-19ac0378fd8c.png) |
| ✅  | ![Screen Shot 2022-03-02 at 17 07 07](https://user-images.githubusercontent.com/637548/156457806-531d2a1b-41ac-48c6-81f5-8180b2957e64.png) |

## Testing Instructions


<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #10693
