### PR TITLE
Layers Toggle Menu: Adjust Width

### DIFF
--- a/packages/story-editor/src/components/footer/layers/layers.js
+++ b/packages/story-editor/src/components/footer/layers/layers.js
@@ -36,6 +36,9 @@ const Container = styled.div`
   z-index: ${Z_INDEX_FOOTER};
 `;
 
+const StyledNavigationWrapper = styled(NavigationWrapper)`
+  width: 260px;
+`;
 function Layers() {
   const layersLength = useLayers().length;
   const [isOpen, setIsOpen] = useState(false);
@@ -48,11 +51,11 @@ function Layers() {
         placement={PLACEMENT.RIGHT}
         ariaLabel={__('Layers Panel', 'web-stories')}
       >
-        <NavigationWrapper alignRight ref={ref} isOpen={isOpen}>
+        <StyledNavigationWrapper alignRight ref={ref} isOpen={isOpen}>
           <Container>
             <LayerPanel />
           </Container>
-        </NavigationWrapper>
+        </StyledNavigationWrapper>
       </Popup>
       <ToggleButton
         isOpen={isOpen}


### PR DESCRIPTION
## Context

Layers panel is sharing its base popup functionality with the other footer popups now that it's not in the inspector pane. Those are a little wider than the layers panel needs to be.

## Summary

Shrink the width from 310px to 260px.

| 310px | 260px |
| --- | --- | 
| <img width="1398" alt="Screen Shot 2022-03-16 at 4 39 03 PM" src="https://user-images.githubusercontent.com/10720454/158708951-d89566d3-98a3-402f-9b87-52518ede2f37.png"> | <img width="1406" alt="Screen Shot 2022-03-16 at 4 39 19 PM" src="https://user-images.githubusercontent.com/10720454/158708971-ba278852-edc7-4a0a-a344-18dae740914d.png"> | 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

Get Amy's approval :) 

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

Is layers panel now 260px wide instead of 310px wide?

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10953 
