### PR TITLE
Dashboard: dynamically import templates package

### DIFF
--- a/packages/dashboard/src/app/api/useTemplateApi.js
+++ b/packages/dashboard/src/app/api/useTemplateApi.js
@@ -19,7 +19,7 @@
  */
 import { useCallback, useReducer } from '@googleforcreators/react';
 import { compareDesc } from '@googleforcreators/date';
-import { getAllTemplates } from '@googleforcreators/templates';
+
 /**
  * Internal dependencies
  */
@@ -41,6 +41,10 @@ const useTemplateApi = () => {
     });
 
     const templatesByTag = {};
+
+    const { getAllTemplates } = await import(
+      /* webpackChunkName: "chunk-web-stories-templates" */ '@googleforcreators/templates'
+    );
 
     const reshapedTemplates = (await getAllTemplates({ cdnURL }))
       .map((template) => {

--- a/packages/dashboard/src/components/navProvider.js
+++ b/packages/dashboard/src/components/navProvider.js
@@ -35,22 +35,17 @@ export function useNavContext(selector = identity) {
 
 export default function NavProvider({ children }) {
   const [sideBarVisible, setSideBarVisible] = useState(false);
-  const [numNewTemplates, setNumNewTemplates] = useState(0);
 
   const toggleSideBar = useCallback(() => {
     setSideBarVisible(!sideBarVisible);
   }, [sideBarVisible]);
 
-  const updateNumNewTemplates = useCallback((newNum) => {
-    setNumNewTemplates(newNum);
-  }, []);
-
   const value = useMemo(
     () => ({
-      actions: { toggleSideBar, updateNumNewTemplates },
-      state: { sideBarVisible, numNewTemplates },
+      actions: { toggleSideBar },
+      state: { sideBarVisible },
     }),
-    [numNewTemplates, sideBarVisible, toggleSideBar, updateNumNewTemplates]
+    [sideBarVisible, toggleSideBar]
   );
 
   return <NavContext.Provider value={value}>{children}</NavContext.Provider>;

--- a/packages/dashboard/src/components/pageStructure/leftRail.js
+++ b/packages/dashboard/src/components/pageStructure/leftRail.js
@@ -24,7 +24,6 @@ import {
   useRef,
 } from '@googleforcreators/react';
 import { trackClick, trackEvent } from '@googleforcreators/tracking';
-import { getTemplateMetaData } from '@googleforcreators/templates';
 import { __, sprintf } from '@googleforcreators/i18n';
 import {
   Button,
@@ -141,6 +140,9 @@ function LeftRail() {
     let mounted = true;
 
     async function refreshNewTemplateCount() {
+      const { getTemplateMetaData } = await import(
+        /* webpackChunkName: "chunk-web-stories-templates" */ '@googleforcreators/templates'
+      );
       const metaData = await getTemplateMetaData();
       if (metaData) {
         const newTemplates = getNewTemplatesMetaData(

--- a/packages/dashboard/src/components/pageStructure/test/pageStructure.js
+++ b/packages/dashboard/src/components/pageStructure/test/pageStructure.js
@@ -36,9 +36,8 @@ describe('<LeftRail />', () => {
         value={{
           actions: {
             toggleSideBar: toggleSideBarFn,
-            updateNumNewTemplates: () => {},
           },
-          state: { sideBarVisible: false, numNewTemplates: 0 },
+          state: { sideBarVisible: false },
         }}
       >
         {children}


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

I stumbled upon the `@googleforcreators/templates` imports in the dashboard and was wondering whether we can improve them.

## Summary

<!-- A brief description of what this PR does. -->

This PR includes two changes:

* Remove the notification count/bubble for new templates
  This essentially reverts #11083. We're not planning on adding new templates, so removing this count means we can avoid unnecessary imports on the main page.
* Dynamically import templates on the dashboard / the templates view
  This way they should end up in a separate chunk and only be loaded on the templates page

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

None

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Visit the Dashboard and afterwards the Explore Templates page
2. Notice the templates chunks only being loaded once going to the Explore Templates page


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
Reverts #8728