### PR TITLE
Sidebar: New Layers Panel

### DIFF
--- a/packages/story-editor/src/components/canvas/karma/rightClickMenu.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/rightClickMenu.karma.js
@@ -36,6 +36,7 @@ describe('Right Click Menu integration', () => {
     fixture = new Fixture();
     await fixture.render();
     await fixture.collapseHelpCenter();
+    await fixture.events.click(fixture.editor.footer.layerPanel.togglePanel);
 
     insertElement = await fixture.renderHook(() => useInsertElement());
 
@@ -414,12 +415,9 @@ describe('Right Click Menu integration', () => {
     it('right clicking a layer in the layer panel should open the custom right click menu', async () => {
       await addEarthImage();
 
-      await fixture.events.click(
-        fixture.editor.inspector.designPanel.layerPanel.layers[0],
-        {
-          button: 'right',
-        }
-      );
+      await fixture.events.click(fixture.editor.footer.layerPanel.layers[0], {
+        button: 'right',
+      });
 
       expect(rightClickMenu()).not.toBeNull();
     });
@@ -504,12 +502,9 @@ describe('Right Click Menu integration', () => {
     it('should not display the option to select layer when opening from the layer panel', async () => {
       await addEarthImage();
 
-      await fixture.events.click(
-        fixture.editor.inspector.designPanel.layerPanel.layers[0],
-        {
-          button: 'right',
-        }
-      );
+      await fixture.events.click(fixture.editor.footer.layerPanel.layers[0], {
+        button: 'right',
+      });
 
       expect(() => selectLayerButton()).toThrow();
     });
@@ -763,18 +758,16 @@ describe('Right Click Menu integration', () => {
       );
 
       // verify multiple layers
-      expect(
-        fixture.editor.inspector.designPanel.layerPanel.layers.length
-      ).toBe(4);
-      expect(
-        fixture.editor.inspector.designPanel.layerPanel.layers[2].textContent
-      ).toContain('Earth');
-      expect(
-        fixture.editor.inspector.designPanel.layerPanel.layers[1].textContent
-      ).toContain('beach');
-      expect(
-        fixture.editor.inspector.designPanel.layerPanel.layers[0].textContent
-      ).toContain('Ranger');
+      expect(fixture.editor.footer.layerPanel.layers.length).toBe(4);
+      expect(fixture.editor.footer.layerPanel.layers[2].textContent).toContain(
+        'Earth'
+      );
+      expect(fixture.editor.footer.layerPanel.layers[1].textContent).toContain(
+        'beach'
+      );
+      expect(fixture.editor.footer.layerPanel.layers[0].textContent).toContain(
+        'Ranger'
+      );
 
       // More than one layer so some movement buttons will be enabled
       expect(sendBackward().disabled).toBeFalse();
@@ -786,15 +779,15 @@ describe('Right Click Menu integration', () => {
       await fixture.events.click(sendBackward());
 
       // verify new layer order
-      expect(
-        fixture.editor.inspector.designPanel.layerPanel.layers[2].textContent
-      ).toContain('Earth');
-      expect(
-        fixture.editor.inspector.designPanel.layerPanel.layers[1].textContent
-      ).toContain('Ranger');
-      expect(
-        fixture.editor.inspector.designPanel.layerPanel.layers[0].textContent
-      ).toContain('beach');
+      expect(fixture.editor.footer.layerPanel.layers[2].textContent).toContain(
+        'Earth'
+      );
+      expect(fixture.editor.footer.layerPanel.layers[1].textContent).toContain(
+        'Ranger'
+      );
+      expect(fixture.editor.footer.layerPanel.layers[0].textContent).toContain(
+        'beach'
+      );
 
       // right click image
       await rightClickOnTarget(
@@ -811,15 +804,15 @@ describe('Right Click Menu integration', () => {
       // Move image with 'Bring forward' button
       await fixture.events.click(bringForward());
 
-      expect(
-        fixture.editor.inspector.designPanel.layerPanel.layers[2].textContent
-      ).toContain('Earth');
-      expect(
-        fixture.editor.inspector.designPanel.layerPanel.layers[1].textContent
-      ).toContain('beach');
-      expect(
-        fixture.editor.inspector.designPanel.layerPanel.layers[0].textContent
-      ).toContain('Ranger');
+      expect(fixture.editor.footer.layerPanel.layers[2].textContent).toContain(
+        'Earth'
+      );
+      expect(fixture.editor.footer.layerPanel.layers[1].textContent).toContain(
+        'beach'
+      );
+      expect(fixture.editor.footer.layerPanel.layers[0].textContent).toContain(
+        'Ranger'
+      );
 
       // Move image all the way to back
       await rightClickOnTarget(
@@ -831,15 +824,15 @@ describe('Right Click Menu integration', () => {
       await rightClickOnTarget(
         fixture.editor.canvas.framesLayer.frame(rangerImage.id).node
       );
-      expect(
-        fixture.editor.inspector.designPanel.layerPanel.layers[2].textContent
-      ).toContain('Ranger');
-      expect(
-        fixture.editor.inspector.designPanel.layerPanel.layers[1].textContent
-      ).toContain('Earth');
-      expect(
-        fixture.editor.inspector.designPanel.layerPanel.layers[0].textContent
-      ).toContain('beach');
+      expect(fixture.editor.footer.layerPanel.layers[2].textContent).toContain(
+        'Ranger'
+      );
+      expect(fixture.editor.footer.layerPanel.layers[1].textContent).toContain(
+        'Earth'
+      );
+      expect(fixture.editor.footer.layerPanel.layers[0].textContent).toContain(
+        'beach'
+      );
 
       // verify 'back' buttons are disabled since ranger image is under everything
       // except the background
@@ -852,15 +845,15 @@ describe('Right Click Menu integration', () => {
       await fixture.events.click(bringToFront());
 
       // verify positioning
-      expect(
-        fixture.editor.inspector.designPanel.layerPanel.layers[2].textContent
-      ).toContain('Earth');
-      expect(
-        fixture.editor.inspector.designPanel.layerPanel.layers[1].textContent
-      ).toContain('beach');
-      expect(
-        fixture.editor.inspector.designPanel.layerPanel.layers[0].textContent
-      ).toContain('Ranger');
+      expect(fixture.editor.footer.layerPanel.layers[2].textContent).toContain(
+        'Earth'
+      );
+      expect(fixture.editor.footer.layerPanel.layers[1].textContent).toContain(
+        'beach'
+      );
+      expect(fixture.editor.footer.layerPanel.layers[0].textContent).toContain(
+        'Ranger'
+      );
 
       // verify 'forward' buttons are disabled since ranger image is under everything
       // except the background

--- a/packages/story-editor/src/components/canvas/pageAttachment/index.js
+++ b/packages/story-editor/src/components/canvas/pageAttachment/index.js
@@ -167,7 +167,7 @@ function PageAttachment({ pageAttachment = {} }) {
                 isRTL={isRTL}
                 anchor={{ current: pageAttachmentContainer }}
                 isOpen
-                placement={'left'}
+                placement="left"
                 spacing={spacing}
                 topOffset={topOffset}
               >

--- a/packages/story-editor/src/components/floatingMenu/elements/karma/border.karma.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/karma/border.karma.js
@@ -63,6 +63,9 @@ describe('Design Menu: Border width & color', () => {
       expect(fixture.editor.canvas.designMenu.borderWidth).not.toBeNull();
       expect(fixture.editor.canvas.designMenu.borderColor).toBeNull();
 
+      // Open style pane
+      await fixture.events.click(fixture.editor.inspector.designTab);
+
       const panel = fixture.editor.inspector.designPanel.border;
       await fixture.events.click(panel.width(), { clickCount: 3 });
       await fixture.events.keyboard.type('10');
@@ -73,6 +76,9 @@ describe('Design Menu: Border width & color', () => {
     });
 
     it('should render border width and color if widths are unlocked but equal', async () => {
+      // Open style pane
+      await fixture.events.click(fixture.editor.inspector.designTab);
+
       const panel = fixture.editor.inspector.designPanel.border;
       await fixture.events.click(panel.width(), { clickCount: 3 });
       await fixture.events.keyboard.type('10');
@@ -85,6 +91,9 @@ describe('Design Menu: Border width & color', () => {
     });
 
     it('should not render border width but still color if widths are uneven', async () => {
+      // Open style pane
+      await fixture.events.click(fixture.editor.inspector.designTab);
+
       const panel = fixture.editor.inspector.designPanel.border;
       await fixture.events.click(panel.width(), { clickCount: 3 });
       await fixture.events.keyboard.type('10');
@@ -144,6 +153,9 @@ describe('Design Menu: Border width & color', () => {
       expect(fixture.editor.canvas.designMenu.borderWidth).not.toBeNull();
       expect(fixture.editor.canvas.designMenu.borderColor).toBeNull();
 
+      // Open style pane
+      await fixture.events.click(fixture.editor.inspector.designTab);
+
       const panel = fixture.editor.inspector.designPanel.border;
       await fixture.events.click(panel.width(), { clickCount: 3 });
       await fixture.events.keyboard.type('10');
@@ -154,6 +166,9 @@ describe('Design Menu: Border width & color', () => {
     });
 
     it('should not allow opacity in color picker', async () => {
+      // Open style pane
+      await fixture.events.click(fixture.editor.inspector.designTab);
+
       const panel = fixture.editor.inspector.designPanel.border;
       await fixture.events.click(panel.width(), { clickCount: 3 });
       await fixture.events.keyboard.type('10');

--- a/packages/story-editor/src/components/floatingMenu/elements/karma/borderRadius.karma.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/karma/borderRadius.karma.js
@@ -74,6 +74,9 @@ describe('Design Menu: Border radius', () => {
 
     expect(fixture.editor.canvas.designMenu.borderRadius).not.toBeNull();
 
+    // Open style pane
+    await fixture.events.click(fixture.editor.inspector.designTab);
+
     const panel = fixture.editor.inspector.designPanel.sizePosition;
     await fixture.events.click(panel.lockBorderRadius);
 
@@ -87,6 +90,9 @@ describe('Design Menu: Border radius', () => {
     await fixture.events.click(
       fixture.editor.library.shapes.shape('Rectangle')
     );
+
+    // Open style pane
+    await fixture.events.click(fixture.editor.inspector.designTab);
 
     const panel = fixture.editor.inspector.designPanel.sizePosition;
     await fixture.events.click(panel.radius(), { clickCount: 3 });

--- a/packages/story-editor/src/components/floatingMenu/elements/karma/loop.karma.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/karma/loop.karma.js
@@ -58,6 +58,9 @@ describe('Design Menu: Video loop toggle', () => {
   });
 
   it('should render the checkbox as checked if the video is set to loop', async () => {
+    // Open style pane
+    await fixture.events.click(fixture.editor.inspector.designTab);
+
     // Toggle the loop property using the design panel
     await fixture.events.click(
       fixture.editor.inspector.designPanel.videoOptions.loop

--- a/packages/story-editor/src/components/floatingMenu/elements/karma/textAlign.karma.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/karma/textAlign.karma.js
@@ -32,6 +32,9 @@ describe('Design Menu: Text alignment', () => {
 
     await fixture.editor.library.textTab.click();
     await fixture.events.click(fixture.editor.library.text.preset('Paragraph'));
+
+    // Open style pane
+    await fixture.events.click(fixture.editor.inspector.designTab);
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/footer/footerLayout.js
+++ b/packages/story-editor/src/components/footer/footerLayout.js
@@ -28,6 +28,7 @@ import Carousel from './carousel';
 import PrimaryMenu from './primaryMenu';
 import SecondaryMenu from './secondaryMenu';
 import { MAX_MENU_WIDTH } from './constants';
+import DirectionAware from '../directionAware';
 
 const Wrapper = styled.section`
   position: relative;
@@ -52,17 +53,19 @@ const Area = styled.div`
 
 function FooterLayout({ footer }) {
   return (
-    <Wrapper aria-label={__('Workspace Footer', 'web-stories')}>
-      <Area area="carousel">
-        <Carousel />
-      </Area>
-      <Area area="primary">
-        <PrimaryMenu />
-      </Area>
-      <Area area="secondary">
-        <SecondaryMenu menu={footer?.secondaryMenu} />
-      </Area>
-    </Wrapper>
+    <DirectionAware>
+      <Wrapper aria-label={__('Workspace Footer', 'web-stories')}>
+        <Area area="carousel">
+          <Carousel />
+        </Area>
+        <Area area="primary">
+          <PrimaryMenu />
+        </Area>
+        <Area area="secondary">
+          <SecondaryMenu menu={footer?.secondaryMenu} />
+        </Area>
+      </Wrapper>
+    </DirectionAware>
   );
 }
 

--- a/packages/story-editor/src/components/footer/footerLayout.js
+++ b/packages/story-editor/src/components/footer/footerLayout.js
@@ -24,11 +24,11 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
+import DirectionAware from '../directionAware';
 import Carousel from './carousel';
 import PrimaryMenu from './primaryMenu';
 import SecondaryMenu from './secondaryMenu';
 import { MAX_MENU_WIDTH } from './constants';
-import DirectionAware from '../directionAware';
 
 const Wrapper = styled.section`
   position: relative;

--- a/packages/story-editor/src/components/footer/layers/index.js
+++ b/packages/story-editor/src/components/footer/layers/index.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default } from './layers';

--- a/packages/story-editor/src/components/footer/layers/layers.js
+++ b/packages/story-editor/src/components/footer/layers/layers.js
@@ -51,7 +51,7 @@ function Layers() {
     <>
       <Popup
         isOpen={isOpen}
-        anchor="right"
+        placement="right"
         ariaLabel={__('Layers Panel', 'web-stories')}
       >
         <StyledNavigationWrapper ref={ref} isOpen={isOpen}>

--- a/packages/story-editor/src/components/footer/layers/layers.js
+++ b/packages/story-editor/src/components/footer/layers/layers.js
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useState } from '@googleforcreators/react';
+import { __ } from '@googleforcreators/i18n';
+import {
+  Icons,
+  Text,
+  NotificationBubble,
+  THEME_CONSTANTS,
+  BUBBLE_VARIANTS,
+} from '@googleforcreators/design-system';
+
+/**
+ * Internal dependencies
+ */
+import styled, { css } from 'styled-components';
+import { LayerPanel } from '../../panels/design';
+import useLayers from '../../panels/design/layer/useLayers';
+import Popup from '../../secondaryPopup';
+
+const Container = styled.div`
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: 300px;
+  border-radius: ${({ theme }) => theme.borders.radius.small};
+  background-color: ${({ theme }) => theme.colors.bg.secondary};
+  overflow: auto;
+`;
+
+export const LabelText = styled(Text)`
+  color: ${({ theme }) => theme.colors.fg.primary};
+  padding-right: 8px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: hidden;
+`;
+
+const Button = styled.button`
+  border: 1px solid ${({ theme }) => theme.colors.border.defaultNormal};
+  background-color: ${({ theme }) => theme.colors.opacity.footprint};
+  border-radius: ${({ theme }) => theme.borders.radius.small};
+  padding: 5px 8px;
+  cursor: pointer;
+  display: flex;
+`;
+
+export const ChevronWrap = styled.div(
+  ({ theme, isOpen }) => css`
+    color: ${theme.colors.fg.primary};
+    width: 32px;
+    height: 32px;
+    margin: -4px;
+
+    ${isOpen &&
+    css`
+      transform: rotate(180deg);
+    `}
+  `
+);
+
+function Layers() {
+  const layers = useLayers();
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <Popup isOpen={isOpen} anchor="right" zIndex={9999}>
+        <Container>
+          <LayerPanel />
+        </Container>
+      </Popup>
+      <Button
+        aria-haspopup
+        ariaLabel={__('Layers', 'web-stories')}
+        onClick={() => setIsOpen((state) => !state)}
+      >
+        <LabelText size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}>
+          {__('Layers', 'web-stories')}
+        </LabelText>
+        <NotificationBubble
+          data-testid="panel-badge"
+          notificationCount={layers?.length}
+          variant={BUBBLE_VARIANTS.SECONDARY}
+          aria-hidden
+        />
+        <ChevronWrap isOpen={isOpen}>
+          <Icons.ChevronDownSmall />
+        </ChevronWrap>
+      </Button>
+    </>
+  );
+}
+
+export default Layers;

--- a/packages/story-editor/src/components/footer/layers/layers.js
+++ b/packages/story-editor/src/components/footer/layers/layers.js
@@ -33,7 +33,6 @@ const LAYERS_PANEL_WIDTH = 300;
 
 const StyledNavigationWrapper = styled(NavigationWrapper)`
   width: ${LAYERS_PANEL_WIDTH}px;
-  right: inherit;
   left: -${LAYERS_PANEL_WIDTH}px;
 `;
 
@@ -53,7 +52,6 @@ function Layers() {
       <Popup
         isOpen={isOpen}
         anchor="right"
-        zIndex={Z_INDEX_FOOTER}
         ariaLabel={__('Layers Panel', 'web-stories')}
       >
         <StyledNavigationWrapper ref={ref} isOpen={isOpen}>

--- a/packages/story-editor/src/components/footer/layers/layers.js
+++ b/packages/story-editor/src/components/footer/layers/layers.js
@@ -29,13 +29,6 @@ import useLayers from '../../panels/design/layer/useLayers';
 import Popup, { NavigationWrapper } from '../../secondaryPopup';
 import { ToggleButton } from '../../toggleButton';
 
-const LAYERS_PANEL_WIDTH = 300;
-
-const StyledNavigationWrapper = styled(NavigationWrapper)`
-  width: ${LAYERS_PANEL_WIDTH}px;
-  left: -${LAYERS_PANEL_WIDTH}px;
-`;
-
 const Container = styled.div`
   background-color: ${({ theme }) => theme.colors.bg.secondary};
   overflow: auto;
@@ -54,11 +47,11 @@ function Layers() {
         placement="right"
         ariaLabel={__('Layers Panel', 'web-stories')}
       >
-        <StyledNavigationWrapper ref={ref} isOpen={isOpen}>
+        <NavigationWrapper alignRight ref={ref} isOpen={isOpen}>
           <Container>
             <LayerPanel />
           </Container>
-        </StyledNavigationWrapper>
+        </NavigationWrapper>
       </Popup>
       <ToggleButton
         isOpen={isOpen}

--- a/packages/story-editor/src/components/footer/layers/layers.js
+++ b/packages/story-editor/src/components/footer/layers/layers.js
@@ -89,7 +89,7 @@ function Layers() {
       </Popup>
       <Button
         aria-haspopup
-        ariaLabel={__('Layers', 'web-stories')}
+        aria-label={__('Layers', 'web-stories')}
         onClick={() => setIsOpen((state) => !state)}
       >
         <LabelText size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}>

--- a/packages/story-editor/src/components/footer/layers/layers.js
+++ b/packages/story-editor/src/components/footer/layers/layers.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,94 +17,58 @@
 /**
  * External dependencies
  */
-import { useState } from '@googleforcreators/react';
+import styled from 'styled-components';
+import { useState, useRef } from '@googleforcreators/react';
 import { __ } from '@googleforcreators/i18n';
-import {
-  Icons,
-  Text,
-  NotificationBubble,
-  THEME_CONSTANTS,
-  BUBBLE_VARIANTS,
-} from '@googleforcreators/design-system';
-
 /**
  * Internal dependencies
  */
-import styled, { css } from 'styled-components';
+import { Z_INDEX_FOOTER } from '../../../constants/zIndex';
 import { LayerPanel } from '../../panels/design';
 import useLayers from '../../panels/design/layer/useLayers';
-import Popup from '../../secondaryPopup';
+import Popup, { NavigationWrapper } from '../../secondaryPopup';
+import { ToggleButton } from '../../toggleButton';
+
+const LAYERS_PANEL_WIDTH = 300;
+
+const StyledNavigationWrapper = styled(NavigationWrapper)`
+  width: ${LAYERS_PANEL_WIDTH}px;
+  right: inherit;
+  left: -${LAYERS_PANEL_WIDTH}px;
+`;
 
 const Container = styled.div`
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  width: 300px;
-  border-radius: ${({ theme }) => theme.borders.radius.small};
   background-color: ${({ theme }) => theme.colors.bg.secondary};
   overflow: auto;
+  z-index: ${Z_INDEX_FOOTER};
 `;
-
-export const LabelText = styled(Text)`
-  color: ${({ theme }) => theme.colors.fg.primary};
-  padding-right: 8px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: hidden;
-`;
-
-const Button = styled.button`
-  border: 1px solid ${({ theme }) => theme.colors.border.defaultNormal};
-  background-color: ${({ theme }) => theme.colors.opacity.footprint};
-  border-radius: ${({ theme }) => theme.borders.radius.small};
-  padding: 5px 8px;
-  cursor: pointer;
-  display: flex;
-`;
-
-export const ChevronWrap = styled.div(
-  ({ theme, isOpen }) => css`
-    color: ${theme.colors.fg.primary};
-    width: 32px;
-    height: 32px;
-    margin: -4px;
-
-    ${isOpen &&
-    css`
-      transform: rotate(180deg);
-    `}
-  `
-);
 
 function Layers() {
-  const layers = useLayers();
+  const layersLength = useLayers().length;
   const [isOpen, setIsOpen] = useState(false);
+  const ref = useRef();
 
   return (
     <>
-      <Popup isOpen={isOpen} anchor="right" zIndex={9999}>
-        <Container>
-          <LayerPanel />
-        </Container>
-      </Popup>
-      <Button
-        aria-haspopup
-        aria-label={__('Layers', 'web-stories')}
-        onClick={() => setIsOpen((state) => !state)}
+      <Popup
+        isOpen={isOpen}
+        anchor="right"
+        zIndex={Z_INDEX_FOOTER}
+        ariaLabel={__('Layers Panel', 'web-stories')}
       >
-        <LabelText size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}>
-          {__('Layers', 'web-stories')}
-        </LabelText>
-        <NotificationBubble
-          data-testid="panel-badge"
-          notificationCount={layers?.length}
-          variant={BUBBLE_VARIANTS.SECONDARY}
-          aria-hidden
-        />
-        <ChevronWrap isOpen={isOpen}>
-          <Icons.ChevronDownSmall />
-        </ChevronWrap>
-      </Button>
+        <StyledNavigationWrapper ref={ref} isOpen={isOpen}>
+          <Container>
+            <LayerPanel />
+          </Container>
+        </StyledNavigationWrapper>
+      </Popup>
+      <ToggleButton
+        isOpen={isOpen}
+        notificationCount={layersLength}
+        copy={__('Layers', 'web-stories')}
+        onClick={() => setIsOpen((state) => !state)}
+        hideTooltip
+      />
     </>
   );
 }

--- a/packages/story-editor/src/components/footer/primaryMenu.js
+++ b/packages/story-editor/src/components/footer/primaryMenu.js
@@ -25,6 +25,7 @@ import styled from 'styled-components';
 import { Z_INDEX_FOOTER } from '../../constants/zIndex';
 import ZoomSelector from './zoomSelector';
 import { GridViewButton } from './gridview';
+import Layers from './layers';
 import { FOOTER_MENU_GAP, FOOTER_MARGIN } from './constants';
 
 const Wrapper = styled.div`
@@ -52,6 +53,7 @@ function PrimaryMenu() {
       <MenuItems id="primary-menu-items">
         <ZoomSelector />
         <GridViewButton />
+        <Layers />
       </MenuItems>
     </Wrapper>
   );

--- a/packages/story-editor/src/components/inspector/design/designInspector.js
+++ b/packages/story-editor/src/components/inspector/design/designInspector.js
@@ -25,22 +25,12 @@ import { STORY_ANIMATION_STATE } from '@googleforcreators/animation';
  * Internal dependencies
  */
 import { useStory } from '../../../app';
-import { LayerPanel } from '../../panels/design';
 import DesignPanels from './designPanels';
 
 const Wrapper = styled.div`
   height: 100%;
-  flex-direction: column;
-  justify-content: space-between;
-  display: flex;
-`;
-
-const TopPanels = styled.div`
   overflow: auto;
-  flex: 1;
 `;
-
-const BottomPanels = styled.div``;
 
 function DesignInspector() {
   const updateAnimationState = useStory(
@@ -53,13 +43,8 @@ function DesignInspector() {
   );
 
   return (
-    <Wrapper>
-      <TopPanels onFocus={resetStoryAnimationState}>
-        <DesignPanels />
-      </TopPanels>
-      <BottomPanels>
-        <LayerPanel />
-      </BottomPanels>
+    <Wrapper onFocus={resetStoryAnimationState}>
+      <DesignPanels />
     </Wrapper>
   );
 }

--- a/packages/story-editor/src/components/library/panes/media/media3p/karma/mediaFetching.karma.js
+++ b/packages/story-editor/src/components/library/panes/media/media3p/karma/mediaFetching.karma.js
@@ -358,6 +358,12 @@ describe('Media3pPane fetching', () => {
     await waitForInitialMediaLoad();
     await fixture.events.click(fixture.editor.library.media3p.coverrTab);
 
+    const mediaGallery = fixture.editor.library.media3p.mediaGallery;
+    mediaGallery.scrollTo(
+      0,
+      mediaGallery.scrollHeight - mediaGallery.clientHeight - ROOT_MARGIN / 2
+    );
+
     // Wait for the debounce
     await expectMediaElements(
       fixture.editor.library.media3p.coverrSection,

--- a/packages/story-editor/src/components/library/panes/text/karma/textPane.karma.js
+++ b/packages/story-editor/src/components/library/panes/text/karma/textPane.karma.js
@@ -135,6 +135,9 @@ describe('CUJ: Creator can Add and Write Text: Consecutive text presets', () => 
     it('should overwrite most of the styles but not text color when applying a preset', async () => {
       // Add label.
       await fixture.events.click(fixture.editor.library.text.preset('LABEL'));
+
+      // Open style pane
+      await fixture.events.click(fixture.editor.inspector.designTab);
       await fixture.events.click(
         fixture.editor.inspector.designPanel.alignment.right
       );
@@ -161,6 +164,10 @@ describe('CUJ: Creator can Add and Write Text: Consecutive text presets', () => 
       expect(label.content).toBe(
         '<span style="font-style: italic; text-decoration: underline; color: #fff; letter-spacing: 0.5em">LABEL</span>'
       );
+
+      // Go to text tab in insert panel
+      await fixture.events.click(fixture.editor.inspector.insertTab);
+      await fixture.editor.library.textTab.click();
 
       // Apply Title 1.
       await fixture.events.click(

--- a/packages/story-editor/src/components/panels/design/layer/karma/layer.karma.js
+++ b/packages/story-editor/src/components/panels/design/layer/karma/layer.karma.js
@@ -47,9 +47,7 @@ describe('Layer Panel', () => {
 
   it('should show the number of layers', async () => {
     expect(layerPanel.layers.length).toBe(1);
-    expect(layerPanel.panelBadge.textContent).toBe(
-      layerPanel.layers.length.toString()
-    );
+    expect(layerPanel.togglePanel.textContent).toBe('Layers1');
 
     await fixture.act(() =>
       insertElement('text', {
@@ -63,9 +61,7 @@ describe('Layer Panel', () => {
     );
 
     expect(layerPanel.layers.length).toBe(2);
-    expect(layerPanel.panelBadge.textContent).toBe(
-      layerPanel.layers.length.toString()
-    );
+    expect(layerPanel.togglePanel.textContent).toBe('Layers2');
 
     await fixture.act(() =>
       insertElement('text', {
@@ -78,9 +74,7 @@ describe('Layer Panel', () => {
     );
 
     expect(layerPanel.layers.length).toBe(3);
-    expect(layerPanel.panelBadge.textContent).toBe(
-      layerPanel.layers.length.toString()
-    );
+    expect(layerPanel.togglePanel.textContent).toBe('Layers3');
   });
 
   it('should show ellipsis for overflowing text', async () => {

--- a/packages/story-editor/src/components/panels/design/layer/karma/layer.karma.js
+++ b/packages/story-editor/src/components/panels/design/layer/karma/layer.karma.js
@@ -34,6 +34,8 @@ describe('Layer Panel', () => {
     fixture = new Fixture();
     await fixture.render();
     await fixture.collapseHelpCenter();
+    layerPanel = fixture.editor.footer.layerPanel;
+    await fixture.events.click(layerPanel.togglePanel);
     await fixture.events.click(fixture.editor.inspector.designTab);
 
     insertElement = await fixture.renderHook(() => useInsertElement());
@@ -44,7 +46,6 @@ describe('Layer Panel', () => {
   });
 
   it('should show the number of layers', async () => {
-    layerPanel = fixture.editor.inspector.designPanel.layerPanel;
     expect(layerPanel.layers.length).toBe(1);
     expect(layerPanel.panelBadge.textContent).toBe(
       layerPanel.layers.length.toString()
@@ -83,7 +84,6 @@ describe('Layer Panel', () => {
   });
 
   it('should show ellipsis for overflowing text', async () => {
-    layerPanel = fixture.editor.inspector.designPanel.layerPanel;
     expect(layerPanel.layers.length).toBe(1);
     await fixture.act(() =>
       insertElement('text', {
@@ -101,61 +101,6 @@ describe('Layer Panel', () => {
     await fixture.snapshot();
   });
 
-  it('should allow changing the layer panel height via slider', async () => {
-    layerPanel = fixture.editor.inspector.designPanel.layerPanel;
-    expect(layerPanel.resizeHandle).toBeTruthy();
-    const section = layerPanel.resizeHandle.closest('section');
-    const initialHeight = section.clientHeight;
-    await fixture.events.mouse.seq(({ moveRel, moveBy, down, up }) => [
-      moveRel(layerPanel.resizeHandle, 3, 3),
-      down(),
-      moveBy(0, 20, { steps: 6 }),
-      up(),
-    ]);
-    expect(section.clientHeight).toBe(initialHeight - 20);
-  });
-
-  it('should not change the layer panel height when changing page', async () => {
-    // resize the panel
-    layerPanel = fixture.editor.inspector.designPanel.layerPanel;
-    let section = layerPanel.resizeHandle.closest('section');
-    const initialHeight = section.clientHeight;
-    await fixture.events.mouse.seq(({ moveRel, moveBy, down, up }) => [
-      moveRel(layerPanel.resizeHandle, 3, 3),
-      down(),
-      moveBy(0, 30, { steps: 6 }),
-      up(),
-    ]);
-    expect(section.clientHeight).toBe(initialHeight - 30);
-
-    // change page
-    await fixture.events.click(fixture.editor.canvas.pageActions.addPage);
-
-    // verify panel height did not change
-    section = layerPanel.resizeHandle.closest('section');
-    expect(section.clientHeight).toBe(initialHeight - 30);
-  });
-
-  it('should not open the layer panel if the panel is collapsed when changing page', async () => {
-    // close the panel
-    layerPanel = fixture.editor.inspector.designPanel.layerPanel;
-    expect(layerPanel.panelCollapseButton.getAttribute('aria-expanded')).toBe(
-      'true'
-    );
-    await fixture.events.click(layerPanel.panelCollapseButton);
-    expect(layerPanel.panelCollapseButton.getAttribute('aria-expanded')).toBe(
-      'false'
-    );
-
-    // change page
-    await fixture.events.click(fixture.editor.canvas.pageActions.addPage);
-
-    // verify panel remains closed
-    expect(layerPanel.panelCollapseButton.getAttribute('aria-expanded')).toBe(
-      'false'
-    );
-  });
-
   it('should be able to delete elements with delete action', async () => {
     await fixture.events.click(fixture.editor.inspector.insertTab);
     await fixture.editor.library.textTab.click();
@@ -166,7 +111,6 @@ describe('Layer Panel', () => {
     await fixture.events.click(fixture.editor.library.text.preset('Title 2'));
 
     await fixture.events.click(fixture.editor.inspector.designTab);
-    layerPanel = fixture.editor.inspector.designPanel.layerPanel;
     expect(layerPanel.layers.length).toBe(3);
     const elementALayer = layerPanel.getLayerByInnerText('Title 1');
     await fixture.events.hover(elementALayer);
@@ -189,7 +133,6 @@ describe('Layer Panel', () => {
     await fixture.events.click(fixture.editor.library.text.preset('Title 2'));
 
     await fixture.events.click(fixture.editor.inspector.designTab);
-    layerPanel = fixture.editor.inspector.designPanel.layerPanel;
     expect(layerPanel.layers.length).toBe(3);
     const elementALayer = layerPanel.getLayerByInnerText('Title 1');
     await fixture.events.hover(elementALayer);

--- a/packages/story-editor/src/components/panels/design/layer/layer.js
+++ b/packages/story-editor/src/components/panels/design/layer/layer.js
@@ -51,10 +51,9 @@ const ActionsContainer = styled.div`
   padding-right: 6px;
   column-gap: 6px;
 
-  --background-color: ${({ theme }) =>
-    theme.colors.interactiveBg.secondaryNormal};
+  --background-color: ${({ theme }) => theme.colors.bg.secondary};
   --background-color-opaque: ${({ theme }) =>
-    rgba(theme.colors.interactiveBg.secondaryNormal, 0)};
+    rgba(theme.colors.bg.secondary, 0)};
   background-color: var(--background-color);
 
   ::before {

--- a/packages/story-editor/src/components/panels/design/layer/layer.js
+++ b/packages/story-editor/src/components/panels/design/layer/layer.js
@@ -112,11 +112,11 @@ const LayerButton = styled(Button).attrs({
   ${({ isSelected, theme }) =>
     isSelected &&
     css`
-      background: ${theme.colors.interactiveBg.secondaryPress};
+      background: ${theme.colors.interactiveBg.tertiaryPress};
       + * {
-        --background-color: ${theme.colors.interactiveBg.secondaryPress};
+        --background-color: ${theme.colors.interactiveBg.tertiaryPress};
         --background-color-opaque: ${rgba(
-          theme.colors.interactiveBg.secondaryPress,
+          theme.colors.interactiveBg.tertiaryPress,
           0
         )};
         --selected-hover-color: ${theme.colors.interactiveBg.tertiaryHover};
@@ -124,23 +124,23 @@ const LayerButton = styled(Button).attrs({
     `}
 
   :hover {
-    background: ${({ theme }) => theme.colors.interactiveBg.secondaryHover};
+    background: ${({ theme }) => theme.colors.interactiveBg.tertiaryHover};
   }
   :hover + * {
     --background-color: ${({ theme }) =>
-      theme.colors.interactiveBg.secondaryHover};
+      theme.colors.interactiveBg.tertiaryHover};
     --background-color-opaque: ${({ theme }) =>
-      rgba(theme.colors.interactiveBg.secondaryHover, 0)};
+      rgba(theme.colors.interactiveBg.tertiaryHover, 0)};
   }
 
   :active {
-    background: ${({ theme }) => theme.colors.interactiveBg.secondaryPress};
+    background: ${({ theme }) => theme.colors.interactiveBg.tertiaryPress};
   }
   :active + * {
     --background-color: ${({ theme }) =>
-      theme.colors.interactiveBg.secondaryPress};
+      theme.colors.interactiveBg.tertiaryPress};
     --background-color-opaque: ${({ theme }) =>
-      rgba(theme.colors.interactiveBg.secondaryPress, 0)};
+      rgba(theme.colors.interactiveBg.tertiaryPress, 0)};
   }
 `;
 

--- a/packages/story-editor/src/components/panels/design/layer/layerList.js
+++ b/packages/story-editor/src/components/panels/design/layer/layerList.js
@@ -45,6 +45,7 @@ const LayerList = styled(Reorderable).attrs({
   align-items: stretch;
   user-select: ${({ hasUserSelect }) => (hasUserSelect ? 'none' : 'initial')};
   overflow-y: auto;
+  padding-bottom: 4px; // for when panel has scroll
 `;
 
 const LayerSeparator = styled(ReorderableSeparator)`

--- a/packages/story-editor/src/components/panels/design/layer/layerPanel.js
+++ b/packages/story-editor/src/components/panels/design/layer/layerPanel.js
@@ -28,9 +28,6 @@ import useInspector from '../../../inspector/useInspector';
 import LayerList from './layerList';
 import useLayers from './useLayers';
 
-const HEAD_AREA_HEIGHT = 64;
-const LAYERS_HEIGHT_PADDING = 12;
-
 const Container = styled.div`
   filter: drop-shadow(0px -4px 8px rgba(0, 0, 0, 0.2));
   max-height: ${({ maxHeight }) => maxHeight}px;
@@ -44,11 +41,8 @@ function LayerPanel() {
     ({ state }) => state.inspectorContentHeight
   );
 
-  const maxHeight =
-    inspectorContentHeight - HEAD_AREA_HEIGHT - LAYERS_HEIGHT_PADDING;
-
   return (
-    <Container maxHeight={maxHeight}>
+    <Container maxHeight={inspectorContentHeight}>
       <PanelContent padding={'0'}>
         <LayerList layers={layers} />
       </PanelContent>

--- a/packages/story-editor/src/components/panels/design/layer/layerPanel.js
+++ b/packages/story-editor/src/components/panels/design/layer/layerPanel.js
@@ -34,6 +34,7 @@ const LAYERS_HEIGHT_PADDING = 12;
 const Container = styled.div`
   filter: drop-shadow(0px -4px 8px rgba(0, 0, 0, 0.2));
   max-height: ${({ maxHeight }) => maxHeight}px;
+  background-color: ${({ theme }) => theme.colors.bg.secondary};
 `;
 
 function LayerPanel() {
@@ -48,7 +49,7 @@ function LayerPanel() {
 
   return (
     <Container maxHeight={maxHeight}>
-      <PanelContent isSecondary padding={'0'}>
+      <PanelContent padding={'0'}>
         <LayerList layers={layers} />
       </PanelContent>
     </Container>

--- a/packages/story-editor/src/components/panels/design/layer/layerPanel.js
+++ b/packages/story-editor/src/components/panels/design/layer/layerPanel.js
@@ -17,37 +17,23 @@
 /**
  * External dependencies
  */
-import { __ } from '@googleforcreators/i18n';
-import { useMemo, memo } from '@googleforcreators/react';
+import { memo } from '@googleforcreators/react';
 import styled from 'styled-components';
 
 /**
  * Internal dependencies
  */
-import { Panel, PanelTitle, PanelContent } from '../../panel';
+import { PanelContent } from '../../panel';
 import useInspector from '../../../inspector/useInspector';
-import { TAB_HEIGHT, TAB_VERTICAL_MARGIN } from '../../../tabview';
 import LayerList from './layerList';
 import useLayers from './useLayers';
 
+const HEAD_AREA_HEIGHT = 64;
+const LAYERS_HEIGHT_PADDING = 12;
+
 const Container = styled.div`
-  margin: 0 4px;
   filter: drop-shadow(0px -4px 8px rgba(0, 0, 0, 0.2));
-`;
-
-const StyledPanelTitle = styled(PanelTitle)`
-  height: 48px;
-  border-top-left-radius: ${({ theme }) => theme.borders.radius.small};
-  border-top-right-radius: ${({ theme }) => theme.borders.radius.small};
-`;
-
-const DividerContainer = styled.div`
-  background: ${({ theme }) => theme.colors.bg.tertiary};
-`;
-
-const Divider = styled.div`
-  border-bottom: 1px solid ${({ theme }) => theme.colors.divider.tertiary};
-  margin: 0 16.5px;
+  max-height: ${({ maxHeight }) => maxHeight}px;
 `;
 
 function LayerPanel() {
@@ -57,42 +43,14 @@ function LayerPanel() {
     ({ state }) => state.inspectorContentHeight
   );
 
-  // We want the max height to fill the space underneath the document/design tab bar.
-  // Since the document/design tab bar has top and bottom margin in addition to a static
-  // height subtract sum from the full height of the inspector.
-  const tabHeight = 2 * TAB_VERTICAL_MARGIN + TAB_HEIGHT;
-  const maxHeight = inspectorContentHeight - tabHeight + 2;
-
-  const initialHeight = useMemo(() => Math.round(window.innerHeight / 4), []);
+  const maxHeight =
+    inspectorContentHeight - HEAD_AREA_HEIGHT - LAYERS_HEIGHT_PADDING;
 
   return (
-    <Container>
-      <Panel
-        name="layer-panel"
-        initialHeight={initialHeight}
-        resizable
-        showDragHandle
-        showFocusStyles={false}
-        ariaHidden
-        collapsedByDefault={false}
-      >
-        <StyledPanelTitle
-          isSecondary
-          isResizable
-          count={layers?.length}
-          maxHeight={maxHeight}
-        >
-          {__('Layers', 'web-stories')}
-        </StyledPanelTitle>
-
-        <DividerContainer>
-          <Divider />
-        </DividerContainer>
-
-        <PanelContent isSecondary padding={'0'}>
-          <LayerList layers={layers} />
-        </PanelContent>
-      </Panel>
+    <Container maxHeight={maxHeight}>
+      <PanelContent isSecondary padding={'0'}>
+        <LayerList layers={layers} />
+      </PanelContent>
     </Container>
   );
 }

--- a/packages/story-editor/src/components/panels/design/textStyle/karma/stylePresets.karma.js
+++ b/packages/story-editor/src/components/panels/design/textStyle/karma/stylePresets.karma.js
@@ -71,7 +71,6 @@ describe('Panel: Style Presets', () => {
 
       // Verify that no styles are added currently.
       await fixture.events.click(fixture.editor.inspector.designTab);
-      const noStylesText = fixture.screen.getByText('No Styles Saved');
       expect(noStylesText).toBeDefined();
       // Click to add a style and verify it was added.
       panel = fixture.editor.inspector.designPanel.textStyle;

--- a/packages/story-editor/src/components/secondaryPopup/index.js
+++ b/packages/story-editor/src/components/secondaryPopup/index.js
@@ -31,9 +31,9 @@ const enterStyles = css`
   opacity: 1;
   transform: none;
 `;
-const exitStyles = (anchor) => css`
+const exitStyles = (placement) => css`
   opacity: 0;
-  transform: translateX(${anchor === 'left' ? -20 : 20}px);
+  transform: translateX(${placement === 'left' ? -20 : 20}px);
 `;
 
 const transitionStyles = {

--- a/packages/story-editor/src/components/secondaryPopup/index.js
+++ b/packages/story-editor/src/components/secondaryPopup/index.js
@@ -46,17 +46,12 @@ const transitionStyles = {
 const Controller = styled.div`
   position: absolute;
   top: -12px;
-  ${({ zIndex }) => (zIndex ? `z-index: ${zIndex};` : '')}
   ${({ anchor }) => anchor}: 0px;
   opacity: 0;
-  transform: translateX(${({ anchor }) => (anchor === 'left' ? -20 : 20)}px);
+  transform: translateX(-20px);
   transition: opacity ${DURATION}ms ${BEZIER.default},
     transform ${DURATION}ms ${BEZIER.default};
-
-  ${({ state, anchor }) => {
-    const fn = transitionStyles[state];
-    return typeof fn === 'function' ? fn(anchor) : transitionStyles[state];
-  }}
+  ${({ state }) => transitionStyles[state]}
 `;
 
 function Popup({
@@ -65,7 +60,6 @@ function Popup({
   children,
   ariaLabel,
   shouldKeepMounted,
-  zIndex,
   anchor = 'left',
   onEnter = noop,
   onExited = noop,
@@ -86,7 +80,6 @@ function Popup({
           aria-label={ariaLabel}
           state={state}
           anchor={anchor}
-          zIndex={zIndex}
         >
           {children}
         </Controller>
@@ -99,7 +92,6 @@ Popup.propTypes = {
   children: PropTypes.node.isRequired,
   popupId: PropTypes.string,
   ariaLabel: PropTypes.string,
-  zIndex: PropTypes.number,
   anchor: PropTypes.string,
   shouldKeepMounted: PropTypes.bool,
   onEnter: PropTypes.func,

--- a/packages/story-editor/src/components/secondaryPopup/index.js
+++ b/packages/story-editor/src/components/secondaryPopup/index.js
@@ -31,9 +31,9 @@ const enterStyles = css`
   opacity: 1;
   transform: none;
 `;
-const exitStyles = css`
+const exitStyles = (anchor) => css`
   opacity: 0;
-  transform: translateX(-20px);
+  transform: translateX(${anchor === 'left' ? -20 : 20}px);
 `;
 
 const transitionStyles = {
@@ -46,13 +46,17 @@ const transitionStyles = {
 const Controller = styled.div`
   position: absolute;
   top: -12px;
-  left: 0px;
+  ${({ zIndex }) => (zIndex ? `z-index: ${zIndex};` : '')}
+  ${({ anchor }) => anchor}: 0px;
   opacity: 0;
-  transform: translateX(-20px);
+  transform: translateX(${({ anchor }) => (anchor === 'left' ? -20 : 20)}px);
   transition: opacity ${DURATION}ms ${BEZIER.default},
     transform ${DURATION}ms ${BEZIER.default};
 
-  ${({ state }) => transitionStyles[state]}
+  ${({ state, anchor }) => {
+    const fn = transitionStyles[state];
+    return typeof fn === 'function' ? fn(anchor) : transitionStyles[state];
+  }}
 `;
 
 function Popup({
@@ -61,6 +65,8 @@ function Popup({
   children,
   ariaLabel,
   shouldKeepMounted,
+  zIndex,
+  anchor = 'left',
   onEnter = noop,
   onExited = noop,
 }) {
@@ -79,6 +85,8 @@ function Popup({
           role="dialog"
           aria-label={ariaLabel}
           state={state}
+          anchor={anchor}
+          zIndex={zIndex}
         >
           {children}
         </Controller>
@@ -91,6 +99,8 @@ Popup.propTypes = {
   children: PropTypes.node.isRequired,
   popupId: PropTypes.string,
   ariaLabel: PropTypes.string,
+  zIndex: PropTypes.number,
+  anchor: PropTypes.string,
   shouldKeepMounted: PropTypes.bool,
   onEnter: PropTypes.func,
   onExited: PropTypes.func,

--- a/packages/story-editor/src/components/secondaryPopup/index.js
+++ b/packages/story-editor/src/components/secondaryPopup/index.js
@@ -46,7 +46,7 @@ const transitionStyles = {
 const Controller = styled.div`
   position: absolute;
   top: -12px;
-  ${({ anchor }) => anchor}: 0px;
+  ${({ placement }) => placement}: 0px;
   opacity: 0;
   transform: translateX(-20px);
   transition: opacity ${DURATION}ms ${BEZIER.default},
@@ -60,7 +60,7 @@ function Popup({
   children,
   ariaLabel,
   shouldKeepMounted,
-  anchor = 'left',
+  placement = 'left',
   onEnter = noop,
   onExited = noop,
 }) {
@@ -79,7 +79,7 @@ function Popup({
           role="dialog"
           aria-label={ariaLabel}
           state={state}
-          anchor={anchor}
+          placement={placement}
         >
           {children}
         </Controller>
@@ -92,7 +92,7 @@ Popup.propTypes = {
   children: PropTypes.node.isRequired,
   popupId: PropTypes.string,
   ariaLabel: PropTypes.string,
-  anchor: PropTypes.string,
+  placement: PropTypes.oneOf(['left', 'right', 'bottom', 'top']),
   shouldKeepMounted: PropTypes.bool,
   onEnter: PropTypes.func,
   onExited: PropTypes.func,

--- a/packages/story-editor/src/components/secondaryPopup/navigationWrapper.js
+++ b/packages/story-editor/src/components/secondaryPopup/navigationWrapper.js
@@ -16,6 +16,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 
 /**
@@ -29,7 +30,7 @@ import {
 
 const NavigationWrapper = styled.div`
   position: absolute;
-  left: 0;
+  ${({ alignRight = false }) => (alignRight ? 'right: 0' : 'left: 0')};
   bottom: 0;
   max-height: calc(100vh - ${DISTANCE_FROM_TOP + DISTANCE_FROM_BOTTOM}px);
   width: ${NAVIGATION_WIDTH + 2}px; /* account for border width */
@@ -49,5 +50,9 @@ const NavigationWrapper = styled.div`
       }
     `}
 `;
+NavigationWrapper.propTypes = {
+  alignRight: PropTypes.bool,
+  isOpen: PropTypes.bool,
+};
 
 export default NavigationWrapper;

--- a/packages/story-editor/src/components/tablist/stories/index.js
+++ b/packages/story-editor/src/components/tablist/stories/index.js
@@ -221,7 +221,7 @@ export const _default = () => {
           />
         </TablistPanel>
         <TablistPanel
-          title={'Design'}
+          title={'Style'}
           isExpanded={openPanel === 'design'}
           onClick={handleClick('design')}
           badgeCount={1}

--- a/packages/story-editor/src/components/toggleButton/index.js
+++ b/packages/story-editor/src/components/toggleButton/index.js
@@ -111,7 +111,7 @@ export const ToggleButton = forwardRef(
         >
           <Wrapper>
             {MainIcon && <MainIcon />}
-            {copy && copy}
+            {copy}
             {hasNotifications && (
               <NotificationCount>{notificationCount}</NotificationCount>
             )}

--- a/packages/story-editor/src/components/toggleButton/index.js
+++ b/packages/story-editor/src/components/toggleButton/index.js
@@ -26,6 +26,8 @@ import {
   Text,
   TOOLTIP_PLACEMENT,
   Tooltip,
+  themeHelpers,
+  THEME_CONSTANTS,
 } from '@googleforcreators/design-system';
 import { forwardRef } from '@googleforcreators/react';
 
@@ -42,11 +44,20 @@ const Button = styled(dsButton)`
       border-color: ${theme.colors.bg.secondary};
       background-color: ${theme.colors.bg.secondary};
     `}
-  ${({ hasText }) =>
+  ${({ hasText, theme }) =>
     hasText &&
     css`
       padding: 2px 0 2px 8px;
       width: auto;
+      ${themeHelpers.expandPresetStyles({
+        preset: {
+          ...theme.typography.presets.paragraph[
+            THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL
+          ],
+        },
+        theme,
+      })};
+
       span {
         padding-left: 6px;
       }

--- a/packages/story-editor/src/components/toggleButton/index.js
+++ b/packages/story-editor/src/components/toggleButton/index.js
@@ -42,7 +42,20 @@ const Button = styled(dsButton)`
       border-color: ${theme.colors.bg.secondary};
       background-color: ${theme.colors.bg.secondary};
     `}
+  ${({ hasText }) =>
+    hasText &&
+    css`
+      padding: 2px 0 2px 8px;
+      width: auto;
+      span {
+        padding-left: 6px;
+      }
+    `}
 `;
+Button.propTypes = {
+  hasText: PropTypes.bool,
+  isOpen: PropTypes.bool,
+};
 
 const Wrapper = styled.div`
   width: 100%;
@@ -62,6 +75,8 @@ const NotificationCount = styled(Text).attrs({ as: 'span' })`
 export const ToggleButton = forwardRef(
   (
     {
+      copy,
+      hideTooltip,
       isOpen = false,
       notificationCount = 0,
       MainIcon,
@@ -76,7 +91,7 @@ export const ToggleButton = forwardRef(
     return (
       <Tooltip
         hasTail
-        title={label}
+        title={!hideTooltip && label}
         placement={TOOLTIP_PLACEMENT.TOP}
         shortcut={shortcut}
         popupZIndexOverride={popupZIndexOverride}
@@ -86,6 +101,7 @@ export const ToggleButton = forwardRef(
           aria-haspopup
           aria-pressed={isOpen}
           aria-expanded={isOpen}
+          hasText={Boolean(copy)}
           isOpen={isOpen}
           isSquare={!hasNotifications}
           type={BUTTON_TYPES.TERTIARY}
@@ -94,7 +110,8 @@ export const ToggleButton = forwardRef(
           {...rest}
         >
           <Wrapper>
-            <MainIcon />
+            {MainIcon && <MainIcon />}
+            {copy && copy}
             {hasNotifications && (
               <NotificationCount>{notificationCount}</NotificationCount>
             )}
@@ -108,9 +125,11 @@ export const ToggleButton = forwardRef(
 ToggleButton.displayName = 'ToggleButton';
 
 ToggleButton.propTypes = {
+  copy: PropTypes.string,
+  hideTooltip: PropTypes.bool,
   isOpen: PropTypes.bool,
-  label: PropTypes.string.isRequired,
-  MainIcon: PropTypes.object.isRequired,
+  label: PropTypes.string,
+  MainIcon: PropTypes.object,
   notificationCount: PropTypes.number,
   shortcut: PropTypes.string,
   popupZIndexOverride: PropTypes.number,

--- a/packages/story-editor/src/karma/fixture/containers/designPanel/index.js
+++ b/packages/story-editor/src/karma/fixture/containers/designPanel/index.js
@@ -15,11 +15,6 @@
  */
 
 /**
- * External dependencies
- */
-import { getByLabelText } from '@testing-library/react';
-
-/**
  * Internal dependencies
  */
 import { Container } from '../container';
@@ -28,7 +23,6 @@ import { Animation } from './animationPanel';
 import { Filter } from './filter';
 import { Border } from './border';
 import { ColorPreset } from './colorPreset';
-import { Layers } from './layers';
 import { Link } from './link';
 import { PageBackground } from './pageBackground';
 import { SizePosition } from './sizePosition';
@@ -149,16 +143,6 @@ export class DesignPanel extends Container {
       this.getByRole('region', { name: /^Page Background$/i }),
       'pageBackground',
       PageBackground
-    );
-  }
-
-  get layerPanel() {
-    // The whole panel is aria-hidden now for accessibility reasons
-    // thus it cannot be accessed by role:
-    return this._get(
-      getByLabelText(this._node, 'Layers'),
-      'layerPanel',
-      Layers
     );
   }
 }

--- a/packages/story-editor/src/karma/fixture/containers/designPanel/layers.js
+++ b/packages/story-editor/src/karma/fixture/containers/designPanel/layers.js
@@ -32,8 +32,8 @@ export class Layers extends AbstractPanel {
     super(node, path);
   }
 
-  get panelCollapseButton() {
-    return this.getByRole('button', { name: /^Layers$/, hidden: true });
+  get togglePanel() {
+    return this._node;
   }
 
   get panelBadge() {
@@ -46,10 +46,6 @@ export class Layers extends AbstractPanel {
 
   get layers() {
     return getAllByTestId(this.layersList, 'layer-option');
-  }
-
-  get resizeHandle() {
-    return getByLabelText(this.node, /Set panel height/i);
   }
 
   getLayerByInnerText(text) {

--- a/packages/story-editor/src/karma/fixture/containers/designPanel/layers.js
+++ b/packages/story-editor/src/karma/fixture/containers/designPanel/layers.js
@@ -36,10 +36,6 @@ export class Layers extends AbstractPanel {
     return this._node;
   }
 
-  get panelBadge() {
-    return this.getByTestId('panel-badge');
-  }
-
   get layersList() {
     return getByLabelText(this.node.ownerDocument, /layers list/i);
   }

--- a/packages/story-editor/src/karma/fixture/containers/footer.js
+++ b/packages/story-editor/src/karma/fixture/containers/footer.js
@@ -63,6 +63,8 @@ export class Footer extends Container {
   }
 
   get layerPanel() {
+    // The whole panel is aria-hidden for accessibility reasons
+    // thus it cannot be accessed by role:
     return this._get(
       this.getByRole('button', { name: /^Layers/ }),
       'layerPanel',

--- a/packages/story-editor/src/karma/fixture/containers/footer.js
+++ b/packages/story-editor/src/karma/fixture/containers/footer.js
@@ -64,7 +64,7 @@ export class Footer extends Container {
 
   get layerPanel() {
     return this._get(
-      this.getByRole('button', { name: 'Layers' }),
+      this.getByRole('button', { name: /^Layers/ }),
       'layerPanel',
       Layers
     );

--- a/packages/story-editor/src/karma/fixture/containers/footer.js
+++ b/packages/story-editor/src/karma/fixture/containers/footer.js
@@ -20,6 +20,7 @@
 import { Container } from './container';
 import { Select } from './common';
 import { Carousel } from './carousel';
+import { Layers } from './designPanel/layers';
 
 /**
  * The workspace footer.
@@ -58,6 +59,14 @@ export class Footer extends Container {
       this.getByRole('button', { name: 'Zoom Level' }),
       'zoomSelector',
       Select
+    );
+  }
+
+  get layerPanel() {
+    return this._get(
+      this.getByRole('button', { name: 'Layers' }),
+      'layerPanel',
+      Layers
     );
   }
 }


### PR DESCRIPTION
## Context

Part of editor redesign. 

## Summary

Lifts the layers panel from the inspector pane (which was combined with the design pane to create the new sidebar) and puts it opposite the sidebar as part of the editor's footer. 

## Relevant Technical Choices

Added a few more props to the shared `ToggleButton` that's used for the many popups of the footer to add a variant with copy visible/no icon and prevent tooltip from showing. 

Added `<DirectionAware>` to the footer so that the padding there is consistent and the layers panel wouldn't require additional work to be readable in RTL. I think it looks better now. 

## To-do

- [x] Fix tests
- [x] Adjust colors
- [x] Check a11y

Opted against moving all of the layers panel files into their own directory (following the suit of the helpcenter, keyboard nav and checklist) because it makes it harder to grok the updates.

Talked to @agingoldseco about the new toggle design, we're going to do that [later as a nonblocking issue.](https://github.com/GoogleForCreators/web-stories-wp/issues/10891)

The layer panel accessibility is not an issue here, it would be introducing new use patterns should we expose it to the keyboard at this point which would bloat the scope significantly. It was discussed at length 5 months ago in the design slack channel. There are keyboard shortcuts for everything that the layers panel can do. If we decide that now the layers panel should be keyboard accessible that would be its own scope of work and own item on the roadmap. 

## User-facing changes

| LTR | RTL | 
| --- | --- | 
| <img width="1008" alt="Screen Shot 2022-03-11 at 11 23 36 AM" src="https://user-images.githubusercontent.com/10720454/157930585-c3a73edf-5fe5-480d-9709-ce443c3d7bb2.png"> | <img width="1001" alt="Screen Shot 2022-03-11 at 11 24 13 AM" src="https://user-images.githubusercontent.com/10720454/157930620-d0a88572-139d-448e-ac20-65c25546ce85.png"> |

With Meta boxes 
| LTR | RTL | 
| --- | --- | 
| <img width="294" alt="Screen Shot 2022-03-11 at 1 38 26 PM" src="https://user-images.githubusercontent.com/10720454/157959130-c97b40eb-0c4f-4cf5-9028-9aaa8d58b140.png"> | <img width="274" alt="Screen Shot 2022-03-11 at 1 38 37 PM" src="https://user-images.githubusercontent.com/10720454/157959144-e1d25ef6-2180-42d3-9a68-0c86414846c3.png"> |

## Testing Instructions

Use the layers panel, now on the opposite side as the sidebar. 
You should be able to expand and collapse it with cursor and keyboard.
Confirm layer selection and behavior.
Check LTR and RTL. 
Install and activate 'yoast seo' to see meta box show up. 

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10804 