### PR TITLE
Custom Fonts: Error handling for failed delete 

### DIFF
--- a/packages/wp-dashboard/src/api/hooks/useFontsApi.js
+++ b/packages/wp-dashboard/src/api/hooks/useFontsApi.js
@@ -55,14 +55,7 @@ export default function useFontsApi() {
   }, [fetchCustomFonts, customFonts]);
 
   const deleteCustomFont = useCallback(
-    async (id) => {
-      try {
-        const response = await deleteCustomFontCallback(fontsApiPath, id);
-        return response;
-      } catch (e) {
-        return null;
-      }
-    },
+    (id) => deleteCustomFontCallback(fontsApiPath, id),
     [fontsApiPath]
   );
 

--- a/packages/wp-dashboard/src/components/editorSettings/customFonts/index.js
+++ b/packages/wp-dashboard/src/components/editorSettings/customFonts/index.js
@@ -35,6 +35,7 @@ import {
   THEME_CONSTANTS,
   Tooltip,
   themeHelpers,
+  useSnackbar,
 } from '@googleforcreators/design-system';
 import styled from 'styled-components';
 import { trackEvent, trackError } from '@googleforcreators/tracking';
@@ -52,6 +53,7 @@ import {
   SettingSubheading,
   TextInputHelperText,
 } from '../components';
+import { ERRORS } from '../../../constants';
 import ConfirmationDialog from './confirmationDialog';
 import getFontDataFromUrl from './utils/getFontDataFromUrl';
 
@@ -179,6 +181,7 @@ function CustomFontsSettings({
   const currentFontsRowsRef = useRef([]);
   const [currentFontsFocusIndex, setCurrentFontsFocusIndex] = useState(0);
   const [currentFontsActiveId, setCurrentFontsActiveId] = useState();
+  const { showSnackbar } = useSnackbar();
 
   const handleUpdateFontUrl = useCallback((event) => {
     const { value } = event.target;
@@ -194,10 +197,20 @@ function CustomFontsSettings({
   }, []);
 
   const handleDelete = useCallback(async () => {
-    await deleteCustomFont(toDelete);
-    await fetchCustomFonts();
-    setToDelete(null);
-    setShowDialog(false);
+    try {
+      await deleteCustomFont(toDelete);
+      await fetchCustomFonts();
+    } catch (err) {
+      trackError('remove_custom_font', err?.message);
+      showSnackbar({
+        'aria-label': ERRORS.REMOVE_FONT.MESSAGE,
+        message: ERRORS.REMOVE_FONT.MESSAGE,
+        dismissible: true,
+      });
+    } finally {
+      setToDelete(null);
+      setShowDialog(false);
+    }
   }, [toDelete, deleteCustomFont, fetchCustomFonts]);
 
   const handleOnSave = useCallback(async () => {

--- a/packages/wp-dashboard/src/components/editorSettings/customFonts/index.js
+++ b/packages/wp-dashboard/src/components/editorSettings/customFonts/index.js
@@ -211,7 +211,7 @@ function CustomFontsSettings({
       setToDelete(null);
       setShowDialog(false);
     }
-  }, [toDelete, deleteCustomFont, fetchCustomFonts]);
+  }, [deleteCustomFont, toDelete, fetchCustomFonts, showSnackbar]);
 
   const handleOnSave = useCallback(async () => {
     if (canSave) {

--- a/packages/wp-dashboard/src/constants/textConstants.js
+++ b/packages/wp-dashboard/src/constants/textConstants.js
@@ -32,6 +32,9 @@ export const ERRORS = {
   REMOVE_PUBLISHER_LOGO: {
     MESSAGE: __('Unable to remove publisher logo', 'web-stories'),
   },
+  REMOVE_FONT: {
+    MESSAGE: __('Unable to remove font', 'web-stories'),
+  },
   UPDATE_PUBLISHER_LOGO: {
     MESSAGE: __('Unable to update publisher logo', 'web-stories'),
   },


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

If a user tries to delete a custom font but the REST API request failing, there is show an error message.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

https://user-images.githubusercontent.com/237508/160143997-d91bcaec-478d-455e-b798-becd09e29f3d.mov

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.Login as admin.
1. Go setting panel.
1. Open another window.
1. To WordPress CMS.
1. Logout.
1. To back to original window.
1. Try to delete font.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10998
