### PR TITLE
Design System:  fix getoffset calculation for Popups

### DIFF
--- a/packages/design-system/src/components/popup/utils/getOffset.js
+++ b/packages/design-system/src/components/popup/utils/getOffset.js
@@ -25,7 +25,6 @@ export function getXOffset(
   dockRect,
   isRTL
 ) {
-  // TODO: https://github.com/GoogleForCreators/web-stories-wp/issues/10928
   // doctRect.left can have a valid value of zero, if dockRect exists, it takes precedence.
   const leftAligned = (dockRect ? dockRect.left : anchorRect.left) - spacing;
   const rightAligned = (dockRect ? dockRect.right : anchorRect.right) + spacing;

--- a/packages/design-system/src/components/popup/utils/getOffset.js
+++ b/packages/design-system/src/components/popup/utils/getOffset.js
@@ -30,7 +30,7 @@ export function getXOffset(
   const leftAligned = (dockRect ? dockRect.left : anchorRect.left) - spacing;
   const rightAligned = (dockRect ? dockRect.right : anchorRect.right) + spacing;
   const centerAligned = dockRect
-    ? dockRect.left
+    ? dockRect.left + dockRect.width / 2
     : anchorRect.left + anchorRect.width / 2;
 
   switch (placement) {

--- a/packages/design-system/src/components/popup/utils/getOffset.js
+++ b/packages/design-system/src/components/popup/utils/getOffset.js
@@ -26,14 +26,12 @@ export function getXOffset(
   isRTL
 ) {
   // TODO: https://github.com/GoogleForCreators/web-stories-wp/issues/10928
-  // doctRect?.left can have a valid value of zero, however in this case, the falsey
-  // value gets ignored and we end up using anchor.left. Additionally, if using `dock`
-  // anchor.width shouldn't need be added
-  const leftAligned = (dockRect?.left || anchorRect.left) - spacing;
-  const rightAligned =
-    (dockRect?.left || anchorRect.left) + anchorRect.width + spacing;
-  const centerAligned =
-    (dockRect?.left || anchorRect.left) + anchorRect.width / 2;
+  // doctRect.left can have a valid value of zero, if dockRect exists, it takes precedence.
+  const leftAligned = (dockRect ? dockRect.left : anchorRect.left) - spacing;
+  const rightAligned = (dockRect ? dockRect.right : anchorRect.right) + spacing;
+  const centerAligned = dockRect
+    ? dockRect.left
+    : anchorRect.left + anchorRect.width / 2;
 
   switch (placement) {
     case PLACEMENT.BOTTOM_START:

--- a/packages/story-editor/src/components/form/color/color.js
+++ b/packages/story-editor/src/components/form/color/color.js
@@ -124,10 +124,6 @@ const Color = forwardRef(function Color(
   });
   const tooltip = __('Pick a color from canvas', 'web-stories');
 
-  const spacing = hasEyedropper
-    ? SPACING.DEFAULT_SIDEBAR
-    : SPACING.SIDEBAR_WITHOUT_EYEDROPPER;
-
   const tooltipPlacement =
     isInDesignMenu || hasEyedropper
       ? TOOLTIP_PLACEMENT.BOTTOM
@@ -170,7 +166,9 @@ const Color = forwardRef(function Color(
             pickerPlacement={pickerPlacement}
             hasInputs={hasInputs}
             isInDesignMenu={isInDesignMenu}
-            spacing={isInDesignMenu ? SPACING.FLOATING_MENU : spacing}
+            spacing={
+              isInDesignMenu ? SPACING.FLOATING_MENU : SPACING.DEFAULT_SIDEBAR
+            }
             tooltipPlacement={tooltipPlacement}
             pickerProps={{
               allowsGradient,

--- a/packages/story-editor/src/components/form/color/colorInput.js
+++ b/packages/story-editor/src/components/form/color/colorInput.js
@@ -51,7 +51,6 @@ import useInspector from '../../inspector/useInspector';
 import DefaultTooltip from '../../tooltip';
 import { focusStyle, inputContainerStyleOverride } from '../../panels/shared';
 import { useCanvas, useConfig } from '../../../app';
-import { SPACING } from './constants';
 
 const Preview = styled.div`
   height: 36px;
@@ -228,8 +227,6 @@ const ColorInput = forwardRef(function ColorInput(
     ? minimalInputContainerStyleOverride
     : inputContainerStyleOverride;
 
-  const spacingAlignment = isRTL && !isInDesignMenu ? SPACING.IS_RTL : spacing;
-
   return (
     <>
       {isEditable ? (
@@ -294,7 +291,7 @@ const ColorInput = forwardRef(function ColorInput(
         dock={isInDesignMenu ? null : inspector}
         isOpen={pickerOpen}
         placement={dynamicPlacement}
-        spacing={spacingAlignment}
+        spacing={spacing}
         invisible={isEyedropperActive}
         topOffset={topOffset}
         refCallback={positionPlacement}

--- a/packages/story-editor/src/components/form/color/constants.js
+++ b/packages/story-editor/src/components/form/color/constants.js
@@ -13,11 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// TODO: https://github.com/GoogleForCreators/web-stories-wp/issues/10928
-// Weird spacing values for x are because of calculation bug in getOffset
 export const SPACING = {
   FLOATING_MENU: { x: 0, y: 12 },
-  DEFAULT_SIDEBAR: { x: 230, y: 0 },
-  SIDEBAR_WITHOUT_EYEDROPPER: { x: 208, y: 0 },
-  IS_RTL: { x: 12, y: 0 },
+  DEFAULT_SIDEBAR: { x: 12, y: 0 },
 };

--- a/packages/story-editor/src/components/panels/design/textStyle/stylePresets.js
+++ b/packages/story-editor/src/components/panels/design/textStyle/stylePresets.js
@@ -69,6 +69,8 @@ const NoStylesText = styled(Text)`
   color: ${({ theme }) => theme.colors.fg.tertiary};
 `;
 
+const SPACING = { x: 12 };
+
 function PresetPanel({ pushUpdate }) {
   const textStyles = useStory(
     ({ state }) => state.story.globalStoryStyles.textStyles
@@ -81,7 +83,6 @@ function PresetPanel({ pushUpdate }) {
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   const { isRTL, styleConstants: { topOffset } = {} } = useConfig();
   const hasPresets = textStyles.length > 0;
-  const spacing = { x: isRTL ? 12 : 46 };
 
   const handleApplyStyle = useApplyStyle({ pushUpdate });
   const { addGlobalPreset } = useAddPreset({ presetType: PRESET_TYPES.STYLE });
@@ -130,7 +131,7 @@ function PresetPanel({ pushUpdate }) {
             dock={inspector}
             isOpen={isPopupOpen}
             placement={PLACEMENT.RIGHT_START}
-            spacing={spacing}
+            spacing={SPACING}
             renderContents={() => (
               <StyleManager
                 styles={textStyles}


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

The background color picker popup is not respecting offset spacing in relation to it's docked element. 

## Summary
The background color picker popup was getting incorrect values for the inspector's `dock` `getXOffset`. Since those calculations were incorrect anyway, see #10928  I decided to fix the calculation instead of continuing to override spacing. 
If a Popup has an element it is docked against, the offset should be based on that dock regardless of it's values.

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
Updated the logic for calculating offset via `dock` element
Reset the spacing for color input and saves styles popups to only reflect expected margin from the docked element

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
### Before
| Border | Text color | Background |
| --- | --- | --- | 
| <img width="642" alt="Screen Shot 2022-03-22 at 10 52 21 AM" src="https://user-images.githubusercontent.com/10720454/159544407-be4a94e3-aa67-4cd6-91ae-455fcc96a76d.png"> | <img width="641" alt="Screen Shot 2022-03-22 at 10 52 28 AM" src="https://user-images.githubusercontent.com/10720454/159544434-8393b1da-1b0e-4618-b243-79b8c3c35dac.png"> | <img width="632" alt="Screen Shot 2022-03-22 at 10 52 35 AM" src="https://user-images.githubusercontent.com/10720454/159544471-3fcfc481-6c78-449c-a209-5972b4acb894.png"> | 

### After 
| Border | Text color | Background |
| --- | --- | --- | 
|<img width="640" alt="border" src="https://user-images.githubusercontent.com/1820266/159602613-af0e5eb2-f67b-48b4-b2b7-7e408d7a8fa2.png">|<img width="646" alt="Screen Shot 2022-03-22 at 7 15 14 PM" src="https://user-images.githubusercontent.com/1820266/159602627-21782f62-3a39-478b-8133-06a69e7c019a.png">|<img width="666" alt="background" src="https://user-images.githubusercontent.com/1820266/159602700-994609ae-c479-4975-a765-2ad4b4fd13a7.png">|

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Open each color picker; check if it is rendered in the correct spot. 
- background color
- shape color
- text color
- border color shape
- image filters
- image borders
- floating menus
2. Check Saved Styles popup is docked to the sidebar as well
3. Check for regressions on all tooltips in editor and on dashboard (Sorry it's a lot) 
4. Don't forget RTL


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11020 
Partially Fixes #10928 
