### PR TITLE
Font picker: fix preview of custom fonts

### DIFF
--- a/packages/story-editor/src/app/font/fontProvider.js
+++ b/packages/story-editor/src/app/font/fontProvider.js
@@ -59,10 +59,11 @@ function FontProvider({ children }) {
     }
 
     const formattedFonts = _customFonts.map((font) => ({
+      ...font,
+      // The font picker & preview expects the ID to be the font family name.
       id: font.family,
       name: font.family,
       value: font.family,
-      ...font,
     }));
 
     setCustomFonts(formattedFonts);
@@ -193,7 +194,8 @@ function FontProvider({ children }) {
   const ensureCustomFontsLoaded = useCallback(
     (fontsToLoad) => {
       for (const font of fontsToLoad) {
-        const fontObj = fonts.find(({ family }) => family === font);
+        const fontObj = customFonts.find(({ family }) => family === font);
+
         if (!fontObj) {
           continue;
         }
@@ -201,7 +203,7 @@ function FontProvider({ children }) {
         maybeLoadFont(fontObj);
       }
     },
-    [fonts, maybeLoadFont]
+    [customFonts, maybeLoadFont]
   );
 
   const state = {

--- a/packages/story-editor/src/components/fontPicker/index.js
+++ b/packages/story-editor/src/components/fontPicker/index.js
@@ -79,8 +79,13 @@ const FontPicker = forwardRef(function FontPicker(
     fonts.forEach((f) => {
       map.set(f.id, f);
     });
+
+    customFonts?.forEach((f) => {
+      map.set(f.id, f);
+    });
+
     return map;
-  }, [fonts]);
+  }, [fonts, customFonts]);
 
   const onObserve = useCallback(
     (observedFonts) => {


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

As per #11048, loading the stylesheets for custom fonts in the font picker was broken. Probably happened because of some refactoring.

## Summary

<!-- A brief description of what this PR does. -->

This fixes the fonts preview in the font picker, ensuring that the font objects have the expected format and fonts are being looked up in the right place.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->


https://user-images.githubusercontent.com/841956/159719343-1e8e3e69-d7c8-4e12-b305-45f97966a42d.mov



## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add some custom fonts on the settings page
2. Create a new story
3. Add text element
4. Open the font picker and see the custom fonts being displayed with their actual expected style


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11048
