### PR TITLE
Fix `web_stories_hide_auto_generated_attachments` filter

### DIFF
--- a/includes/Media/Media_Source_Taxonomy.php
+++ b/includes/Media/Media_Source_Taxonomy.php
@@ -201,6 +201,8 @@ class Media_Source_Taxonomy extends Taxonomy_Base {
 	 * @return array  Tax query arg.
 	 */
 	private function get_exclude_tax_query( array $args ): array {
+		$tax_query = ! empty( $args['tax_query'] ) ? $args['tax_query'] : [];
+
 		/**
 		 * Filter whether generated attachments should be hidden in the media library.
 		 *
@@ -211,17 +213,8 @@ class Media_Source_Taxonomy extends Taxonomy_Base {
 		 */
 		$enabled = apply_filters( 'web_stories_hide_auto_generated_attachments', true, $args );
 		if ( true !== $enabled ) {
-			return $args;
+			return $tax_query;
 		}
-
-		$tax_query = [
-			[
-				'taxonomy' => $this->taxonomy_slug,
-				'field'    => 'slug',
-				'terms'    => [ 'poster-generation', 'source-video', 'source-image', 'page-template' ],
-				'operator' => 'NOT IN',
-			],
-		];
 
 		/**
 		 *  Merge with existing tax query if needed,
@@ -234,9 +227,17 @@ class Media_Source_Taxonomy extends Taxonomy_Base {
 		 *   [ [ any ], [ existing ], [ tax queries] ]
 		 * ]
 		 */
-		if ( ! empty( $args['tax_query'] ) ) {
-			$tax_query[] = $args['tax_query'];
-		}
+		array_unshift(
+			$tax_query,
+			[
+				[
+					'taxonomy' => $this->taxonomy_slug,
+					'field'    => 'slug',
+					'terms'    => [ 'poster-generation', 'source-video', 'source-image', 'page-template' ],
+					'operator' => 'NOT IN',
+				],
+			]
+		);
 
 		return $tax_query;
 	}

--- a/tests/phpunit/integration/tests/Media/Media_Source_Taxonomy.php
+++ b/tests/phpunit/integration/tests/Media/Media_Source_Taxonomy.php
@@ -182,18 +182,19 @@ class Media_Source_Taxonomy extends DependencyInjectedTestCase {
 	 */
 	public function test_get_exclude_tax_query_filter(): void {
 		add_filter( 'web_stories_hide_auto_generated_attachments', '__return_false' );
-		$args    = [
-			'tax_query' => [
-				[
-					'taxonomy' => 'people',
-					'field'    => 'slug',
-					'terms'    => 'bob',
-				],
+		$tax_query = [
+			[
+				'taxonomy' => 'people',
+				'field'    => 'slug',
+				'terms'    => 'bob',
 			],
 		];
-		$results = $this->call_private_method( $this->instance, 'get_exclude_tax_query', [ $args ] );
+		$args      = [
+			'tax_query' => $tax_query,
+		];
+		$results   = $this->call_private_method( $this->instance, 'get_exclude_tax_query', [ $args ] );
 		remove_filter( 'web_stories_hide_auto_generated_attachments', '__return_false' );
-		$this->assertSame( $args, $results );
+		$this->assertSame( $tax_query, $results );
 	}
 
 	/**
@@ -206,14 +207,15 @@ class Media_Source_Taxonomy extends DependencyInjectedTestCase {
 		$expected = [
 			'tax_query' => [
 				[
-					'taxonomy' => $tax_slug,
-					'field'    => 'slug',
-					'terms'    => [ 'poster-generation', 'source-video', 'source-image', 'page-template' ],
-					'operator' => 'NOT IN',
+					[
+						'taxonomy' => $tax_slug,
+						'field'    => 'slug',
+						'terms'    => [ 'poster-generation', 'source-video', 'source-image', 'page-template' ],
+						'operator' => 'NOT IN',
+					],
 				],
 			],
 		];
-
 
 		$actual = $this->instance->filter_ajax_query_attachments_args( [] );
 
@@ -230,22 +232,21 @@ class Media_Source_Taxonomy extends DependencyInjectedTestCase {
 		$expected = [
 			'tax_query' => [
 				[
-					'taxonomy' => $tax_slug,
-					'field'    => 'slug',
-					'terms'    => [ 'poster-generation', 'source-video', 'source-image', 'page-template' ],
-					'operator' => 'NOT IN',
-				],
-				[
 					[
-						'taxonomy' => 'category',
+						'taxonomy' => $tax_slug,
 						'field'    => 'slug',
-						'terms'    => [ 'uncategorized' ],
+						'terms'    => [ 'poster-generation', 'source-video', 'source-image', 'page-template' ],
 						'operator' => 'NOT IN',
 					],
 				],
+				[
+					'taxonomy' => 'category',
+					'field'    => 'slug',
+					'terms'    => [ 'uncategorized' ],
+					'operator' => 'NOT IN',
+				],
 			],
 		];
-
 
 		$actual = $this->instance->filter_ajax_query_attachments_args(
 			[
@@ -285,7 +286,6 @@ class Media_Source_Taxonomy extends DependencyInjectedTestCase {
 		$query    = new WP_Query();
 		$expected = $query->get( 'tax_query' );
 
-
 		$this->instance->filter_generated_media_attachments( $query );
 		$actual = $query->get( 'tax_query' );
 
@@ -315,18 +315,18 @@ class Media_Source_Taxonomy extends DependencyInjectedTestCase {
 
 		$expected = [
 			[
-				'taxonomy' => $this->instance->get_taxonomy_slug(),
-				'field'    => 'slug',
-				'terms'    => [ 'poster-generation', 'source-video', 'source-image', 'page-template' ],
-				'operator' => 'NOT IN',
-			],
-			[
 				[
-					'taxonomy' => 'category',
+					'taxonomy' => $this->instance->get_taxonomy_slug(),
 					'field'    => 'slug',
-					'terms'    => [ 'uncategorized' ],
+					'terms'    => [ 'poster-generation', 'source-video', 'source-image', 'page-template' ],
 					'operator' => 'NOT IN',
 				],
+			],
+			[
+				'taxonomy' => 'category',
+				'field'    => 'slug',
+				'terms'    => [ 'uncategorized' ],
+				'operator' => 'NOT IN',
 			],
 		];
 
@@ -361,10 +361,12 @@ class Media_Source_Taxonomy extends DependencyInjectedTestCase {
 		$expected = [
 			'tax_query' => [
 				[
-					'taxonomy' => $tax_slug,
-					'field'    => 'slug',
-					'terms'    => [ 'poster-generation', 'source-video', 'source-image', 'page-template' ],
-					'operator' => 'NOT IN',
+					[
+						'taxonomy' => $tax_slug,
+						'field'    => 'slug',
+						'terms'    => [ 'poster-generation', 'source-video', 'source-image', 'page-template' ],
+						'operator' => 'NOT IN',
+					],
 				],
 			],
 		];


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

The `web_stories_hide_auto_generated_attachments` filter does not work as expected.

`get_exclude_tax_query()` is expected to receive all query args and return only tax query args.

Right now, when doing `add_filter( 'web_stories_hide_auto_generated_attachments', '__return_false' );`, tax query args are emptied, even if there are existing ones.

## Summary

<!-- A brief description of what this PR does. -->

Fixes `web_stories_hide_auto_generated_attachments` the filter so that it works as expected.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

**Without this PR**

1. Use `add_filter( 'web_stories_hide_auto_generated_attachments', '__return_false' );`
2. See empty media library in the editor

**With this PR**

1. Use `add_filter( 'web_stories_hide_auto_generated_attachments', '__return_false' );`
2. See media items in the editor


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
