### PR TITLE
Additional changes to PR #10737

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37251,9 +37251,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-photo-album": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/react-photo-album/-/react-photo-album-1.7.0.tgz",
-      "integrity": "sha512-vWUFc6/QSGuEOv1QWcVBvCxsflsomFmB8JrldbTfDZMs92e4TOrYAqQT2X4QQRoDlx6xG3fnf9KGx6JfK9oz+w==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/react-photo-album/-/react-photo-album-1.9.0.tgz",
+      "integrity": "sha512-RR8vzyjssp8v3bAN+T4VlcsfLpgwX4rOxrNymD2dv3kF3yeh+d8uTo/jGYL77sJgE8Cnuzpbg93OwmIRLvpcLQ==",
       "engines": {
         "node": ">=12"
       },
@@ -45154,7 +45154,7 @@
         "react-blurhash": "^0.1.3",
         "react-calendar": "^3.7.0",
         "react-color": "^2.19.3",
-        "react-photo-album": "^1.7.0",
+        "react-photo-album": "^1.9.0",
         "react-transition-group": "^4.4.2",
         "react-virtual": "^2.10.4",
         "sat": "^0.9.0",
@@ -47706,7 +47706,7 @@
         "react-calendar": "^3.7.0",
         "react-color": "^2.19.3",
         "react-moveable": "^0.30.3",
-        "react-photo-album": "^1.7.0",
+        "react-photo-album": "^1.9.0",
         "react-transition-group": "^4.4.2",
         "react-virtual": "^2.10.4",
         "sat": "^0.9.0",
@@ -74423,9 +74423,9 @@
       }
     },
     "react-photo-album": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/react-photo-album/-/react-photo-album-1.7.0.tgz",
-      "integrity": "sha512-vWUFc6/QSGuEOv1QWcVBvCxsflsomFmB8JrldbTfDZMs92e4TOrYAqQT2X4QQRoDlx6xG3fnf9KGx6JfK9oz+w==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/react-photo-album/-/react-photo-album-1.9.0.tgz",
+      "integrity": "sha512-RR8vzyjssp8v3bAN+T4VlcsfLpgwX4rOxrNymD2dv3kF3yeh+d8uTo/jGYL77sJgE8Cnuzpbg93OwmIRLvpcLQ==",
       "requires": {}
     },
     "react-popper": {

--- a/packages/story-editor/package.json
+++ b/packages/story-editor/package.json
@@ -74,7 +74,7 @@
     "react-blurhash": "^0.1.3",
     "react-calendar": "^3.7.0",
     "react-color": "^2.19.3",
-    "react-photo-album": "^1.7.0",
+    "react-photo-album": "^1.9.0",
     "react-transition-group": "^4.4.2",
     "react-virtual": "^2.10.4",
     "sat": "^0.9.0",

--- a/packages/story-editor/src/components/library/panes/media/common/mediaGallery.js
+++ b/packages/story-editor/src/components/library/panes/media/common/mediaGallery.js
@@ -27,8 +27,9 @@ import Gallery from 'react-photo-album';
 import MediaElement from './mediaElement';
 import { GalleryContainer } from './styles';
 
-const PHOTO_MARGIN = 8;
+const PHOTO_SPACING = 8;
 const TARGET_ROW_HEIGHT = 110;
+const ROW_CONSTRAINTS = { maxPhotos: 2 };
 
 // eslint-disable-next-line react/prop-types -- disable react/prop-types eslint rule for the local component
 const ContainerRenderer = ({ children, containerRef }) => {
@@ -69,7 +70,7 @@ function MediaGallery({ resources, onInsert, providerType, canEditMedia }) {
         <MediaElement
           key={photo.key}
           index={photo.index}
-          margin={`0px 0px ${PHOTO_MARGIN}px 0px`}
+          margin={`0px 0px ${PHOTO_SPACING}px 0px`}
           resource={resources[photo.index]}
           width={layout.width}
           height={layout.height}
@@ -91,11 +92,8 @@ function MediaGallery({ resources, onInsert, providerType, canEditMedia }) {
         renderRowContainer={RowRenderer}
         renderContainer={ContainerRenderer}
         targetRowHeight={TARGET_ROW_HEIGHT}
-        rowConstraints={{
-          maxPhotos: 2,
-        }}
-        // This should match the actual margin the element is styled with.
-        spacing={PHOTO_MARGIN}
+        rowConstraints={ROW_CONSTRAINTS}
+        spacing={PHOTO_SPACING}
       />
     </div>
   );

--- a/packages/story-editor/src/components/library/panes/media/common/mediaGallery.js
+++ b/packages/story-editor/src/components/library/panes/media/common/mediaGallery.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { useCallback, forwardRef } from '@googleforcreators/react';
+import { useCallback } from '@googleforcreators/react';
 import PropTypes from 'prop-types';
 import Gallery from 'react-photo-album';
 
@@ -30,9 +30,11 @@ import { GalleryContainer } from './styles';
 const PHOTO_MARGIN = 8;
 const TARGET_ROW_HEIGHT = 110;
 
-const ContainerRenderer = forwardRef(({ children }, ref) => {
-  return <GalleryContainer ref={ref}>{children}</GalleryContainer>;
-});
+// eslint-disable-next-line react/prop-types -- disable react/prop-types eslint rule for the local component
+const ContainerRenderer = ({ children, containerRef }) => {
+  return <GalleryContainer ref={containerRef}>{children}</GalleryContainer>;
+};
+
 const RowRenderer = ({ children }) => {
   return children;
 };

--- a/packages/story-editor/src/components/library/panes/media/common/styles.js
+++ b/packages/story-editor/src/components/library/panes/media/common/styles.js
@@ -54,16 +54,11 @@ export const MediaGalleryContainer = styled.div`
   min-height: 100px;
 `;
 
-// 312px is the width of the gallery minus the 24px paddings.
-// We add a -4px l/r margin because the react-photo-album adds 4px margins
-// around images.
-// Width is thus 312-(-4)*2=320
 // TODO (pbakaus@): this needs a refactor for less magic numbers, but for now,
 // replacing 320px with the calc below produces the exact result in a dynamic,
 // scalable way.
 export const MediaGalleryInnerContainer = styled.div`
-  width: calc(100% + 19px);
-  margin: 0 -4px;
+  width: calc(100% + 11px);
 `;
 
 export const MediaGalleryLoadingPill = styled.div`


### PR DESCRIPTION
## Context

I'd like to offer some additional changes to the existing PR #10737

## Summary

 - bump `react-photo-album` from 1.7.0 to 1.9.0
 - remove `forwardRef` from the `ContainerRenderer` as it's no longer needed, and will be decommission in the next major release
 - remove negative margin from the media gallery container (it was implemented to counter `react-photo-gallery`'s margin around media elements, but is not needed for `react-photo-album`)

## Testing Instructions

All relevant testing can be performed under the PR #10737

## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

