### PR TITLE
UI Simplification: Floating menu - hook up 'More' button

### DIFF
--- a/packages/story-editor/src/app/highlights/states.js
+++ b/packages/story-editor/src/app/highlights/states.js
@@ -35,6 +35,9 @@ import {
 const keys = {
   STORY_TITLE: 'STORY_TITLE',
 
+  // Inspector tabs
+  STYLE_PANE: 'STYLE_PANE',
+
   // INSPECTOR
   ANIMATION: 'ANIMATION',
   ASSISTIVE_TEXT: 'ASSISTIVE_TEXT',
@@ -59,6 +62,12 @@ const keys = {
 export const STATES = {
   [keys.STORY_TITLE]: {
     focus: true,
+  },
+
+  // Inspector tabs
+  [keys.STYLE_PANE]: {
+    focus: true,
+    tab: STYLE,
   },
 
   // Inspector

--- a/packages/story-editor/src/components/floatingMenu/elements/karma/more.karma.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/karma/more.karma.js
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import STICKERS from '@googleforcreators/stickers';
+/**
+ * Internal dependencies
+ */
+import { Fixture } from '../../../../karma';
+
+const stickerTestType = Object.keys(STICKERS)[0];
+
+describe('More button', () => {
+  let fixture;
+
+  beforeEach(async () => {
+    fixture = new Fixture();
+    fixture.setFlags({ floatingMenu: true });
+
+    await fixture.render();
+    await fixture.collapseHelpCenter();
+  });
+
+  afterEach(() => {
+    fixture.restore();
+  });
+
+  it('media element: should focus the size and position panel when the more button is clicked', async () => {
+    // add image to canvas
+    await fixture.events.mouse.clickOn(
+      fixture.editor.library.media.item(0),
+      20,
+      20
+    );
+
+    // click more button
+    await fixture.events.click(fixture.editor.canvas.designMenu.more);
+
+    // verify that first input in size and position panel is focused
+    expect(document.activeElement).toBe(fixture.editor.inspector.designTab);
+  });
+
+  it('text element: should focus the size and position panel when the more button is clicked', async () => {
+    // add text to canvas
+    await fixture.editor.library.textTab.click();
+    await fixture.events.click(fixture.editor.library.text.preset('Paragraph'));
+
+    // click more button
+    await fixture.events.click(fixture.editor.canvas.designMenu.more);
+
+    // verify that first input in size and position panel is focused
+    expect(document.activeElement).toBe(fixture.editor.inspector.designTab);
+  });
+
+  it('shape element: should focus the size and position panel when the more button is clicked', async () => {
+    // add text to canvas
+    await fixture.editor.library.shapesTab.click();
+    await fixture.events.click(fixture.editor.library.shapes.shape('Triangle'));
+
+    // click more button
+    await fixture.events.click(fixture.editor.canvas.designMenu.more);
+
+    // verify that first input in size and position panel is focused
+    expect(document.activeElement).toBe(fixture.editor.inspector.designTab);
+  });
+
+  it('sticker element: should focus the size and position panel when the more button is clicked', async () => {
+    // add text to canvas
+    await fixture.editor.library.shapesTab.click();
+    await fixture.events.click(
+      fixture.editor.library.shapes.sticker(stickerTestType)
+    );
+
+    // click more button
+    await fixture.events.click(fixture.editor.canvas.designMenu.more);
+
+    // verify that first input in size and position panel is focused
+    expect(document.activeElement).toBe(fixture.editor.inspector.designTab);
+  });
+});

--- a/packages/story-editor/src/components/floatingMenu/elements/karma/more.karma.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/karma/more.karma.js
@@ -68,7 +68,7 @@ describe('More button', () => {
   });
 
   it('shape element: should focus the size and position panel when the more button is clicked', async () => {
-    // add text to canvas
+    // add shape to canvas
     await fixture.editor.library.shapesTab.click();
     await fixture.events.click(fixture.editor.library.shapes.shape('Triangle'));
 
@@ -80,7 +80,7 @@ describe('More button', () => {
   });
 
   it('sticker element: should focus the size and position panel when the more button is clicked', async () => {
-    // add text to canvas
+    // add sticker to canvas
     await fixture.editor.library.shapesTab.click();
     await fixture.events.click(
       fixture.editor.library.shapes.sticker(stickerTestType)

--- a/packages/story-editor/src/components/floatingMenu/elements/more.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/more.js
@@ -39,7 +39,7 @@ function More() {
     });
 
     trackEvent('floating_menu', {
-      name: 'set_opacity',
+      name: 'click_more_button',
       element: selectedElementType,
     });
   };

--- a/packages/story-editor/src/components/floatingMenu/elements/more.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/more.js
@@ -18,13 +18,32 @@
  * External dependencies
  */
 import { _x } from '@googleforcreators/i18n';
+import { trackEvent } from '@googleforcreators/tracking';
 
 /**
  * Internal dependencies
  */
+import { useStory } from '../../../app';
+import { states, useHighlights } from '../../../app/highlights';
 import { TextButton } from './shared';
 
 function More() {
+  const setHighlights = useHighlights(({ setHighlights }) => setHighlights);
+  const selectedElementType = useStory(
+    ({ state }) => state.selectedElements[0].type
+  );
+
+  const handleHighlightDesignPanel = () => {
+    setHighlights({
+      highlight: states.STYLE_PANE,
+    });
+
+    trackEvent('floating_menu', {
+      name: 'set_opacity',
+      element: selectedElementType,
+    });
+  };
+
   return (
     <TextButton
       text={_x(
@@ -32,7 +51,7 @@ function More() {
         'Link to more options in design panel for selected element',
         'web-stories'
       )}
-      onClick={() => {}}
+      onClick={handleHighlightDesignPanel}
     />
   );
 }

--- a/packages/story-editor/src/components/inspector/design/designInspector.js
+++ b/packages/story-editor/src/components/inspector/design/designInspector.js
@@ -25,6 +25,7 @@ import { STORY_ANIMATION_STATE } from '@googleforcreators/animation';
  * Internal dependencies
  */
 import { useStory } from '../../../app';
+import { states, styles, useHighlights } from '../../../app/highlights';
 import DesignPanels from './designPanels';
 
 const Wrapper = styled.div`
@@ -37,13 +38,23 @@ function DesignInspector() {
     ({ actions }) => actions.updateAnimationState
   );
 
+  const { highlight, resetHighlight } = useHighlights((state) => ({
+    highlight: state[states.STYLE_PANE],
+    resetHighlight: state.onFocusOut,
+    cancelHighlight: state.cancelEffect,
+  }));
+
   const resetStoryAnimationState = useCallback(
     () => updateAnimationState({ animationState: STORY_ANIMATION_STATE.RESET }),
     [updateAnimationState]
   );
 
   return (
-    <Wrapper onFocus={resetStoryAnimationState}>
+    <Wrapper
+      css={highlight?.showEffect && styles.FLASH}
+      onAnimationEnd={resetHighlight}
+      onFocus={resetStoryAnimationState}
+    >
       <DesignPanels />
     </Wrapper>
   );

--- a/packages/story-editor/src/components/inspector/inspectorProvider.js
+++ b/packages/story-editor/src/components/inspector/inspectorProvider.js
@@ -35,7 +35,7 @@ import { useFeature } from 'flagged';
  */
 import { useAPI } from '../../app/api';
 import { useStory } from '../../app/story';
-import { useHighlights } from '../../app/highlights';
+import { states, useHighlights } from '../../app/highlights';
 import Library from '../library';
 import { DOCUMENT, STYLE, PUBLISH_MODAL_DOCUMENT, INSERT } from './constants';
 import Context from './context';
@@ -55,8 +55,12 @@ function InspectorProvider({ inspectorTabs, children }) {
     currentPage: state.currentPage,
   }));
 
-  const { tab: highlightedTab } = useHighlights(({ tab }) => ({ tab }));
+  const { tab: highlightedTab, highlight } = useHighlights((state) => ({
+    tab: state.tab,
+    highlight: state[states.STYLE_PANE],
+  }));
 
+  // set tab when content is highlighted
   useEffect(() => {
     if (INSPECTOR_TAB_IDS.has(highlightedTab)) {
       setTab(highlightedTab);
@@ -110,6 +114,14 @@ function InspectorProvider({ inspectorTabs, children }) {
       setTab(STYLE);
     }
   }, [currentPage]);
+
+  // focus design pane when highlighted
+  useEffect(() => {
+    const node = designPaneRef.current;
+    if (node && highlight?.focus && highlight?.showEffect) {
+      node.focus();
+    }
+  }, [highlight]);
 
   const loadUsers = useCallback(() => {
     if (!isUsersLoading && users.length === 0) {

--- a/packages/story-editor/src/karma/fixture/containers/designMenu.js
+++ b/packages/story-editor/src/karma/fixture/containers/designMenu.js
@@ -124,4 +124,8 @@ export class DesignMenu extends Container {
       ToggleButton
     );
   }
+
+  get more() {
+    return this.getByRole('menuitem', { name: /^More$/ });
+  }
 }


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Hook up `More` button in the floating menu.

## Relevant Technical Choices

When adding the highlight functionality to the size and position panel (titled `Selection` in the UI), saw that other code added event listeners in the ref callback. This is rather strange - and react provides an api for hooking into events, so I went with that instead.

## To-do

n/a

## User-facing changes

![more-button](https://user-images.githubusercontent.com/22185279/159027134-37e81b28-7ffa-42eb-9442-8a1215b17219.gif)

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. enable floating menu experiment
2. Add any element
3. click on element to show floating menu
4. click `more` button

Should highlight the size and position (titled `Selection`) panel and focus the first input.

Note: the floating menu isn't shown for background images.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10761 
