### PR TITLE
Dynamically import `opentype.js` in `getFontDataFromUrl`

### DIFF
--- a/packages/wp-dashboard/src/components/editorSettings/customFonts/utils/getFontDataFromUrl.js
+++ b/packages/wp-dashboard/src/components/editorSettings/customFonts/utils/getFontDataFromUrl.js
@@ -15,11 +15,6 @@
  */
 
 /**
- * External dependencies
- */
-import { load } from 'opentype.js';
-
-/**
  * @typedef {Object} FontMetrics font metrics.
  * @property {number} upm units per em.
  * @property {number} asc ascender.
@@ -45,6 +40,9 @@ import { load } from 'opentype.js';
  * @return {Object} Font data, including metrics, name.
  */
 async function getFontDataFromUrl(fontURL) {
+  const { load } = await import(
+    /* webpackChunkName: "chunk-opentype" */ 'opentype.js'
+  );
   const fontInfo = await load(fontURL);
 
   return {


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

As per the title, it would be good to only import this on the fly.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10275
