### PR TITLE
Define default padding in presets

### DIFF
--- a/packages/story-editor/src/components/library/panes/text/textPresets.js
+++ b/packages/story-editor/src/components/library/panes/text/textPresets.js
@@ -52,6 +52,8 @@ const DEFAULT_TEXT_BORDER_RADIUS = {
 const DEFAULT_TEXT_PADDING = {
   locked: true,
   hasHiddenPadding: false,
+  horizontal: 0,
+  vertical: 0,
 };
 
 const DEFAULT_TEXT_ALIGN = 'left';


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Previously, the padding value was undefined in text presets, causing odd padding values in the design panel.
This PR adds the default padding `0` when adding any text preset.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add a text preset (e.g. Title 1)
2. Verify the Padding value shows `0` in the design panel.
3. Change text alignment.
4. Verify the padding is still `0` (and not "Mixed" as before).


## Reviews

### Does this PR have a security-related impact?
No
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
No
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
No
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10802 
