### PR TITLE
Quick Action Menus: Remove Newly Redundant Actions

### DIFF
--- a/packages/story-editor/src/app/highlights/quickActions/test/useQuickActions.js
+++ b/packages/story-editor/src/app/highlights/quickActions/test/useQuickActions.js
@@ -216,28 +216,11 @@ const foregroundImageQuickActionsWithClear = [
   resetElementAction,
 ];
 
-const shapeQuickActions = [
-  expect.objectContaining({
-    label: ACTIONS.CHANGE_COLOR.text,
-    onClick: expect.any(Function),
-    Icon: Bucket,
-  }),
-  ...foregroundCommonActions,
-];
+const shapeQuickActions = foregroundCommonActions;
 
 const shapeQuickActionsWithClear = [...shapeQuickActions, resetElementAction];
 
 const textQuickActions = [
-  expect.objectContaining({
-    label: ACTIONS.CHANGE_TEXT_COLOR.text,
-    onClick: expect.any(Function),
-    Icon: Bucket,
-  }),
-  expect.objectContaining({
-    label: ACTIONS.CHANGE_FONT.text,
-    onClick: expect.any(Function),
-    Icon: LetterTLargeLetterTSmall,
-  }),
   expect.objectContaining({
     label: ACTIONS.AUTO_STYLE_TEXT.text,
     onClick: expect.any(Function),
@@ -734,16 +717,10 @@ describe('useQuickActions', () => {
       result.current[0].onClick(mockClickEvent);
       expect(highlight).toStrictEqual({
         elementId: SHAPE_ELEMENT.id,
-        highlight: states.STYLE,
-      });
-
-      result.current[1].onClick(mockClickEvent);
-      expect(highlight).toStrictEqual({
-        elementId: SHAPE_ELEMENT.id,
         highlight: states.ANIMATION,
       });
 
-      result.current[2].onClick(mockClickEvent);
+      result.current[1].onClick(mockClickEvent);
       expect(highlight).toStrictEqual({
         elementId: SHAPE_ELEMENT.id,
         highlight: states.LINK,
@@ -762,13 +739,13 @@ describe('useQuickActions', () => {
 
       const { result } = renderHook(() => useQuickActions());
 
-      expect(result.current[3]).toBeUndefined();
+      expect(result.current[2]).toBeUndefined();
     });
 
     it('clicking `clear animations` should call `updateElementsById`', () => {
       const { result } = renderHook(() => useQuickActions());
 
-      result.current[3].onClick(mockClickEvent);
+      result.current[2].onClick(mockClickEvent);
       expect(mockUpdateElementsById).toHaveBeenCalledWith({
         elementIds: [SHAPE_ELEMENT.id],
         properties: expect.any(Function),
@@ -795,25 +772,13 @@ describe('useQuickActions', () => {
     it('should set the correct highlight', () => {
       const { result } = renderHook(() => useQuickActions());
 
-      result.current[0].onClick(mockClickEvent);
-      expect(highlight).toStrictEqual({
-        elementId: TEXT_ELEMENT.id,
-        highlight: states.TEXT_COLOR,
-      });
-
       result.current[1].onClick(mockClickEvent);
-      expect(highlight).toStrictEqual({
-        elementId: TEXT_ELEMENT.id,
-        highlight: states.FONT,
-      });
-
-      result.current[3].onClick(mockClickEvent);
       expect(highlight).toStrictEqual({
         elementId: TEXT_ELEMENT.id,
         highlight: states.ANIMATION,
       });
 
-      result.current[4].onClick(mockClickEvent);
+      result.current[2].onClick(mockClickEvent);
       expect(highlight).toStrictEqual({
         elementId: TEXT_ELEMENT.id,
         highlight: states.LINK,
@@ -832,7 +797,7 @@ describe('useQuickActions', () => {
 
       const { result } = renderHook(() => useQuickActions());
 
-      expect(result.current[5]).toBeUndefined();
+      expect(result.current[3]).toBeUndefined();
     });
 
     it('clicking `reset element` should update the element', () => {
@@ -852,7 +817,7 @@ describe('useQuickActions', () => {
       const { result } = renderHook(() => useQuickActions());
       expect(result.current).toStrictEqual(textQuickActionsWithClear);
 
-      result.current[5].onClick(mockClickEvent);
+      result.current[3].onClick(mockClickEvent);
       expect(mockUpdateElementsById).toHaveBeenCalledWith({
         elementIds: [TEXT_ELEMENT.id],
         properties: expect.any(Function),

--- a/packages/story-editor/src/app/highlights/quickActions/test/useQuickActions.js
+++ b/packages/story-editor/src/app/highlights/quickActions/test/useQuickActions.js
@@ -41,7 +41,6 @@ const {
   CircleSpeed,
   ColorBucket,
   Eraser,
-  LetterTLargeLetterTSmall,
   LetterTPlus,
   Link,
   Media,

--- a/packages/story-editor/src/components/canvas/karma/quickActions.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/quickActions.karma.js
@@ -357,19 +357,6 @@ describe('Quick Actions integration', () => {
       );
     });
 
-    it(`should select the \`${ACTIONS.CHANGE_COLOR.text}\` button and select the shape style panel and focus the input`, async () => {
-      await fixture.events.click(
-        fixture.editor.canvas.quickActionMenu.changeColorButton
-      );
-
-      expect(
-        fixture.editor.inspector.designPanel.shapeStyle.backgroundColor.hex
-      ).not.toBeNull();
-      expect(document.activeElement).toEqual(
-        fixture.editor.inspector.designPanel.shapeStyle.backgroundColor.hex
-      );
-    });
-
     it(`should select the \`${ACTIONS.ADD_ANIMATION.text}\` button and select the animation panel and focus the dropdown`, async () => {
       // click quick menu button
       await fixture.events.click(
@@ -712,36 +699,6 @@ describe('Quick Actions integration', () => {
       );
 
       await fixture.editor.canvas.framesLayer.waitFocusedWithin();
-    });
-
-    it(`clicking the \`${ACTIONS.CHANGE_TEXT_COLOR.text}\` button should select the font styles on the design panel and focus the color input`, async () => {
-      // click quick menu button
-      await fixture.events.click(
-        fixture.editor.canvas.quickActionMenu.textColorButton
-      );
-
-      expect(fixture.editor.inspector.designPanel.textStyle).not.toBeNull();
-
-      const textStyleColorInput = fixture.screen.queryByRole('textbox', {
-        name: /^Text color$/,
-      });
-      expect(textStyleColorInput).toBeDefined();
-      expect(document.activeElement).toEqual(textStyleColorInput);
-    });
-
-    it(`clicking the \`${ACTIONS.CHANGE_FONT.text}\` button should select the font styles on the design panel and focus the font dropdown`, async () => {
-      // click quick menu button
-      await fixture.events.click(
-        fixture.editor.canvas.quickActionMenu.fontButton
-      );
-
-      expect(fixture.editor.inspector.designPanel.textStyle).not.toBeNull();
-
-      const fontDropdown = fixture.screen.queryByRole('button', {
-        name: /^Font family$/,
-      });
-      expect(fontDropdown).toBeDefined();
-      expect(document.activeElement).toEqual(fontDropdown);
     });
 
     it(`clicking the \`${ACTIONS.ADD_ANIMATION.text}\` button should select the animation panel and focus the dropdown`, async () => {


### PR DESCRIPTION
## Context

New floating menus make some of the quick actions redundant. 

## Summary

Remove duplicated actions from quick actions menu where needed now that we have the floating element menu. These are: Text element (change color, edit text), Shape element (change color), Video element (trim).

## Relevant Technical Choices

This is just removing code. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

| Menu | This Branch | Main | 
| -- | --- | --- | 
| Text Element | <img width="513" alt="Screen Shot 2022-03-03 at 9 59 34 AM" src="https://user-images.githubusercontent.com/10720454/156613637-febfd3be-3844-4155-98b3-20b357a2ab96.png"> |  <img width="530" alt="Screen Shot 2022-03-03 at 11 46 48 AM" src="https://user-images.githubusercontent.com/10720454/156631918-9ad7a8d4-9e4c-4606-8a06-e0b7c16cd117.png"> |
| Shape Element | <img width="480" alt="Screen Shot 2022-03-03 at 9 59 45 AM" src="https://user-images.githubusercontent.com/10720454/156613659-364ddde6-000b-4f27-8330-c5b098efe594.png"> | <img width="475" alt="Screen Shot 2022-03-03 at 11 46 55 AM" src="https://user-images.githubusercontent.com/10720454/156631884-43d6f516-9048-4e3b-9164-79f5d94463b9.png"> | 
| (local) Video |  <img width="538" alt="Screen Shot 2022-03-03 at 11 47 21 AM" src="https://user-images.githubusercontent.com/10720454/156631829-2be45cb4-a1bb-4a85-98af-bceca2a790a7.png"> | <img width="495" alt="Screen Shot 2022-03-03 at 11 46 40 AM" src="https://user-images.githubusercontent.com/10720454/156631852-49451daa-0fa0-4ebf-8fe3-febd388ac79f.png"> |



## Testing Instructions

Verify that the following quick actions are removed: 

- Text element: Change Color; Edit Text
- Shape element: Change Color
- Video element: Trim


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10639 
