### PR TITLE
Floating Menus: Enable Experiment

### DIFF
--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -357,7 +357,7 @@ class Experiments extends Service_Base implements HasRequirements {
 				'label'       => __( 'Floating Menu', 'web-stories' ),
 				'description' => __( 'Enable the new floating design menu', 'web-stories' ),
 				'group'       => 'editor',
-				'default'     => true
+				'default'     => true,
 			],
 			/**
 			 * Author: @timarney

--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -357,6 +357,7 @@ class Experiments extends Service_Base implements HasRequirements {
 				'label'       => __( 'Floating Menu', 'web-stories' ),
 				'description' => __( 'Enable the new floating design menu', 'web-stories' ),
 				'group'       => 'editor',
+				'default'     => true
 			],
 			/**
 			 * Author: @timarney

--- a/packages/e2e-tests/src/specs/dashboard/templates/useTemplate.js
+++ b/packages/e2e-tests/src/specs/dashboard/templates/useTemplate.js
@@ -83,13 +83,16 @@ describe('Template', () => {
       text: /^Fresh/,
     });
 
-    // Collapse layers popup to avoid aXe error about duplicative alt tags
-    await expect(page).toClick('button', { text: /^Layers/ });
-    // make sure popup is closed otherwise aXe will error
-    await page.waitForTimeout(300);
-
     // Open style pane
     await expect(page).toClick('li[role="tab"]', { text: /^Style$/ });
+
+    // Collapse layers popup to avoid aXe error about duplicative alt tags
+    await expect(page).toClick('button', { text: /^Layers/ });
+    // close floating menu
+    await expect(page).toClick('button', { text: 'Dismiss menu' });
+
+    // make sure popup is closed otherwise aXe will error
+    await page.waitForTimeout(300);
 
     await expect(page).toMatchElement('input[placeholder="Add title"]');
     await expect(page).toMatchElement('[data-element-id]');


### PR DESCRIPTION
## Context

Enables the floating menus by default.

## Summary

Menus for everything! 
See #10988 for detailed list of feature. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

Whatever tests break when I make this PR. 

## User-facing changes

We now have a 'floating menu' for the selected element(s) on the canvas. 

https://user-images.githubusercontent.com/10720454/159078233-961ed770-830f-408a-b0da-3db4f306e1ea.mp4


## Testing Instructions

There's a really detailed acceptance criteria on #10988 please reference that. 

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10988 
