### PR TITLE
Bug Fix: Move floating menu in front of popups so that functionality is fixed

### DIFF
--- a/packages/story-editor/src/components/floatingMenu/elements/karma/text.karma.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/karma/text.karma.js
@@ -96,10 +96,7 @@ describe('Design Menu: Text Styles', () => {
       );
     });
 
-    // This is failing due to keyboard problems
-    // TODO #10872 https://github.com/GoogleForCreators/web-stories-wp/issues/10872
-    // eslint-disable-next-line jasmine/no-disabled-tests
-    xit('should allow changing text color for a selection from the design menu', async () => {
+    it('should allow changing text color for a selection from the design menu', async () => {
       // Enter edit-mode
       await fixture.events.keyboard.press('Enter');
       await fixture.screen.findByTestId('textEditor');

--- a/packages/story-editor/src/constants/zIndex.js
+++ b/packages/story-editor/src/constants/zIndex.js
@@ -26,10 +26,14 @@ export const Z_INDEX_CANVAS_SIDE_MENU = 3;
 // Floating element menu (a context menu) should be behind other popopups
 export const Z_INDEX_FLOATING_MENU = 4;
 
+// TODO these layers are taking priority over the floating menu but they can't.
+// Visually we want them in front of the floating menu but
+// they actually need to be behind to be usable. This is going to be a much bigger lift.
+// https://github.com/GoogleForCreators/web-stories-wp/issues/10892
 // Edit Layer holds footer, popups in footer need to be in front of floating menu
-export const Z_INDEX_EDIT_LAYER = Z_INDEX_FLOATING_MENU + 1;
+export const Z_INDEX_EDIT_LAYER = 3;
 
 // sibling inherits parent z-index of Z_INDEX_EDIT_LAYER
 // so popups nested in footer need to be placed above that
 // while still retaining position in the DOM for focus purposes
-export const Z_INDEX_FOOTER = Z_INDEX_EDIT_LAYER + 1;
+export const Z_INDEX_FOOTER = 3;


### PR DESCRIPTION
## Context

Miina pointed out here: https://github.com/GoogleForCreators/web-stories-wp/pull/10861#discussion_r824902184 and here https://github.com/GoogleForCreators/web-stories-wp/pull/10875#issuecomment-1065285614 that fixing the layering visually actually makes features completely unusable. 
 
## Summary

move popups behind floating menu so that things can be edited.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

Getting the layering right here is going to be a much bigger lift than fixing the z index, we need to restructure the HTML. Ticket created here: #10892 but for now, the floating menus are just going to need to be on top. 

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
