### PR TITLE
Video: Improved handling of video play button

### DIFF
--- a/packages/element-library/src/video/playPauseButton.js
+++ b/packages/element-library/src/video/playPauseButton.js
@@ -223,7 +223,7 @@ function PlayPauseButton({
       videoNode.pause();
       setShowControls(true);
     } else {
-      videoNode.play();
+      videoNode.play().catch(() => {});
     }
   };
   useKeyDownEffect(

--- a/packages/element-library/src/video/playPauseButton.js
+++ b/packages/element-library/src/video/playPauseButton.js
@@ -183,7 +183,7 @@ function PlayPauseButton({
       videoNode.removeEventListener('play', onVideoPlay);
       videoNode.removeEventListener('pause', onVideoPause);
     };
-  }, [shouldResetOnEnd, getVideoNode, id]);
+  }, [getVideoNode, id]);
 
   const checkShowControls = useDebouncedCallback(() => {
     if (!isPlayAbove) {

--- a/packages/element-library/src/video/playPauseButton.js
+++ b/packages/element-library/src/video/playPauseButton.js
@@ -159,20 +159,29 @@ function PlayPauseButton({
       return undefined;
     }
 
-    const onVideoPlay = () => setIsPlaying(true);
-    const onVideoPause = () => setIsPlaying(false);
     const onVideoEnd = () => {
       videoNode.currentTime = 0;
       setIsPlaying(false);
     };
 
+    videoNode.addEventListener('ended', onVideoEnd);
+    return () => videoNode.removeEventListener('ended', onVideoEnd);
+  }, [shouldResetOnEnd, getVideoNode, id]);
+
+  useEffect(() => {
+    const videoNode = getVideoNode();
+    if (!videoNode) {
+      return undefined;
+    }
+
+    const onVideoPlay = () => setIsPlaying(true);
+    const onVideoPause = () => setIsPlaying(false);
+
     videoNode.addEventListener('play', onVideoPlay);
     videoNode.addEventListener('pause', onVideoPause);
-    videoNode.addEventListener('ended', onVideoEnd);
     return () => {
       videoNode.removeEventListener('play', onVideoPlay);
       videoNode.removeEventListener('pause', onVideoPause);
-      videoNode.removeEventListener('ended', onVideoEnd);
     };
   }, [shouldResetOnEnd, getVideoNode, id]);
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Videos can be play / paused using media controls in the browser. ( See video ). But the play / pause button does not respect that.

## Relevant Technical Choices

This PR, make code simplier, but treating the video tags, play / pause events as a point of trust on if the video is playing or not. Removing a lot of logic. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

https://user-images.githubusercontent.com/237508/160124232-76d50e02-ec2f-4b43-8529-f2be8eadb628.mov

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Create story
2. Insert a video ( video must have audio ).
3. Start video playing. 
4. Use chrome media controls / media keys on keyboard. 


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11068
