### PR TITLE
Floating Menu: Font Size, fix text element selection size

### DIFF
--- a/packages/story-editor/src/components/floatingMenu/elements/fontSize.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/fontSize.js
@@ -18,11 +18,14 @@
  * External dependencies
  */
 import { __ } from '@googleforcreators/i18n';
+import { useCallback } from '@googleforcreators/react';
 
 /**
  * Internal dependencies
  */
 import { useStory } from '../../../app';
+import getUpdatedSizeAndPosition from '../../../utils/getUpdatedSizeAndPosition';
+import updateProperties from '../../inspector/design/updateProperties';
 import { focusStyle, inputContainerStyleOverride } from '../../panels/shared';
 import { MIN_MAX } from '../../panels/design/textStyle/font';
 // TODO: https://github.com/GoogleForCreators/web-stories-wp/issues/10799
@@ -36,18 +39,31 @@ function FontSize() {
     })
   );
 
-  const handleChange = (value) =>
-    updateSelectedElements({
-      properties: {
-        fontSize: value,
-      },
-    });
+  const pushUpdate = useCallback(
+    (update) => {
+      updateSelectedElements({
+        properties: (element) => {
+          const updates = updateProperties(element, update, true);
+          const sizeUpdates = getUpdatedSizeAndPosition({
+            ...element,
+            ...updates,
+          });
+          return {
+            ...updates,
+            ...sizeUpdates,
+          };
+        },
+      });
+    },
+    [updateSelectedElements]
+  );
+
   return (
     <Input
       aria-label={__('Font size', 'web-stories')}
       isFloat
       value={fontSize}
-      onChange={(evt, value) => handleChange(value)}
+      onChange={(evt, value) => pushUpdate({ fontSize: value })}
       min={MIN_MAX.FONT_SIZE.MIN}
       max={MIN_MAX.FONT_SIZE.MAX}
       placeholder={fontSize}


### PR DESCRIPTION
## Context
When the font size changes, the box that surrounds the text element should expand / contrast along with it.
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
This component can be used to replace the font size `StyledNumericInput` inside `FontControls`, but we would need to find a width for that input that works for both spots. The current width of `StyledNumericInput` is too narrow for 3 digit numbers. But this FontSize component is still a little wide. I am happy to chat with @agingoldseco to find a size that will allow us to pull this out and use it in both places. 
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
Grabbed `getUpdatedSizeAndPosition` thanks Miina. 


<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
|before|after|
|--|--|
|![font size](https://user-images.githubusercontent.com/1820266/157346908-a31af369-5472-47c5-a5e4-7b940646db95.gif)|![after](https://user-images.githubusercontent.com/1820266/157346827-69c2c320-6a79-443d-a53b-68c73ad26002.gif)|

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. select some text and change the font size. 
2. Check that the containing box size adjusts to fit the text. 


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10855 
