### PR TITLE
Fix issues related to selecting all text

### DIFF
--- a/packages/rich-text/src/editor.js
+++ b/packages/rich-text/src/editor.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { Editor } from 'draft-js';
+import { Editor, getDefaultKeyBinding, KeyBindingUtil } from 'draft-js';
 import PropTypes from 'prop-types';
 import {
   useEffect,
@@ -82,6 +82,15 @@ function RichTextEditor({ content, onChange }, ref) {
     return null;
   }
 
+  const { hasCommandModifier } = KeyBindingUtil;
+
+  function bindKeys(e) {
+    if (e.code === 'KeyA' && hasCommandModifier(e)) {
+      return 'selectall';
+    }
+    return getDefaultKeyBinding(e);
+  }
+
   // Handle basic key commands such as bold, italic and underscore.
   const handleKeyCommand = getHandleKeyCommand();
   return (
@@ -91,6 +100,7 @@ function RichTextEditor({ content, onChange }, ref) {
       editorState={editorState}
       handleKeyCommand={handleKeyCommand}
       handlePastedText={handlePastedText}
+      keyBindingFn={bindKeys}
       customStyleFn={customInlineDisplay}
       spellCheck
       stripPastedStyles

--- a/packages/rich-text/src/editor.js
+++ b/packages/rich-text/src/editor.js
@@ -85,7 +85,7 @@ function RichTextEditor({ content, onChange }, ref) {
   const { hasCommandModifier } = KeyBindingUtil;
 
   function bindKeys(e) {
-    if (e.code === 'KeyA' && hasCommandModifier(e)) {
+    if (e.code === 'KeyAX' && hasCommandModifier(e)) {
       return 'selectall';
     }
     return getDefaultKeyBinding(e);

--- a/packages/rich-text/src/editor.js
+++ b/packages/rich-text/src/editor.js
@@ -85,7 +85,7 @@ function RichTextEditor({ content, onChange }, ref) {
   const { hasCommandModifier } = KeyBindingUtil;
 
   function bindKeys(e) {
-    if (e.code === 'KeyAX' && hasCommandModifier(e)) {
+    if (e.code === 'KeyA' && hasCommandModifier(e)) {
       return 'selectall';
     }
     return getDefaultKeyBinding(e);

--- a/packages/rich-text/src/util.js
+++ b/packages/rich-text/src/util.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { SelectionState } from 'draft-js';
+import { EditorState, SelectionState } from 'draft-js';
 import { filterEditorState } from 'draftjs-filters';
 
 /**
@@ -62,6 +62,12 @@ function getStateFromCommmand(command, oldEditorState) {
 
     case 'uppercase':
       return uppercaseFormatter.setters.toggleUppercase(oldEditorState);
+
+    case 'selectall':
+      return EditorState.forceSelection(
+        oldEditorState,
+        getSelectionForAll(oldEditorState.getCurrentContent())
+      );
 
     default:
       return null;

--- a/packages/story-editor/src/karma/element-library/text/edit.karma.js
+++ b/packages/story-editor/src/karma/element-library/text/edit.karma.js
@@ -151,9 +151,9 @@ describe('TextEdit integration', () => {
       });
 
       it('should select all text and delete it', async () => {
-        // Testing this on the BROKEN version
         await fixture.events.mouse.clickOn(frame, 30, 5); // enter the edit mode by clicking
 
+        // Needed because of https://github.com/puppeteer/puppeteer/issues/1313
         if (navigator.userAgentData.platform === 'macOS') {
           document.execCommand('selectAll'); // not the same as mod+a, but does work on macOS
         } else {

--- a/packages/story-editor/src/karma/element-library/text/edit.karma.js
+++ b/packages/story-editor/src/karma/element-library/text/edit.karma.js
@@ -154,11 +154,27 @@ describe('TextEdit integration', () => {
       fit('should select all text and delete it', async () => {
         // Testing this on the BROKEN version
         await fixture.events.mouse.clickOn(frame, 30, 5); // enter the edit mode by clicking
-        await fixture.events.keyboard.shortcut('mod+a'); // doesn't work on macOS, maybe will work on Ubuntu
-        //document.execCommand("selectAll"); // selects all, but it's not the same as MOD+A, so we can't use it
-        await fixture.events.keyboard.type('BAR');
-        // result: BAR, expected: Lorem...BAR...ipsum
-        expect(frame.querySelector('p').innerHTML).not.toEqual('BAR');
+
+        if (navigator.userAgentData.platform === 'macOS') {
+          document.execCommand('selectAll'); // not the same as mod+a
+        } else {
+          await fixture.events.keyboard.shortcut('mod+a'); // doesn't work on macOS, works on Ubuntu
+        }
+        const text = '461';
+        await fixture.events.keyboard.type(text);
+
+        // Exit edit mode using the Esc key
+        await fixture.events.keyboard.press('Esc');
+
+        // The element is still selected and updated.
+        await waitFor(async () => {
+          const story = await fixture.renderHook(() => useStory());
+          if (!story.state.selectedElements.length) {
+            throw new Error('story not ready');
+          }
+
+          expect(story.state.selectedElements[0].content).toEqual(text);
+        });
       });
     });
 

--- a/packages/story-editor/src/karma/element-library/text/edit.karma.js
+++ b/packages/story-editor/src/karma/element-library/text/edit.karma.js
@@ -150,13 +150,12 @@ describe('TextEdit integration', () => {
         );
       });
 
-      // eslint-disable-next-line jasmine/no-focused-tests
-      fit('should select all text and delete it', async () => {
+      it('should select all text and delete it', async () => {
         // Testing this on the BROKEN version
         await fixture.events.mouse.clickOn(frame, 30, 5); // enter the edit mode by clicking
 
         if (navigator.userAgentData.platform === 'macOS') {
-          document.execCommand('selectAll'); // not the same as mod+a
+          document.execCommand('selectAll'); // not the same as mod+a, but does work on macOS
         } else {
           await fixture.events.keyboard.shortcut('mod+a'); // doesn't work on macOS, works on Ubuntu
         }

--- a/packages/story-editor/src/karma/element-library/text/edit.karma.js
+++ b/packages/story-editor/src/karma/element-library/text/edit.karma.js
@@ -149,6 +149,17 @@ describe('TextEdit integration', () => {
           '<span style="font-weight: 700">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</span>'
         );
       });
+
+      // eslint-disable-next-line jasmine/no-focused-tests
+      fit('should select all text and delete it', async () => {
+        // Testing this on the BROKEN version
+        await fixture.events.mouse.clickOn(frame, 30, 5); // enter the edit mode by clicking
+        await fixture.events.keyboard.shortcut('mod+a'); // doesn't work on macOS, maybe will work on Ubuntu
+        //document.execCommand("selectAll"); // selects all, but it's not the same as MOD+A, so we can't use it
+        await fixture.events.keyboard.type('BAR');
+        // result: BAR, expected: Lorem...BAR...ipsum
+        expect(frame.querySelector('p').innerHTML).not.toEqual('BAR');
+      });
     });
 
     describe('shortcuts', () => {


### PR DESCRIPTION
## Summary

There are issues with selecting all text that were reported in #11034 and #11061.

There might be a different/better solution (because CMD+A generally works, it's more a problem with selection/focus), but this one is easy and harmless and most importantly - fixes all the issues with selecting all text.

I tell CMD+A to explicitly select all text in the text element.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add a text element
2. Click on it once (in the middle of the text)
3. Select all text by CMD+A
4. Paste or delete text
5. It should work as expected (and was broken before)


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11034
Fixes #11061