### PR TITLE
Experiments: Turn Floating Menus off by default to properly go through QA

### DIFF
--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -357,7 +357,6 @@ class Experiments extends Service_Base implements HasRequirements {
 				'label'       => __( 'Floating Menu', 'web-stories' ),
 				'description' => __( 'Enable the new floating design menu', 'web-stories' ),
 				'group'       => 'editor',
-				'default'     => true,
 			],
 			/**
 			 * Author: @timarney


### PR DESCRIPTION
Turn experiment for floating menu back off because i did not send this through qa before merging it earlier today, got a little trigger happy. Will immediately make another PR to go through QA and then merge. Sorry everyone!
