### PR TITLE
Allow selecting page when in Empty Story state

### DIFF
--- a/packages/story-editor/src/components/canvas/emptyStateLayer.js
+++ b/packages/story-editor/src/components/canvas/emptyStateLayer.js
@@ -59,6 +59,10 @@ const EmptyStateMessage = styled.div`
   }
 `;
 
+const StyledButton = styled(Button)`
+  pointer-events: initial;
+`;
+
 function EmptyStateLayer() {
   const { isRTL } = useConfig();
   const { isMenuOpen, onOpenMenu } = useRightClickMenu(
@@ -89,10 +93,14 @@ function EmptyStateLayer() {
   };
 
   return (
-    <Layer onContextMenu={onOpenMenu}>
+    <Layer
+      onContextMenu={onOpenMenu}
+      pointerEvents="none"
+      aria-label={__('Empty state layer', 'web-stories')}
+    >
       <DisplayPageArea withSafezone={false}>
         <EmptyStateMessage>
-          <Button
+          <StyledButton
             type={BUTTON_TYPES.SECONDARY}
             variant={BUTTON_VARIANTS.CIRCLE}
             onClick={onButtonClick}
@@ -102,7 +110,7 @@ function EmptyStateLayer() {
             aria-expanded={isMenuOpen}
           >
             <Icons.Media />
-          </Button>
+          </StyledButton>
           <ThemeProvider theme={{ ...theme, colors: lightMode }}>
             <Text
               id="emptystate-message"

--- a/packages/story-editor/src/components/canvas/pageAttachment/karma/pageAttachment.cuj.karma.js
+++ b/packages/story-editor/src/components/canvas/pageAttachment/karma/pageAttachment.cuj.karma.js
@@ -41,8 +41,12 @@ describe('Page Attachment', () => {
     await fixture.collapseHelpCenter();
 
     // Select Page by default.
-    safezone = fixture.querySelector('[data-testid="safezone"]');
-    await clickOnTarget(safezone);
+    // Click the background element
+    await fixture.events.mouse.clickOn(
+      fixture.editor.canvas.framesLayer.frames[0].node,
+      10,
+      10
+    );
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/canvas/pageAttachment/karma/pageAttachment.cuj.karma.js
+++ b/packages/story-editor/src/components/canvas/pageAttachment/karma/pageAttachment.cuj.karma.js
@@ -40,12 +40,9 @@ describe('Page Attachment', () => {
     await fixture.render();
     await fixture.collapseHelpCenter();
 
-    // Select Page by default and remove empty state.
-    await fixture.events.click(
-      fixture.editor.canvas.quickActionMenu.changeBackgroundColorButton
-    );
-    await fixture.events.keyboard.type('ef');
-    await fixture.events.keyboard.press('Tab');
+    // Select Page by default.
+    safezone = fixture.querySelector('[data-testid="safezone"]');
+    await clickOnTarget(safezone);
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/colorPicker/karma/colorPicker.karma.js
+++ b/packages/story-editor/src/components/colorPicker/karma/colorPicker.karma.js
@@ -42,8 +42,7 @@ describe('ColorPicker', () => {
       });
 
       it('should display correctly', async () => {
-        await fixture.events.click(fixture.editor.canvas.pageActions.addPage);
-
+        // Click the background element
         await fixture.events.click(
           fixture.editor.canvas.framesLayer.frames[0].node
         );

--- a/packages/story-editor/src/components/colorPicker/karma/colorPicker.karma.js
+++ b/packages/story-editor/src/components/colorPicker/karma/colorPicker.karma.js
@@ -43,8 +43,10 @@ describe('ColorPicker', () => {
 
       it('should display correctly', async () => {
         // Click the background element
-        await fixture.events.click(
-          fixture.editor.canvas.framesLayer.frames[0].node
+        await fixture.events.mouse.clickOn(
+          fixture.editor.canvas.framesLayer.frames[0].node,
+          10,
+          10
         );
 
         const bgPanel = fixture.editor.inspector.designPanel.pageBackground;

--- a/packages/story-editor/src/components/panels/design/link/karma/link.karma.js
+++ b/packages/story-editor/src/components/panels/design/link/karma/link.karma.js
@@ -234,8 +234,12 @@ describe('Link Panel', () => {
   describe('CUJ: Creator Can Add A Link: Link with Page Attachment', () => {
     beforeEach(async () => {
       // Select Page.
-      safezone = fixture.querySelector('[data-testid="safezone"]');
-      await clickOnTarget(safezone);
+      // Click the background element
+      await fixture.events.mouse.clickOn(
+        fixture.editor.canvas.framesLayer.frames[0].node,
+        10,
+        10
+      );
 
       // Add Page Attachment
       await setPageAttachmentLink('http://pageattachment.com');

--- a/packages/story-editor/src/components/panels/design/link/karma/link.karma.js
+++ b/packages/story-editor/src/components/panels/design/link/karma/link.karma.js
@@ -233,12 +233,9 @@ describe('Link Panel', () => {
 
   describe('CUJ: Creator Can Add A Link: Link with Page Attachment', () => {
     beforeEach(async () => {
-      // Select Page and remove empty state message.
-      await fixture.events.click(
-        fixture.editor.canvas.quickActionMenu.changeBackgroundColorButton
-      );
-      await fixture.events.keyboard.type('ef');
-      await fixture.events.keyboard.press('Tab');
+      // Select Page.
+      safezone = fixture.querySelector('[data-testid="safezone"]');
+      await clickOnTarget(safezone);
 
       // Add Page Attachment
       await setPageAttachmentLink('http://pageattachment.com');


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
Changes the pointer-events of the layer to allow clicking through it but still support clicking on the button.
<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Open a new Story
2. Verify you can select the page by clicking on it in Empty Story state.


## Reviews

### Does this PR have a security-related impact?
No
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
No
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
No
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10701 
