### PR TITLE
Add tests for fonts used in templates / text sets

### DIFF
--- a/.github/workflows/tests-unit-js.yml
+++ b/.github/workflows/tests-unit-js.yml
@@ -10,6 +10,7 @@ on:
       - 'packages/templates/src/raw/**'
       - 'packages/text-sets/src/raw/**'
       - 'patches/**'
+      - 'packages/fonts/src/fonts.json'
     branches:
       - main
       - release/*
@@ -22,6 +23,7 @@ on:
       - 'packages/templates/src/raw/**'
       - 'packages/text-sets/src/raw/**'
       - 'patches/**'
+      - 'packages/fonts/src/fonts.json'
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:

--- a/packages/templates/src/test/raw.js
+++ b/packages/templates/src/test/raw.js
@@ -193,5 +193,26 @@ describe('raw template files', () => {
       expect(isValid(new Date(metaData.creationDate))).toBe(true);
       expect(isValid(new Date(templateData.creationDate))).toBe(true);
     });
+
+    // eslint-disable-next-line jest/no-disabled-tests -- TODO(#10829): Replace Andada
+    it.skip('should contain fonts from global fonts list', () => {
+      const fonts = JSON.parse(
+        readFileSync(
+          resolve(process.cwd(), 'packages/fonts/src/fonts.json'),
+          'utf8'
+        )
+      );
+      const fontNames = fonts.map(({ family }) => family);
+
+      for (const { elements } of templateData.pages) {
+        for (const element of elements) {
+          if (!['text'].includes(element?.type)) {
+            continue;
+          }
+
+          expect(fontNames).toContain(element.font.family);
+        }
+      }
+    });
   });
 });

--- a/packages/text-sets/src/test/raw.js
+++ b/packages/text-sets/src/test/raw.js
@@ -25,20 +25,40 @@ describe('Raw text set files', () => {
     resolve(process.cwd(), 'packages/text-sets/src/raw')
   );
 
-  it.each(textSets)(
-    '%s text set should contain at least two non-background elements',
-    (textSet) => {
-      const category = basename(textSet, '.json');
-      const rawData = readFileSync(
-        resolve(process.cwd(), `packages/text-sets/src/raw/${category}.json`),
-        'utf8'
-      );
-      const data = JSON.parse(rawData);
+  describe.each(textSets)('%s text set', (textSet) => {
+    const category = basename(textSet, '.json');
+    const rawData = readFileSync(
+      resolve(process.cwd(), `packages/text-sets/src/raw/${category}.json`),
+      'utf8'
+    );
+    const data = JSON.parse(rawData);
 
+    it('should contain at least two non-background elements', () => {
       for (const { elements } of data.pages) {
         // 3 since one is background element.
         expect(elements.length >= 3).toBeTrue();
       }
-    }
-  );
+    });
+
+    // eslint-disable-next-line jest/no-disabled-tests -- TODO(#10828): Replace Open Sans Condensed
+    it.skip('should contain fonts from global fonts list', () => {
+      const fonts = JSON.parse(
+        readFileSync(
+          resolve(process.cwd(), 'packages/fonts/src/fonts.json'),
+          'utf8'
+        )
+      );
+      const fontNames = fonts.map(({ family }) => family);
+
+      for (const { elements } of data.pages) {
+        for (const element of elements) {
+          if (!['text'].includes(element?.type)) {
+            continue;
+          }
+
+          expect(fontNames).toContain(element.font.family);
+        }
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

We want to get notified in the future if a template or text set uses a font that we no longer include in our fonts list.

## Summary

<!-- A brief description of what this PR does. -->

This adds some regression tests for #10828 and #10829.

They're currently disabled and can be enabled in the respective ticket

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

See #10828
See #10829
