### PR TITLE
Floating Menus: Shapes, only show border options when locked

### DIFF
--- a/packages/story-editor/src/components/floatingMenu/elements/borderRadius.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/borderRadius.js
@@ -45,8 +45,14 @@ function BorderRadius() {
   // Only multi-border elements support border radius
   const canHaveBorderRadius = canSupportMultiBorder({ mask });
 
+  // We only allow editing the current border radii, if all corners are identical
+  const hasUniformBorder =
+    borderRadius.topLeft === borderRadius.topRight &&
+    borderRadius.topLeft === borderRadius.bottomLeft &&
+    borderRadius.topLeft === borderRadius.bottomRight;
+
   // Render nothing if radii not supported or not locked
-  if (!canHaveBorderRadius || !borderRadius.locked) {
+  if (!canHaveBorderRadius || (!borderRadius.locked && !hasUniformBorder)) {
     return null;
   }
 

--- a/packages/story-editor/src/components/floatingMenu/elements/borderWidthAndColor.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/borderWidthAndColor.js
@@ -28,7 +28,7 @@ import { canSupportMultiBorder } from '@googleforcreators/masks';
  */
 import { useStory } from '../../../app';
 import { DEFAULT_BORDER } from '../../panels/design/border/shared';
-import { Input, Color, useProperties } from './shared';
+import { Input, Color, Separator, useProperties } from './shared';
 
 const Container = styled.div`
   display: flex;
@@ -63,25 +63,23 @@ function BorderWidthAndColor() {
   const updateSelectedElements = useStory(
     (state) => state.actions.updateSelectedElements
   );
-
-  // Only multi-border elements support border opacity
-  const canHaveBorderOpacity = canSupportMultiBorder({ mask });
-
   // We only allow editing the current border width, if all borders are identical
   const hasUniformBorder =
     border.left === border.right &&
     border.left === border.top &&
     border.left === border.bottom;
 
+  // Border width and color inputs should only be rendered if all sides of the border are the same.
+  // Both checks are needed since not all shaped have lockedWidth eg. circles.
+  if (!border.lockedWidth && !hasUniformBorder) {
+    return null;
+  }
+
+  // Only multi-border elements support border opacity
+  const canHaveBorderOpacity = canSupportMultiBorder({ mask });
+
   // We only allow editing border color, if at least one border has a non-zero width
   const hasBorderWidth = getHasBorderWidth(border);
-
-  // If both controls are displayed, also add a dash between them
-  const hasBoth = hasUniformBorder && hasBorderWidth;
-
-  // NB: Note that it can never be the case, that both of the above bools, hasUniformBorder
-  // and hasBorderWidth, are false. If so, neither input would be shown. But because they
-  // partially contradict each other, one of the inputs will always render.
 
   const handleWidthChange = (value) => {
     trackEvent('floating_menu', {
@@ -121,30 +119,30 @@ function BorderWidthAndColor() {
   };
 
   return (
-    <Container>
-      {hasUniformBorder && (
+    <>
+      <Container>
         <Input
           suffix={<Icons.BorderBox />}
           value={border.left || 0}
           aria-label={__('Border width', 'web-stories')}
           onChange={(_, value) => handleWidthChange(value)}
         />
-      )}
-      {hasBoth && <Dash />}
-      {hasBorderWidth && (
-        <Color
-          label={__('Border color', 'web-stories')}
-          value={border.color || BLACK}
-          onChange={handleColorChange}
-          hasInputs={false}
-          hasEyedropper={false}
-          allowsOpacity={canHaveBorderOpacity}
-          allowsGradient={false}
-          pickerHasEyedropper={false} // override shared floating menu Color component TODO https://github.com/GoogleForCreators/web-stories-wp/issues/11024
-          allowsSavedColors={false}
-        />
-      )}
-    </Container>
+        {hasBorderWidth && (
+          <>
+            <Dash />
+            <Color
+              label={__('Border color', 'web-stories')}
+              value={border.color || BLACK}
+              onChange={handleColorChange}
+              hasInputs={false}
+              hasEyeDropper={false}
+              allowsOpacity={canHaveBorderOpacity}
+            />
+          </>
+        )}
+      </Container>
+      <Separator />
+    </>
   );
 }
 

--- a/packages/story-editor/src/components/floatingMenu/elements/karma/border.karma.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/karma/border.karma.js
@@ -59,7 +59,7 @@ describe('Design Menu: Border width & color', () => {
       );
     });
 
-    it('should render border width but only color once width is non-zero', async () => {
+    it('should render color once width is non-zero', async () => {
       expect(fixture.editor.canvas.designMenu.borderWidth).not.toBeNull();
       expect(fixture.editor.canvas.designMenu.borderColor).toBeNull();
 
@@ -90,7 +90,22 @@ describe('Design Menu: Border width & color', () => {
       expect(fixture.editor.canvas.designMenu.borderColor).not.toBeNull();
     });
 
-    it('should not render border width but still color if widths are uneven', async () => {
+    it('should render border width and color if widths are locked', async () => {
+      // Open style pane
+      await fixture.events.click(fixture.editor.inspector.designTab);
+
+      const panel = fixture.editor.inspector.designPanel.border;
+      await fixture.events.click(panel.width(), { clickCount: 3 });
+      await fixture.events.keyboard.type('10');
+      await fixture.events.keyboard.press('tab');
+
+      await fixture.events.click(panel.lockBorderWidth);
+
+      expect(fixture.editor.canvas.designMenu.borderWidth).not.toBeNull();
+      expect(fixture.editor.canvas.designMenu.borderColor).not.toBeNull();
+    });
+
+    it('should not render border width or color if widths are uneven', async () => {
       // Open style pane
       await fixture.events.click(fixture.editor.sidebar.designTab);
 
@@ -106,7 +121,7 @@ describe('Design Menu: Border width & color', () => {
       await fixture.events.keyboard.press('tab');
 
       expect(fixture.editor.canvas.designMenu.borderWidth).toBeNull();
-      expect(fixture.editor.canvas.designMenu.borderColor).not.toBeNull();
+      expect(fixture.editor.canvas.designMenu.borderColor).toBeNull();
     });
 
     it('should actually set the border width and color when updated', async () => {

--- a/packages/story-editor/src/components/floatingMenu/elements/karma/border.karma.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/karma/border.karma.js
@@ -92,9 +92,9 @@ describe('Design Menu: Border width & color', () => {
 
     it('should render border width and color if widths are locked', async () => {
       // Open style pane
-      await fixture.events.click(fixture.editor.inspector.designTab);
+      await fixture.events.click(fixture.editor.sidebar.designTab);
 
-      const panel = fixture.editor.inspector.designPanel.border;
+      const panel = fixture.editor.sidebar.designPanel.border;
       await fixture.events.click(panel.width(), { clickCount: 3 });
       await fixture.events.keyboard.type('10');
       await fixture.events.keyboard.press('tab');

--- a/packages/story-editor/src/components/floatingMenu/elements/karma/borderRadius.karma.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/karma/borderRadius.karma.js
@@ -64,7 +64,7 @@ describe('Design Menu: Border radius', () => {
     expect(fixture.editor.canvas.designMenu.borderRadius).toBeNull();
   });
 
-  it('should render for rectangular shape but only while radii are locked', async () => {
+  it('should render for rectangular shape but only while radii are equal', async () => {
     await fixture.events.click(fixture.editor.library.shapesTab);
     await waitFor(() => fixture.editor.library.shapes);
 
@@ -79,6 +79,10 @@ describe('Design Menu: Border radius', () => {
 
     const panel = fixture.editor.sidebar.designPanel.sizePosition;
     await fixture.events.click(panel.lockBorderRadius);
+
+    await fixture.events.click(panel.radius('Top left'), { clickCount: 3 });
+    await fixture.events.keyboard.type('10');
+    await fixture.events.keyboard.press('tab');
 
     expect(fixture.editor.canvas.designMenu.borderRadius).toBeNull();
   });

--- a/packages/story-editor/src/components/floatingMenu/menus/shape.js
+++ b/packages/story-editor/src/components/floatingMenu/menus/shape.js
@@ -48,8 +48,6 @@ const FloatingShapeMenu = memo(function FloatingShapeMenu() {
 
       <BorderWidthAndColor />
 
-      <Separator />
-
       <More />
 
       <Separator />


### PR DESCRIPTION
## Context
Floating menus for shapes had inconsistencies between when to show corner radius, border width, and border color. These features should work on the same logic for when to appear. 

Design is undecided on the border color functionality inside the floating menu when border radius or border widths are unlocked. For now, all these options including border color should be hidden if they are unlocked and the values are different. 

## Relevant Technical Choices
Since some shapes don't have `border.locked`, eg. circles, we need to check `!border.locked` or `!hasUniformBorder`. I choose to wait until both conditions were met. This allows the user to toggle borders open in the panel, but doesn't remove from floating menu until the sides are actually different. Made radius work with that same logic. 
 
<!-- Please describe your changes. -->

## To-do
@agingoldseco is still deciding what to do with colors / what to do when it is unlocked or there are variable width sides. 

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
|example||
|--|--|
|Circle|![circle](https://user-images.githubusercontent.com/1820266/159555853-f4d2b39d-d946-411a-9eb4-e60aedd12b93.gif)|
|Radius|![corner](https://user-images.githubusercontent.com/1820266/159555900-6316ec14-94e2-42be-ae3d-c15ee34f3c82.gif)|
|Border|![border](https://user-images.githubusercontent.com/1820266/159555933-6c9c58de-8aed-4cd2-a431-5e8191d5178c.gif)|

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. add a shape
2. change border toggle to unlocked
3. change the width of at least one side
4. once one side is different, the border options should be removed from floating toolbar. 
5. repeat for radius


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10992 
