### PR TITLE
Bug: Stacking context with lotsa popups & floating menu

### DIFF
--- a/packages/story-editor/src/components/canvas/navLayer.js
+++ b/packages/story-editor/src/components/canvas/navLayer.js
@@ -44,8 +44,8 @@ function NavLayer({ header, footer }) {
             <PageSideMenu />
           </PageMenuArea>
         </DirectionAware>
-        <FooterArea pointerEvents="initial" zIndex={Z_INDEX_NAV_LAYER}>
-          <Footer footer={footer} />
+        <FooterArea pointerEvents="initial">
+          <Footer footer={footer} zIndex={Z_INDEX_NAV_LAYER} />
         </FooterArea>
       </Layer>
     </ChecklistCountProvider>

--- a/packages/story-editor/src/components/canvas/navLayer.js
+++ b/packages/story-editor/src/components/canvas/navLayer.js
@@ -23,7 +23,7 @@ import Proptypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { Z_INDEX_HEAD_AREA } from '../../constants/zIndex';
+import { Z_INDEX_NAV_LAYER } from '../../constants/zIndex';
 import { ChecklistCountProvider } from '../checklist';
 import Footer from '../footer';
 import DirectionAware from '../directionAware';
@@ -36,7 +36,7 @@ function NavLayer({ header, footer }) {
       hasChecklist={Boolean(footer?.secondaryMenu?.checklist)}
     >
       <Layer pointerEvents="none" onMouseDown={(evt) => evt.stopPropagation()}>
-        <HeadArea pointerEvents="initial" zIndex={Z_INDEX_HEAD_AREA}>
+        <HeadArea pointerEvents="initial" zIndex={Z_INDEX_NAV_LAYER}>
           {header}
         </HeadArea>
         <DirectionAware>
@@ -44,7 +44,7 @@ function NavLayer({ header, footer }) {
             <PageSideMenu />
           </PageMenuArea>
         </DirectionAware>
-        <FooterArea pointerEvents="initial">
+        <FooterArea pointerEvents="initial" zIndex={Z_INDEX_NAV_LAYER}>
           <Footer footer={footer} />
         </FooterArea>
       </Layer>

--- a/packages/story-editor/src/components/checklist/toggle/index.js
+++ b/packages/story-editor/src/components/checklist/toggle/index.js
@@ -39,6 +39,7 @@ const MainIcon = styled(Icons.Checkbox)`
 
 const StyledToggleButton = styled(ToggleButton)`
   display: block;
+  background-color: ${({ theme }) => theme.colors.bg.primary};
 `;
 
 function Toggle({ isOpen = false, popupId = '', onClick = noop }) {

--- a/packages/story-editor/src/components/footer/footer.js
+++ b/packages/story-editor/src/components/footer/footer.js
@@ -42,7 +42,7 @@ const Inner = styled(Outer)`
   margin-right: ${({ marginRight }) => marginRight}px;
 `;
 
-function Footer({ footer }) {
+function Footer({ footer, zIndex }) {
   const ref = useRef();
   const [workspaceWidth, setWorkspaceWidth] = useState(0);
 
@@ -57,7 +57,7 @@ function Footer({ footer }) {
       <KeyboardShortcutsMenuProvider>
         <Outer ref={ref}>
           <Inner marginRight={margin}>
-            <FooterLayout footer={footer} />
+            <FooterLayout footer={footer} zIndex={zIndex} />
           </Inner>
         </Outer>
       </KeyboardShortcutsMenuProvider>
@@ -67,6 +67,7 @@ function Footer({ footer }) {
 
 Footer.propTypes = {
   footer: PropTypes.object,
+  zIndex: PropTypes.number,
 };
 
 // Don't rerender the workspace footer needlessly e.g. on element selection change.

--- a/packages/story-editor/src/components/footer/footerLayout.js
+++ b/packages/story-editor/src/components/footer/footerLayout.js
@@ -49,19 +49,20 @@ const Area = styled.div`
   display: flex;
   align-items: flex-end;
   justify-content: center;
+  z-index: ${({ zIndex = 'auto' }) => zIndex};
 `;
 
-function FooterLayout({ footer }) {
+function FooterLayout({ footer, zIndex }) {
   return (
     <DirectionAware>
       <Wrapper aria-label={__('Workspace Footer', 'web-stories')}>
         <Area area="carousel">
           <Carousel />
         </Area>
-        <Area area="primary">
+        <Area area="primary" zIndex={zIndex}>
           <PrimaryMenu />
         </Area>
-        <Area area="secondary">
+        <Area area="secondary" zIndex={zIndex}>
           <SecondaryMenu menu={footer?.secondaryMenu} />
         </Area>
       </Wrapper>
@@ -71,6 +72,7 @@ function FooterLayout({ footer }) {
 
 FooterLayout.propTypes = {
   footer: PropTypes.object,
+  zIndex: PropTypes.number,
 };
 
 export default FooterLayout;

--- a/packages/story-editor/src/components/footer/zoomSelector/zoomSelector.js
+++ b/packages/story-editor/src/components/footer/zoomSelector/zoomSelector.js
@@ -31,6 +31,7 @@ import { useLayout } from '../../../app/layout';
 const selectButtonCSS = css`
   height: 36px;
   padding: 8px;
+  background-color: ${({ theme }) => theme.colors.bg.primary};
 
   span {
     padding: 0;

--- a/packages/story-editor/src/components/helpCenter/toggle/index.js
+++ b/packages/story-editor/src/components/helpCenter/toggle/index.js
@@ -35,6 +35,7 @@ const StyledToggleButton = styled(ToggleButton)`
   padding-left: 3px;
   padding-right: 3px;
   display: block;
+  background-color: ${({ theme }) => theme.colors.bg.primary};
 `;
 
 function Toggle({

--- a/packages/story-editor/src/components/keyboardShortcutsMenu/index.js
+++ b/packages/story-editor/src/components/keyboardShortcutsMenu/index.js
@@ -43,6 +43,7 @@ const StyledToggleButton = styled(ToggleButton)`
   padding-right: ${KEYBOARD_SHORTCUTS_PADDING}px;
   width: auto;
   display: block;
+  background-color: ${({ theme }) => theme.colors.bg.primary};
 `;
 
 const Wrapper = styled.div`

--- a/packages/story-editor/src/constants/zIndex.js
+++ b/packages/story-editor/src/constants/zIndex.js
@@ -17,23 +17,24 @@
 // Bring element in front of story details modal
 export const Z_INDEX_STORY_DETAILS = 10;
 
-// Lift the head area from under the canvas, only impacts Karma.
-export const Z_INDEX_HEAD_AREA = 3;
-
 // Floating menu lays on top of side menu
 export const Z_INDEX_CANVAS_SIDE_MENU = 3;
 
 // Floating element menu (a context menu) should be behind other popopups
 export const Z_INDEX_FLOATING_MENU = 4;
 
-// TODO these layers are taking priority over the floating menu but they can't.
-// Visually we want them in front of the floating menu but
-// they actually need to be behind to be usable. This is going to be a much bigger lift.
-// https://github.com/GoogleForCreators/web-stories-wp/issues/10892
 // Edit Layer holds footer, popups in footer need to be in front of floating menu
 export const Z_INDEX_EDIT_LAYER = 3;
 
-// sibling inherits parent z-index of Z_INDEX_EDIT_LAYER
-// so popups nested in footer need to be placed above that
-// while still retaining position in the DOM for focus purposes
+// Nav layer doesn't have it's own stacking context, so we apply this
+// to the header and footer to be in the same stacking context as
+// floating menu layer & edit layer
+export const Z_INDEX_NAV_LAYER = 5;
+
+// idk why these are defined in here. they're used through out parts of the
+// codebase, but they're not in the same stacking as the other layers in this
+// file. Keeping them in here to avoid regressions in the codebase, but
+// we should look into only storing z-index constants that apply to the same
+// stacking context
 export const Z_INDEX_FOOTER = 3;
+export const Z_INDEX_HEAD_AREA = 3;


### PR DESCRIPTION
## Context
Part of work for the floating menu. This provides the layering fix described in [this ticket #10892](https://app.zenhub.com/workspaces/web-stories-5e94d3aced449034e1e9b226/issues/googleforcreators/web-stories-wp/10892) without effecting edit layer functionality.

Did talk it over with @agingoldseco today in the design meeting and she may not want this stacking behavior. Will wait till she gives the green light before we move forward.
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Fixes footer popups rendering under the floating menu.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
Tried a couple of approaches, but was able to figure out a low impact fix that doesn't change the markup and leverages some canvas layers not establishing a stacking context.
<!-- Please describe your changes. -->

## To-do
- [ ] get design approval once this branch is viewable in QA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
| Before | After |
| ----- | ------ |
| <img width="1725" alt="Screen Shot 2022-03-15 at 4 01 40 PM" src="https://user-images.githubusercontent.com/35983235/158471958-1677dba7-2978-439b-9744-7b57aedbd040.png"> | 
<img width="1728" alt="Screen Shot 2022-03-15 at 4 00 47 PM" src="https://user-images.githubusercontent.com/35983235/158471986-5c84e88a-dee5-419b-ad5d-29b620b7d538.png"> |


<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

See that this PR follows acceptance criteria as indicated by:
- #10892 

This PR can be tested by following these steps:

1. All footer popups are visually in front of the floating menu
2. Floating menu is in front of the sidebar menu
3. Elements need to retain selection.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10892 
