### PR TITLE
Context Menu: Prevent auto focus when already focused

### DIFF
--- a/packages/design-system/src/components/contextMenu/menu.js
+++ b/packages/design-system/src/components/contextMenu/menu.js
@@ -128,6 +128,13 @@ const Menu = ({
   const menuRef = useRef(null);
   const composedListRef = useCombinedRefs(mouseDownOutsideRef, menuRef);
 
+  /**
+   * Focus the first element when the user focuses the wrapper
+   * with their keyboard.
+   *
+   * Clicking in the wrapper should not automatically focus the first
+   * focusable element.
+   */
   const handleFocus = useCallback(
     (evt) => {
       onFocus(evt);

--- a/packages/design-system/src/components/contextMenu/menu.js
+++ b/packages/design-system/src/components/contextMenu/menu.js
@@ -132,9 +132,11 @@ const Menu = ({
     (evt) => {
       onFocus(evt);
 
-      const focusableChildren = getFocusableChildren(menuRef.current);
-
-      if (menuRef.current === evt.target) {
+      if (
+        menuRef.current === evt.target &&
+        !menuRef.current.contains(evt.target)
+      ) {
+        const focusableChildren = getFocusableChildren(menuRef.current);
         focusableChildren?.[0]?.focus();
       }
     },

--- a/packages/story-editor/src/components/floatingMenu/elements/borderWidthAndColor.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/borderWidthAndColor.js
@@ -28,7 +28,7 @@ import { canSupportMultiBorder } from '@googleforcreators/masks';
  */
 import { useStory } from '../../../app';
 import { DEFAULT_BORDER } from '../../panels/design/border/shared';
-import { Input, Color, Separator, useProperties } from './shared';
+import { Input, Color, useProperties } from './shared';
 
 const Container = styled.div`
   display: flex;
@@ -119,30 +119,27 @@ function BorderWidthAndColor() {
   };
 
   return (
-    <>
-      <Container>
-        <Input
-          suffix={<Icons.BorderBox />}
-          value={border.left || 0}
-          aria-label={__('Border width', 'web-stories')}
-          onChange={(_, value) => handleWidthChange(value)}
-        />
-        {hasBorderWidth && (
-          <>
-            <Dash />
-            <Color
-              label={__('Border color', 'web-stories')}
-              value={border.color || BLACK}
-              onChange={handleColorChange}
-              hasInputs={false}
-              hasEyeDropper={false}
-              allowsOpacity={canHaveBorderOpacity}
-            />
-          </>
-        )}
-      </Container>
-      <Separator />
-    </>
+    <Container>
+      <Input
+        suffix={<Icons.BorderBox />}
+        value={border.left || 0}
+        aria-label={__('Border width', 'web-stories')}
+        onChange={(_, value) => handleWidthChange(value)}
+      />
+      {hasBorderWidth && (
+        <>
+          <Dash />
+          <Color
+            label={__('Border color', 'web-stories')}
+            value={border.color || BLACK}
+            onChange={handleColorChange}
+            hasInputs={false}
+            hasEyeDropper={false}
+            allowsOpacity={canHaveBorderOpacity}
+          />
+        </>
+      )}
+    </Container>
   );
 }
 

--- a/packages/story-editor/src/components/floatingMenu/menus/shape.js
+++ b/packages/story-editor/src/components/floatingMenu/menus/shape.js
@@ -48,6 +48,8 @@ const FloatingShapeMenu = memo(function FloatingShapeMenu() {
 
       <BorderWidthAndColor />
 
+      <Separator />
+
       <More />
 
       <Separator />


### PR DESCRIPTION
## Context



## Summary

Clicking on the menu away from buttons and interactive elements no longer auto focuses the first focusable element.

## Relevant Technical Choices

`handleFocus` focuses the first focusable element in the context menu when the wrapper is focused. This is important when using keyboard, but if a user clicks the menu then it should not run.
https://github.com/GoogleForCreators/web-stories-wp/blob/90ca2edffaf12f1c9c4082b310d57eaf17d2addd/packages/design-system/src/components/contextMenu/menu.js#L131-L142

## To-do

n/a

## User-facing changes

|Before|After|
|--|--|
|![before](https://user-images.githubusercontent.com/22185279/160187358-5375ba36-f06c-4891-a819-700d9ee61c15.gif)|![after](https://user-images.githubusercontent.com/22185279/160187368-26829fa1-8c29-4171-acf1-1516ebdb6515.gif)|

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add an image to the canvas.
2. Click on the border input in the floating menu.
3. Click the menu or the icon in the input. The input should blur, but the opacity input should not be focused.


## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11088
