### PR TITLE
Floating Menu: Fix "Saved Color" (gradient) as border color causes crash

### DIFF
--- a/packages/story-editor/src/components/colorPicker/basicColorPicker.js
+++ b/packages/story-editor/src/components/colorPicker/basicColorPicker.js
@@ -197,41 +197,40 @@ function BasicColorPicker({
             </StyledText>
           </EyedropperWrapper>
         )}
-        <SavedColors>
-          {allowsSavedColors && (
-            <>
-              <Label id="colorpicker-story-colors-title">
-                {__('Current story', 'web-stories')}
-              </Label>
-              <BasicColorList
-                color={color}
-                colors={storyColors}
-                handleClick={handleClick}
-                isLocal
-                allowsOpacity={allowsOpacity}
-                allowsGradient={allowsGradient}
-                aria-labelledby="colorpicker-story-colors-title"
-                isEditMode={isEditMode}
-                data-testid="saved-story-colors"
-                changedStyle={changedStyle}
-              />
-              <Label id="colorpicker-saved-colors-title">
-                {__('Saved colors', 'web-stories')}
-              </Label>
-              <BasicColorList
-                color={color}
-                colors={savedColors}
-                isGlobal
-                handleClick={handleClick}
-                allowsOpacity={allowsOpacity}
-                allowsGradient={allowsGradient}
-                aria-labelledby="colorpicker-saved-colors-title"
-                isEditMode={isEditMode}
-                changedStyle={changedStyle}
-              />
-            </>
-          )}
-        </SavedColors>
+        {allowsSavedColors && (
+          <SavedColors>
+            <Label id="colorpicker-story-colors-title">
+              {__('Current story', 'web-stories')}
+            </Label>
+            <BasicColorList
+              color={color}
+              colors={storyColors}
+              handleClick={handleClick}
+              isLocal
+              allowsOpacity={allowsOpacity}
+              allowsGradient={allowsGradient}
+              aria-labelledby="colorpicker-story-colors-title"
+              isEditMode={isEditMode}
+              data-testid="saved-story-colors"
+              changedStyle={changedStyle}
+            />
+            <Label id="colorpicker-saved-colors-title">
+              {__('Saved colors', 'web-stories')}
+            </Label>
+            <BasicColorList
+              color={color}
+              colors={savedColors}
+              isGlobal
+              handleClick={handleClick}
+              allowsOpacity={allowsOpacity}
+              allowsGradient={allowsGradient}
+              aria-labelledby="colorpicker-saved-colors-title"
+              isEditMode={isEditMode}
+              changedStyle={changedStyle}
+            />
+          </SavedColors>
+        )}
+
         <DefaultColors>
           <Label id="colorpicker-default-colors-title">
             {__('Default', 'web-stories')}

--- a/packages/story-editor/src/components/floatingMenu/elements/borderWidthAndColor.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/borderWidthAndColor.js
@@ -137,8 +137,10 @@ function BorderWidthAndColor() {
           value={border.color || BLACK}
           onChange={handleColorChange}
           hasInputs={false}
-          hasEyeDropper={false}
+          hasEyedropper={false}
           allowsOpacity={canHaveBorderOpacity}
+          pickerHasEyedropper={false} // override shared floating menu Color component TODO https://github.com/GoogleForCreators/web-stories-wp/issues/11024
+          allowsSavedColors={false} // if this changes to true, need to change allowsGradient to false because borders cannot be gradient.
         />
       )}
     </Container>

--- a/packages/story-editor/src/components/floatingMenu/elements/borderWidthAndColor.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/borderWidthAndColor.js
@@ -139,8 +139,9 @@ function BorderWidthAndColor() {
           hasInputs={false}
           hasEyedropper={false}
           allowsOpacity={canHaveBorderOpacity}
+          allowsGradient={false}
           pickerHasEyedropper={false} // override shared floating menu Color component TODO https://github.com/GoogleForCreators/web-stories-wp/issues/11024
-          allowsSavedColors={false} // if this changes to true, need to change allowsGradient to false because borders cannot be gradient.
+          allowsSavedColors={false}
         />
       )}
     </Container>


### PR DESCRIPTION
## Context

Saved colors can include gradients, but gradients shouldn't be border colors - that was causing the crash noted in bug bash.

## Summary

I chose to fix this by not showing saved colors in the border color popup of the floating menu because the border color popup in the style pane doesn't show saved colors either and this felt more consistent to me. 

That said, we should discuss (if this hasn't happened yet and I am just unaware) allowing saved styles for borders. I tried that first and it's fine as long as `allowsGradient` is false. There's be an update necessary in `useAddPreset` to grab a color from a border - right now that doesn't exist so adding a new saved color doesn't work. 

## Relevant Technical Choices

- Fixes a casing typo that doesn't really matter because it's false but still `hasEyeDropper` not `hasEyedropper`
- `pickerHasEyedropper` is set to false on the border color level to override the shared eyedropper setting in the floating menu color component.
- `allowsSavedColors` is overridden also so that it doesn't show by default. 

## To-do

While debugging this found that the eyedropper in the border color popup isn't actually getting the border color. I set `pickerHasEyedropper` to false so it's hidden for now but we should fix it. https://github.com/GoogleForCreators/web-stories-wp/issues/11024

## User-facing changes

| Broken | Fixed | 
| --- | --- | 
| https://user-images.githubusercontent.com/10720454/159569958-a9704fd0-ccc2-43e4-aa85-2770587d6b0f.mp4 | https://user-images.githubusercontent.com/10720454/159570083-84cdc6c2-1ce3-4bf8-8cea-a7208c76230a.mp4 |



## Testing Instructions

Give elements borders and border colors and see that it doesn't crash. 

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11019 
