### PR TITLE
Sanitization: catch edge case with malformed start/end tags

### DIFF
--- a/includes/Renderer/Story/HTML.php
+++ b/includes/Renderer/Story/HTML.php
@@ -181,8 +181,8 @@ class HTML {
 		$end_tag   = '<meta name="web-stories-replace-head-end"/>';
 
 		// Replace malformed meta tags with correct tags.
-		$content = (string) preg_replace( '/<meta name="web-stories-replace-head-start\s?"\s?\/>/i', $start_tag, $content );
-		$content = (string) preg_replace( '/<meta name="web-stories-replace-head-end\s?"\s?\/>/i', $end_tag, $content );
+		$content = (string) preg_replace( '/<meta name="web-stories-replace-head-start\s?"\s?\/?>/i', $start_tag, $content );
+		$content = (string) preg_replace( '/<meta name="web-stories-replace-head-end\s?"\s?\/?>/i', $end_tag, $content );
 
 		$start_tag_pos = strpos( $content, $start_tag );
 		$end_tag_pos   = strpos( $content, $end_tag );

--- a/tests/phpunit/integration/tests/Renderer/Story/HTML.php
+++ b/tests/phpunit/integration/tests/Renderer/Story/HTML.php
@@ -90,9 +90,36 @@ class HTML extends TestCase {
 	 * @covers ::replace_html_head
 	 * @covers ::get_html_head_markup
 	 */
-	public function test_replace_html_head_invalid(): void {
+	public function test_replace_html_head_malformed(): void {
 		$start_tag = '<meta name="web-stories-replace-head-start " />';
 		$end_tag   = '<meta name="web-stories-replace-head-end" />';
+
+		$post = self::factory()->post->create_and_get(
+			[
+				'post_type'    => Story_Post_Type::POST_TYPE_SLUG,
+				'post_content' => "<html><head>FOO{$start_tag}BAR{$end_tag}BAZ</head><body><amp-story></amp-story></body></html>",
+			]
+		);
+
+		$actual = $this->setup_renderer( $post );
+
+		$this->assertStringContainsString( 'FOO', $actual );
+		$this->assertStringContainsString( 'BAZ', $actual );
+		$this->assertStringNotContainsString( 'BAR', $actual );
+		$this->assertStringNotContainsString( $start_tag, $actual );
+		$this->assertStringNotContainsString( $end_tag, $actual );
+		$this->assertStringContainsString( '<meta name="amp-story-generator-name" content="Web Stories for WordPress"', $actual );
+		$this->assertStringContainsString( '<meta name="amp-story-generator-version" content="', $actual );
+		$this->assertSame( 1, did_action( 'web_stories_story_head' ) );
+	}
+
+	/**
+	 * @covers ::replace_html_head
+	 * @covers ::get_html_head_markup
+	 */
+	public function test_replace_html_head_malformed_missing_slash(): void {
+		$start_tag = '<meta name="web-stories-replace-head-start">';
+		$end_tag   = '<meta name="web-stories-replace-head-end">';
 
 		$post = self::factory()->post->create_and_get(
 			[


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

This is essentially a follow-up to #5682

I stumbled upon a story where the start/end markers had no slash at the end, causing the replacement to be broken.

## Summary

<!-- A brief description of what this PR does. -->

This adds some extra hardening to catch instances like `<meta name="web-stories-replace-head-start">` and `<meta name="web-stories-replace-head-end">`

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

None

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
