### PR TITLE
Editor: add focus styling to title input

### DIFF
--- a/packages/story-editor/src/components/header/title.js
+++ b/packages/story-editor/src/components/header/title.js
@@ -43,6 +43,8 @@ const Input = styled.input`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  ${({ theme }) => themeHelpers.focusableOutlineCSS(theme.colors.border.focus)};
+
   ${({ isHighlighted }) =>
     isHighlighted &&
     css`

--- a/packages/story-editor/src/components/header/title.js
+++ b/packages/story-editor/src/components/header/title.js
@@ -43,7 +43,7 @@ const Input = styled.input`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  ${({ theme }) => themeHelpers.focusableOutlineCSS(theme.colors.border.focus)};
+  ${themeHelpers.focusableOutlineCSS};
 
   ${({ isHighlighted }) =>
     isHighlighted &&

--- a/packages/story-editor/src/components/header/title.js
+++ b/packages/story-editor/src/components/header/title.js
@@ -43,6 +43,8 @@ const Input = styled.input`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  border-radius: ${({ theme }) => theme.borders.radius.small};
+
   ${themeHelpers.focusableOutlineCSS};
 
   ${({ isHighlighted }) =>


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
The title input was missing focus outline

## Summary

<!-- A brief description of what this PR does. -->
Adds the focus outline to title input.

## Relevant Technical Choices
I was going to grab `Input` from design system, but the styling is quite different from our basic input so this seemed the better choice. 

Added radius, the outline looked a little weird with square corners
<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

![title](https://user-images.githubusercontent.com/1820266/159567876-8b4b1c71-d8ee-4742-8d90-bfbff0a6cfd4.gif)

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. tab to title input, you should see outline while the input is in focus


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10849 
