### PR TITLE
Floating Menu: add font size functionality

### DIFF
--- a/packages/story-editor/src/components/floatingMenu/elements/fontSize.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/fontSize.js
@@ -29,7 +29,7 @@ import {
   inputContainerStyleOverride,
 } from '../../panels/shared';
 import { MIN_MAX } from '../../panels/design/textStyle/font';
-
+// TODO: https://github.com/GoogleForCreators/web-stories-wp/issues/10799
 import { Input } from './shared';
 
 function FontSize() {

--- a/packages/story-editor/src/components/floatingMenu/elements/fontSize.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/fontSize.js
@@ -23,26 +23,18 @@ import { __ } from '@googleforcreators/i18n';
  * Internal dependencies
  */
 import { useStory } from '../../../app';
-import {
-  focusStyle,
-  getCommonValue,
-  inputContainerStyleOverride,
-} from '../../panels/shared';
+import { focusStyle, inputContainerStyleOverride } from '../../panels/shared';
 import { MIN_MAX } from '../../panels/design/textStyle/font';
 // TODO: https://github.com/GoogleForCreators/web-stories-wp/issues/10799
 import { Input } from './shared';
 
 function FontSize() {
-  const { selectedElements, updateSelectedElements } = useStory(
-    ({ state: { selectedElements }, actions: { updateSelectedElements } }) => {
-      return {
-        selectedElements,
-        updateSelectedElements,
-      };
-    }
+  const { fontSize, updateSelectedElements } = useStory(
+    ({ state, actions }) => ({
+      fontSize: state.selectedElements[0].fontSize,
+      updateSelectedElements: actions.updateSelectedElements,
+    })
   );
-
-  const fontSize = getCommonValue(selectedElements, 'fontSize');
 
   const handleChange = (value) =>
     updateSelectedElements({

--- a/packages/story-editor/src/components/floatingMenu/elements/fontSize.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/fontSize.js
@@ -24,7 +24,6 @@ import { NumericInput } from '@googleforcreators/design-system';
  * Internal dependencies
  */
 import { useStory } from '../../../app';
-import { MULTIPLE_VALUE, MULTIPLE_DISPLAY_VALUE } from '../../../constants';
 import {
   focusStyle,
   getCommonValue,
@@ -58,8 +57,7 @@ function FontSize() {
       onChange={(evt, value) => handleChange(value)}
       min={MIN_MAX.FONT_SIZE.MIN}
       max={MIN_MAX.FONT_SIZE.MAX}
-      isIndeterminate={MULTIPLE_VALUE === fontSize}
-      placeholder={MULTIPLE_VALUE === fontSize ? MULTIPLE_DISPLAY_VALUE : null}
+      placeholder={fontSize}
       containerStyleOverride={inputContainerStyleOverride}
       selectButtonStylesOverride={focusStyle}
     />

--- a/packages/story-editor/src/components/floatingMenu/elements/fontSize.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/fontSize.js
@@ -17,20 +17,51 @@
 /**
  * External dependencies
  */
-import { Icons } from '@googleforcreators/design-system';
 import { __ } from '@googleforcreators/i18n';
+import { NumericInput } from '@googleforcreators/design-system';
 
 /**
  * Internal dependencies
  */
-import { IconButton } from './shared';
+import { useStory } from '../../../app';
+import { MULTIPLE_VALUE, MULTIPLE_DISPLAY_VALUE } from '../../../constants';
+import {
+  focusStyle,
+  getCommonValue,
+  inputContainerStyleOverride,
+} from '../../panels/shared';
+import { MIN_MAX } from '../../panels/design/textStyle/font';
 
 function FontSize() {
+  const { selectedElements, updateSelectedElements } = useStory(
+    ({ state: { selectedElements }, actions: { updateSelectedElements } }) => {
+      return {
+        selectedElements,
+        updateSelectedElements,
+      };
+    }
+  );
+
+  const fontSize = getCommonValue(selectedElements, 'fontSize');
+
+  const handleChange = (value) =>
+    updateSelectedElements({
+      properties: {
+        fontSize: value,
+      },
+    });
   return (
-    <IconButton
-      Icon={Icons.LetterTArrow}
-      title={__('Change font size', 'web-stories')}
-      onClick={() => {}}
+    <NumericInput
+      aria-label={__('Font size', 'web-stories')}
+      isFloat
+      value={fontSize}
+      onChange={(evt, value) => handleChange(value)}
+      min={MIN_MAX.FONT_SIZE.MIN}
+      max={MIN_MAX.FONT_SIZE.MAX}
+      isIndeterminate={MULTIPLE_VALUE === fontSize}
+      placeholder={MULTIPLE_VALUE === fontSize ? MULTIPLE_DISPLAY_VALUE : null}
+      containerStyleOverride={inputContainerStyleOverride}
+      selectButtonStylesOverride={focusStyle}
     />
   );
 }

--- a/packages/story-editor/src/components/floatingMenu/elements/fontSize.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/fontSize.js
@@ -18,7 +18,6 @@
  * External dependencies
  */
 import { __ } from '@googleforcreators/i18n';
-import { NumericInput } from '@googleforcreators/design-system';
 
 /**
  * Internal dependencies
@@ -30,6 +29,8 @@ import {
   inputContainerStyleOverride,
 } from '../../panels/shared';
 import { MIN_MAX } from '../../panels/design/textStyle/font';
+
+import { Input } from './shared';
 
 function FontSize() {
   const { selectedElements, updateSelectedElements } = useStory(
@@ -50,7 +51,7 @@ function FontSize() {
       },
     });
   return (
-    <NumericInput
+    <Input
       aria-label={__('Font size', 'web-stories')}
       isFloat
       value={fontSize}

--- a/packages/story-editor/src/components/floatingMenu/elements/karma/text.karma.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/karma/text.karma.js
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { within } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { Fixture } from '../../../../karma';
+import { useStory } from '../../../../app/story';
+
+describe('Design Menu: Text Styles', () => {
+  let fixture;
+
+  beforeEach(async () => {
+    fixture = new Fixture();
+    fixture.setFlags({ floatingMenu: true });
+    await fixture.render();
+
+    await fixture.collapseHelpCenter();
+
+    await fixture.editor.library.textTab.click();
+    await fixture.events.click(fixture.editor.library.text.preset('Paragraph'));
+  });
+
+  afterEach(() => {
+    fixture.restore();
+  });
+
+  it('should allow whole number font sizes', async () => {
+    const menuList = await fixture.screen.findByRole('region', {
+      name: 'Design menu',
+    });
+
+    const fontSize = await within(menuList).findByLabelText('Font size');
+
+    const size = 42;
+
+    await fixture.events.focus(fontSize);
+    await fixture.events.keyboard.type(`${size}`);
+    await fixture.events.keyboard.press('tab');
+
+    const {
+      state: {
+        currentPage: { elements },
+      },
+    } = await fixture.renderHook(() => useStory());
+    expect(elements[1].fontSize).toBe(size);
+  });
+
+  it('should allow fractional font sizes', async () => {
+    const menuList = await fixture.screen.findByRole('region', {
+      name: 'Design menu',
+    });
+
+    const fontSize = await within(menuList).findByLabelText('Font size');
+
+    const size = 15.25;
+
+    await fixture.events.focus(fontSize);
+    await fixture.events.keyboard.type(`${size}`);
+    await fixture.events.keyboard.press('tab');
+
+    const {
+      state: {
+        currentPage: { elements },
+      },
+    } = await fixture.renderHook(() => useStory());
+    expect(elements[1].fontSize).toBe(size);
+  });
+});

--- a/packages/story-editor/src/components/panels/design/textStyle/font.js
+++ b/packages/story-editor/src/components/panels/design/textStyle/font.js
@@ -40,7 +40,7 @@ import useRichTextFormatting from './useRichTextFormatting';
 import getFontWeights from './getFontWeights';
 import FontPicker from './fontPicker';
 
-const MIN_MAX = {
+export const MIN_MAX = {
   FONT_SIZE: {
     MIN: 8,
     MAX: 800,


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
The `floating menu` currently has placeholder buttons. This is to add the `Font Size` functionality. 

## Summary

<!-- A brief description of what this PR does. -->
Make `Font Size` work in the floating menu
## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do
- [ ] Adjust input size #10799 
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. turn on floating menu experiment
2. select text in a story
3. adjust font size via the floating menu
4. notice it should update in both the design panel and on the floating menu.


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10629 
