### PR TITLE
Floating Menu: Fix Overlapping Section between 'colors' and 'more'.

### DIFF
--- a/packages/story-editor/src/components/form/color/color.js
+++ b/packages/story-editor/src/components/form/color/color.js
@@ -35,10 +35,10 @@ import {
 /**
  * Internal dependencies
  */
+import { MULTIPLE_VALUE } from '../../../constants';
 import useEyedropper from '../../eyedropper';
 import Tooltip from '../../tooltip';
 import { focusStyle } from '../../panels/shared';
-import { MULTIPLE_VALUE } from '../../../constants';
 import applyOpacityChange from './applyOpacityChange';
 import OpacityInput from './opacityInput';
 import ColorInput from './colorInput';

--- a/packages/story-editor/src/components/form/color/color.js
+++ b/packages/story-editor/src/components/form/color/color.js
@@ -47,6 +47,8 @@ import { SPACING } from './constants';
 const containerCss = css`
   display: flex;
   align-items: center;
+  width: ${({ width, ignoreWidth }) =>
+    (ignoreWidth && 'inherit') || (width ? `${width}px` : `100%`)};
 `;
 
 const Container = styled.section`
@@ -104,6 +106,7 @@ const Color = forwardRef(function Color(
   },
   ref
 ) {
+  console.log({ label, value });
   const handleOpacityChange = useCallback(
     (newOpacity) => onChange(applyOpacityChange(value, newOpacity)),
     [value, onChange]
@@ -128,8 +131,17 @@ const Color = forwardRef(function Color(
       ? TOOLTIP_PLACEMENT.BOTTOM
       : TOOLTIP_PLACEMENT.BOTTOM_START;
 
+  // Sometimes the value of the set color is "(MULTIPLE)", this is the only time the color comes back a string not an object.
+  // When there's multiple colors the input displays "Mixed" (in english) and takes up a different amount of space.
+  // By checking here to ignore that value based on mixed colors we prevent overlaps in any language too.
+  const ignoreSetWidth = typeof value === 'string';
   return (
-    <Container aria-label={containerLabel} isInDesignMenu={isInDesignMenu}>
+    <Container
+      aria-label={containerLabel}
+      isInDesignMenu={isInDesignMenu}
+      width={width}
+      ignoreWidth={ignoreSetWidth}
+    >
       {hasEyedropper && (
         <Tooltip
           title={tooltip}

--- a/packages/story-editor/src/components/form/color/color.js
+++ b/packages/story-editor/src/components/form/color/color.js
@@ -52,9 +52,12 @@ const containerCss = css`
 const Container = styled.section`
   ${containerCss}
   gap: ${({ isInDesignMenu }) => (isInDesignMenu ? 6 : 8)}px;
-  width: ${({ width, ignoreWidth }) =>
-    (ignoreWidth && 'inherit') || (width ? `${width}px` : `100%`)};
+  width: ${({ width }) => (width ? `${width}px` : 'inherit')};
 `;
+Container.propTypes = {
+  isInDesignMenu: PropTypes.bool,
+  width: PropTypes.string,
+};
 
 const ColorInputsWrapper = styled.div`
   ${containerCss}
@@ -133,13 +136,12 @@ const Color = forwardRef(function Color(
   // Sometimes there's more than 1 color to an element.
   // When there's multiple colors the input displays "Mixed" (in english) and takes up a different amount of space.
   // By checking here to ignore that value based on mixed colors we prevent visual spill over of content.
-  const ignoreSetWidth = value === MULTIPLE_VALUE;
+  const ignoreSetWidth = width && value === MULTIPLE_VALUE;
   return (
     <Container
       aria-label={containerLabel}
       isInDesignMenu={isInDesignMenu}
-      width={width}
-      ignoreWidth={ignoreSetWidth}
+      width={!ignoreSetWidth && width}
     >
       {hasEyedropper && (
         <Tooltip

--- a/packages/story-editor/src/components/form/color/color.js
+++ b/packages/story-editor/src/components/form/color/color.js
@@ -52,7 +52,6 @@ const containerCss = css`
 const Container = styled.section`
   ${containerCss}
   gap: ${({ isInDesignMenu }) => (isInDesignMenu ? 6 : 8)}px;
-  width: ${({ width }) => (width ? `${width}px` : `100%`)};
 `;
 
 const ColorInputsWrapper = styled.div`
@@ -130,11 +129,7 @@ const Color = forwardRef(function Color(
       : TOOLTIP_PLACEMENT.BOTTOM_START;
 
   return (
-    <Container
-      aria-label={containerLabel}
-      isInDesignMenu={isInDesignMenu}
-      width={width}
-    >
+    <Container aria-label={containerLabel} isInDesignMenu={isInDesignMenu}>
       {hasEyedropper && (
         <Tooltip
           title={tooltip}

--- a/packages/story-editor/src/components/form/color/color.js
+++ b/packages/story-editor/src/components/form/color/color.js
@@ -130,10 +130,10 @@ const Color = forwardRef(function Color(
       ? TOOLTIP_PLACEMENT.BOTTOM
       : TOOLTIP_PLACEMENT.BOTTOM_START;
 
-  // Sometimes the value of the set color is "(MULTIPLE)", this is the only time the color comes back a string not an object.
+  // Sometimes there's more than 1 color to an element.
   // When there's multiple colors the input displays "Mixed" (in english) and takes up a different amount of space.
-  // By checking here to ignore that value based on mixed colors we prevent overlaps in any language too.
-  const ignoreSetWidth = typeof value === 'string';
+  // By checking here to ignore that value based on mixed colors we prevent visual spill over of content.
+  const ignoreSetWidth = value === MULTIPLE_VALUE;
   return (
     <Container
       aria-label={containerLabel}

--- a/packages/story-editor/src/components/form/color/color.js
+++ b/packages/story-editor/src/components/form/color/color.js
@@ -47,13 +47,13 @@ import { SPACING } from './constants';
 const containerCss = css`
   display: flex;
   align-items: center;
-  width: ${({ width, ignoreWidth }) =>
-    (ignoreWidth && 'inherit') || (width ? `${width}px` : `100%`)};
 `;
 
 const Container = styled.section`
   ${containerCss}
   gap: ${({ isInDesignMenu }) => (isInDesignMenu ? 6 : 8)}px;
+  width: ${({ width, ignoreWidth }) =>
+    (ignoreWidth && 'inherit') || (width ? `${width}px` : `100%`)};
 `;
 
 const ColorInputsWrapper = styled.div`
@@ -106,7 +106,6 @@ const Color = forwardRef(function Color(
   },
   ref
 ) {
-  console.log({ label, value });
   const handleOpacityChange = useCallback(
     (newOpacity) => onChange(applyOpacityChange(value, newOpacity)),
     [value, onChange]

--- a/packages/story-editor/src/components/form/color/colorInput.js
+++ b/packages/story-editor/src/components/form/color/colorInput.js
@@ -272,7 +272,10 @@ const ColorInput = forwardRef(function ColorInput(
                 {/* We display Mixed value even without inputs */}
                 {isMixed && (
                   <MixedLabel>
-                    <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}>
+                    <Text
+                      size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}
+                      as="span"
+                    >
                       {MULTIPLE_DISPLAY_VALUE}
                     </Text>
                   </MixedLabel>


### PR DESCRIPTION
## Context

Bug identified in bugbash today where if a color input is 'mixed' (2 colors or more in an element) then that color input overlaps the 'more' button. 

## Summary

Checks for multiple color value in color input to override set width, allowing input to expand when needed.

## Relevant Technical Choices

When color value is `MULTIPLE_VALUE` override the asked for width in the input so that 'mixed' (or whatever the translated version of that is) can take up its needed space. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

| Broken | Fixed | 
| --- | --- | 
| <img width="211" alt="Screen Shot 2022-03-22 at 2 45 37 PM" src="https://user-images.githubusercontent.com/10720454/159581513-4984f20b-3ac1-4ed0-b03e-b0d583ecf68f.png"> | <img width="422" alt="Screen Shot 2022-03-22 at 2 46 28 PM" src="https://user-images.githubusercontent.com/10720454/159581617-39cb1032-80ce-462c-9b96-a670d4c563f9.png"> | 

## Testing Instructions

This Color section I removed width from is shared by all the color inputs so some regression testing around the color inputs in the various areas of the editor will be necessary. The ones I checked and am aware of before submitting this for review: Floating menu elements, style panel for borders, background color, foreground color, text color combos.

![color input change size](https://user-images.githubusercontent.com/10720454/159581705-6550b375-e815-4ba7-b7c4-a566bd143d8b.gif)


<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11018 
