### PR TITLE
Quick Actions: when no actions present don't render menu

### DIFF
--- a/packages/story-editor/src/components/canvas/karma/quickActions.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/quickActions.karma.js
@@ -56,6 +56,60 @@ describe('Quick Actions integration', () => {
 
       expect(fixture.screen.queryByTestId('quick-actions-menu')).toBeNull();
     });
+
+    it('quick menu should not be visible if no quick actions are present', async () => {
+      // when two different elements types are selected, there may not be any quick actions to show
+      // in that case, we shouldn't be rendering the context menu at all
+      const insertElement = await fixture.renderHook(() => useInsertElement());
+      const shapeElement = await fixture.act(() =>
+        insertElement('shape', {
+          backgroundColor: {
+            color: {
+              r: 203,
+              g: 103,
+              b: 103,
+            },
+          },
+          type: 'shape',
+          x: 48,
+          y: 0,
+          width: 148,
+          height: 137,
+          scale: 100,
+          focalX: 50,
+          focalY: 50,
+          mask: {
+            type: 'heart',
+          },
+          id: 'cb89750a-3ffd-4876-8ed9-d715c553e05b',
+          link: null,
+        })
+      );
+
+      await fixture.act(() =>
+        insertElement('text', {
+          font: TEXT_ELEMENT_DEFAULT_FONT,
+          content: 'Hello world!',
+          x: 10,
+          y: 20,
+          width: 400,
+        })
+      );
+
+      await fixture.editor.canvas.framesLayer.waitFocusedWithin();
+
+      expect(
+        fixture.screen.queryByTestId('Element quick actions')
+      ).not.toBeNull();
+
+      await fixture.events.keyboard.down('Shift');
+      await clickOnTarget(
+        fixture.editor.canvas.framesLayer.frame(shapeElement.id).node
+      );
+      await fixture.events.keyboard.up('Shift');
+
+      expect(fixture.screen.queryByTestId('Element quick actions')).toBeNull();
+    });
   });
 
   describe('quick action menu should have no aXe accessibility violations', () => {

--- a/packages/story-editor/src/components/canvas/karma/quickActions.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/quickActions.karma.js
@@ -60,52 +60,27 @@ describe('Quick Actions integration', () => {
     it('quick menu should not be visible if no quick actions are present', async () => {
       // when two different elements types are selected, there may not be any quick actions to show
       // in that case, we shouldn't be rendering the context menu at all
-      const insertElement = await fixture.renderHook(() => useInsertElement());
-      const shapeElement = await fixture.act(() =>
-        insertElement('shape', {
-          backgroundColor: {
-            color: {
-              r: 203,
-              g: 103,
-              b: 103,
-            },
-          },
-          type: 'shape',
-          x: 48,
-          y: 0,
-          width: 148,
-          height: 137,
-          scale: 100,
-          focalX: 50,
-          focalY: 50,
-          mask: {
-            type: 'heart',
-          },
-          id: 'cb89750a-3ffd-4876-8ed9-d715c553e05b',
-          link: null,
-        })
+      // add shape to canvas
+      await fixture.editor.library.shapesTab.click();
+      await fixture.events.click(
+        fixture.editor.library.shapes.shape('Triangle')
       );
 
-      await fixture.act(() =>
-        insertElement('text', {
-          font: TEXT_ELEMENT_DEFAULT_FONT,
-          content: 'Hello world!',
-          x: 10,
-          y: 20,
-          width: 400,
-        })
+      // add text to canvas
+      await fixture.editor.library.textTab.click();
+      await fixture.events.click(
+        fixture.editor.library.text.preset('Paragraph')
       );
-
       await fixture.editor.canvas.framesLayer.waitFocusedWithin();
 
       expect(
         fixture.screen.queryByTestId('Element quick actions')
       ).not.toBeNull();
 
+      // select both text and shape elements
       await fixture.events.keyboard.down('Shift');
-      await clickOnTarget(
-        fixture.editor.canvas.framesLayer.frame(shapeElement.id).node
-      );
+      const triangle = fixture.editor.canvas.framesLayer.frames[1].node;
+      await clickOnTarget(triangle);
       await fixture.events.keyboard.up('Shift');
 
       expect(fixture.screen.queryByTestId('Element quick actions')).toBeNull();

--- a/packages/story-editor/src/components/canvas/pageSideMenu.js
+++ b/packages/story-editor/src/components/canvas/pageSideMenu.js
@@ -77,69 +77,77 @@ function PageSideMenu() {
       aria-label={__('Page side menu', 'web-stories')}
       isZoomed={isZoomed}
     >
-      <ContextMenu
-        isInline
-        isAlwaysVisible
-        isIconMenu
-        disableControlledTabNavigation
-        aria-label={__(
-          'Group of available options for selected element',
-          'web-stories'
-        )}
-        onMouseDown={(e) => {
-          // Stop the event from bubbling if the user clicks in between buttons.
-          // This prevents the selected element in the canvas from losing focus.
-          e.stopPropagation();
-        }}
-      >
-        {quickActions.map(
-          ({
-            Icon,
-            label,
-            onClick,
-            separator,
-            tooltipPlacement,
-            wrapWithMediaPicker,
-            ...quickAction
-          }) => {
-            const action = (externalOnClick = noop) => (
-              <Fragment key={label}>
-                {separator === 'top' && <ContextMenuComponents.MenuSeparator />}
-                <Tooltip placement={tooltipPlacement} title={label}>
-                  <ContextMenuComponents.MenuButton
-                    aria-label={label}
-                    onClick={(evt) => {
-                      onClick(evt);
-                      externalOnClick(evt);
-                    }}
-                    {...quickAction}
-                  >
-                    <ContextMenuComponents.MenuIcon title={label}>
-                      <Icon />
-                    </ContextMenuComponents.MenuIcon>
-                  </ContextMenuComponents.MenuButton>
-                </Tooltip>
-                {separator === 'bottom' && (
-                  <ContextMenuComponents.MenuSeparator />
-                )}
-              </Fragment>
-            );
+      {
+        // Dont render a menu wrapper if there are no quick actions
+        quickActions.length ? (
+          <ContextMenu
+            isInline
+            isAlwaysVisible
+            isIconMenu
+            disableControlledTabNavigation
+            data-testid={'Element quick actions'}
+            aria-label={__(
+              'Group of available options for selected element',
+              'web-stories'
+            )}
+            onMouseDown={(e) => {
+              // Stop the event from bubbling if the user clicks in between buttons.
+              // This prevents the selected element in the canvas from losing focus.
+              e.stopPropagation();
+            }}
+          >
+            {quickActions.map(
+              ({
+                Icon,
+                label,
+                onClick,
+                separator,
+                tooltipPlacement,
+                wrapWithMediaPicker,
+                ...quickAction
+              }) => {
+                const action = (externalOnClick = noop) => (
+                  <Fragment key={label}>
+                    {separator === 'top' && (
+                      <ContextMenuComponents.MenuSeparator />
+                    )}
+                    <Tooltip placement={tooltipPlacement} title={label}>
+                      <ContextMenuComponents.MenuButton
+                        aria-label={label}
+                        onClick={(evt) => {
+                          onClick(evt);
+                          externalOnClick(evt);
+                        }}
+                        {...quickAction}
+                      >
+                        <ContextMenuComponents.MenuIcon title={label}>
+                          <Icon />
+                        </ContextMenuComponents.MenuIcon>
+                      </ContextMenuComponents.MenuButton>
+                    </Tooltip>
+                    {separator === 'bottom' && (
+                      <ContextMenuComponents.MenuSeparator />
+                    )}
+                  </Fragment>
+                );
 
-            if (wrapWithMediaPicker) {
-              return (
-                <MediaPicker
-                  key={label}
-                  render={({ onClick: openMediaPicker }) =>
-                    action(openMediaPicker)
-                  }
-                />
-              );
-            }
+                if (wrapWithMediaPicker) {
+                  return (
+                    <MediaPicker
+                      key={label}
+                      render={({ onClick: openMediaPicker }) =>
+                        action(openMediaPicker)
+                      }
+                    />
+                  );
+                }
 
-            return action();
-          }
-        )}
-      </ContextMenu>
+                return action();
+              }
+            )}
+          </ContextMenu>
+        ) : null
+      }
       {isZoomed && <Divider />}
       <PageMenu />
     </MenusWrapper>

--- a/packages/story-editor/src/components/canvas/pageSideMenu.js
+++ b/packages/story-editor/src/components/canvas/pageSideMenu.js
@@ -85,7 +85,7 @@ function PageSideMenu() {
             isAlwaysVisible
             isIconMenu
             disableControlledTabNavigation
-            data-testid={'Element quick actions'}
+            data-testid="Element quick actions"
             aria-label={__(
               'Group of available options for selected element',
               'web-stories'


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
If you select two differing element types, the quick actions context menu renders an empty box. Let's not do that. 

## Relevant Technical Choices
Checks if there are any quick actions, if not, don't render the context menu at all .
Added a `data-testid` since I wasn't sure how else to check for `null` on this context menu. 🤔 

<!-- Please describe your changes. -->

## User-facing changes
|🙃|🙂|
|--|--|
|<img width="553" alt="Screen Shot 2022-03-23 at 3 58 49 PM" src="https://user-images.githubusercontent.com/1820266/159802969-1b366269-a75c-4542-83f5-613dbf063045.png">|<img width="466" alt="Screen Shot 2022-03-23 at 3 56 01 PM" src="https://user-images.githubusercontent.com/1820266/159802978-bec38c96-20cc-412b-937b-fbafd52514d4.png">|

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. add two different element types to a page and selected them both.
2. notice no empty box were quick actions should be


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist
no
<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10950 
