### PR TITLE
Editor: Fixed layer order of design menu relative to edit layer

### DIFF
--- a/packages/story-editor/src/components/floatingMenu/menu.js
+++ b/packages/story-editor/src/components/floatingMenu/menu.js
@@ -32,7 +32,7 @@ import MenuSelector from './menus';
 const MenuWrapper = styled.section`
   display: flex;
   position: absolute;
-  z-index: 2;
+  z-index: 4;
 `;
 
 const FloatingMenu = memo(


### PR DESCRIPTION
## Context

This simply moves the layering of the design menu (was `z-index:2`, now `z-index:4`) to be above the edit layer (`z-index:3`).

Note that there are still other layering issues to be resolved in #10636.

## Non-user-facing changes

![Screen Shot 2022-03-08 at 16 00 34](https://user-images.githubusercontent.com/637548/157324582-eb3e66ac-4666-44c2-b475-ec90dbf8b010.png)

## Testing Instructions

<!-- ignore-task-list-start -->
-[x ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #10845
