### PR TITLE
Code Quality: remove `featuredMedia` from `updateMedia` callback

### DIFF
--- a/packages/story-editor/src/app/media/utils/useUploadVideoFrame.js
+++ b/packages/story-editor/src/app/media/utils/useUploadVideoFrame.js
@@ -82,7 +82,6 @@ function useUploadVideoFrame({ updateMediaElement }) {
       // If video ID is not set, skip relating media.
       if (id) {
         await updateMedia(id, {
-          featuredMedia: posterId,
           posterId,
           storyId,
         });

--- a/packages/wp-story-editor/src/api/media.js
+++ b/packages/wp-story-editor/src/api/media.js
@@ -219,7 +219,6 @@ export function updateMedia(config, mediaId, data) {
     mediaSource,
     optimizedId,
     mutedId,
-    featuredMedia,
     posterId,
     storyId,
     altText,
@@ -235,7 +234,7 @@ export function updateMedia(config, mediaId, data) {
     },
     web_stories_is_muted: isMuted,
     web_stories_media_source: mediaSource,
-    featured_media: featuredMedia,
+    featured_media: posterId,
     post: storyId,
     alt_text: altText,
   };

--- a/packages/wp-story-editor/src/api/test/media.js
+++ b/packages/wp-story-editor/src/api/test/media.js
@@ -77,9 +77,9 @@ describe('Media API Callbacks', () => {
       mediaSource: 'source-video',
       optimizedId: 12,
       mutedId: 13,
-      featuredMedia: 14,
       altText: 'New Alt Text',
       storyId: 11,
+      posterId: 14,
     };
     const expectedWpKeysMapping = {
       meta: {
@@ -87,11 +87,12 @@ describe('Media API Callbacks', () => {
         web_stories_blurhash: mockData.blurHash,
         web_stories_optimized_id: mockData.optimizedId,
         web_stories_muted_id: mockData.mutedId,
+        web_stories_poster_id: mockData.posterId,
       },
       web_stories_is_muted: mockData.isMuted,
       web_stories_media_source: mockData.mediaSource,
       post: mockData.storyId,
-      featured_media: mockData.featuredMedia,
+      featured_media: mockData.posterId,
       alt_text: mockData.altText,
     };
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
A small change changing `updateMedia` callbacks args. Moves `feturedMedia` key in the data arg to `wp-story-editor`
## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
