### PR TITLE
Improve handling of corrupt page templates data

### DIFF
--- a/packages/story-editor/src/components/library/panes/pageTemplates/pageTemplatesPane.js
+++ b/packages/story-editor/src/components/library/panes/pageTemplates/pageTemplatesPane.js
@@ -31,6 +31,7 @@ import {
   LOCAL_STORAGE_PREFIX,
 } from '@googleforcreators/design-system';
 import { DATA_VERSION, migrate } from '@googleforcreators/migration';
+import { trackError } from '@googleforcreators/tracking';
 
 /**
  * Internal dependencies
@@ -152,7 +153,8 @@ function PageTemplatesPane(props) {
           setNextTemplatesToFetch(nextTemplatesToFetch + 1);
         }
       })
-      .catch(() => {
+      .catch((err) => {
+        trackError('saved_templates', err.message);
         setNextTemplatesToFetch(false);
         setSavedTemplates((_savedTemplates) => _savedTemplates ?? []);
       })

--- a/packages/story-editor/src/components/library/panes/pageTemplates/templateList.js
+++ b/packages/story-editor/src/components/library/panes/pageTemplates/templateList.js
@@ -158,7 +158,7 @@ TemplateList.propTypes = {
   parentRef: PropTypes.object.isRequired,
   pages: PropTypes.arrayOf(
     PropTypes.shape({
-      id: PropTypes.string.isRequired,
+      id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
     })
   ),
   pageSize: PropTypes.object.isRequired,

--- a/packages/wp-story-editor/src/api/pageTemplate.js
+++ b/packages/wp-story-editor/src/api/pageTemplate.js
@@ -35,7 +35,11 @@ const TEMPLATE_FIELDS = [
 const TEMPLATE_EMBED = 'wp:featuredmedia';
 
 function transformResponse(template) {
-  const { _embedded: embedded = {}, id: templateId, story_data } = template;
+  const {
+    _embedded: embedded = {},
+    id: templateId,
+    story_data = {},
+  } = template;
   const image = {
     id: embedded?.['wp:featuredmedia']?.[0].id || 0,
     height: embedded?.['wp:featuredmedia']?.[0]?.media_details?.height || 0,
@@ -43,7 +47,7 @@ function transformResponse(template) {
     url: embedded?.['wp:featuredmedia']?.[0]?.source_url || '',
   };
 
-  return { ...story_data, templateId, image };
+  return { id: templateId, elements: [], ...story_data, templateId, image };
 }
 
 export function getCustomPageTemplates(config, page = 1) {

--- a/packages/wp-story-editor/src/api/test/pageTemplates.js
+++ b/packages/wp-story-editor/src/api/test/pageTemplates.js
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { bindToCallbacks } from '@web-stories-wp/wp-utils';
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import * as apiCallbacks from '..';
+
+jest.mock('@wordpress/api-fetch');
+
+describe('pageTemplates', () => {
+  afterEach(() => {
+    apiFetch.mockReset();
+  });
+
+  describe('getCustomPageTemplates', () => {
+    it('should always provide id and elements', async () => {
+      apiFetch.mockReturnValue(
+        Promise.resolve({
+          headers: {
+            'X-WP-TotalPages': 20,
+          },
+          body: [
+            {
+              id: 123,
+              story_data: { id: 'page-id', elements: [{ id: 'foo' }] },
+            },
+            { id: 456, story_data: [] },
+          ],
+        })
+      );
+
+      const { getCustomPageTemplates } = bindToCallbacks(apiCallbacks, {
+        api: { pageTemplates: '/web-stories/v1/web-story-page/' },
+      });
+
+      await expect(getCustomPageTemplates(1)).resolves.toStrictEqual({
+        hasMore: true,
+        templates: [
+          {
+            elements: [{ id: 'foo' }],
+            id: 'page-id',
+            image: { height: 0, id: 0, url: '', width: 0 },
+            templateId: 123,
+          },
+          {
+            elements: [],
+            id: 456,
+            image: { height: 0, id: 0, url: '', width: 0 },
+            templateId: 456,
+          },
+        ],
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

As reported in #10936, the Saved Templates library tab is empty if there is 1 page template with empty `story_data`.

`story_data` is empty if the story data stored in `post_content_filtered` is corrupt and not valid JSON anymore.

This leads to some JS errors being thrown and silenced, causing the whole tab to be empty.

## Summary

<!-- A brief description of what this PR does. -->

This PR improves handling of corrupt page templates by ensuring certain object keys are always present, even if `story_data` is empty.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

In the future, if this becomes a more frequent issue, we might want to look into ways to surface this to the users.

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Create a new story with some content
2. Save as a template
3. Modify the template in the database, emptying the `post_content_filtered` column
4. Go to the editor and to the Saved Templates list
5. Verify that the all saved templates appear as expected


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

Adds new error tracking for when loading page templates fails.

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10936
