### PR TITLE
Floating Menu: Fix "Saved Color" (gradient) as border color causes crash (Again)

### DIFF
--- a/packages/story-editor/src/components/floatingMenu/elements/borderWidthAndColor.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/borderWidthAndColor.js
@@ -134,8 +134,11 @@ function BorderWidthAndColor() {
             value={border.color || BLACK}
             onChange={handleColorChange}
             hasInputs={false}
-            hasEyeDropper={false}
+            hasEyedropper={false}
             allowsOpacity={canHaveBorderOpacity}
+            allowsGradient={false}
+            pickerHasEyedropper={false} // override shared floating menu Color component TODO https://github.com/GoogleForCreators/web-stories-wp/issues/11024
+            allowsSavedColors={false}
           />
         </>
       )}

--- a/packages/story-editor/src/components/form/color/color.js
+++ b/packages/story-editor/src/components/form/color/color.js
@@ -56,7 +56,7 @@ const Container = styled.section`
 `;
 Container.propTypes = {
   isInDesignMenu: PropTypes.bool,
-  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  width: PropTypes.number,
 };
 
 const ColorInputsWrapper = styled.div`
@@ -141,7 +141,7 @@ const Color = forwardRef(function Color(
     <Container
       aria-label={containerLabel}
       isInDesignMenu={isInDesignMenu}
-      width={!ignoreSetWidth && width ? width : ''}
+      width={!ignoreSetWidth && width ? width : null}
     >
       {hasEyedropper && (
         <Tooltip

--- a/packages/story-editor/src/components/form/color/color.js
+++ b/packages/story-editor/src/components/form/color/color.js
@@ -56,7 +56,7 @@ const Container = styled.section`
 `;
 Container.propTypes = {
   isInDesignMenu: PropTypes.bool,
-  width: PropTypes.string,
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 const ColorInputsWrapper = styled.div`
@@ -141,7 +141,7 @@ const Color = forwardRef(function Color(
     <Container
       aria-label={containerLabel}
       isInDesignMenu={isInDesignMenu}
-      width={!ignoreSetWidth && width}
+      width={!ignoreSetWidth && width ? width : ''}
     >
       {hasEyedropper && (
         <Tooltip

--- a/packages/story-editor/src/components/form/color/test/color.js
+++ b/packages/story-editor/src/components/form/color/test/color.js
@@ -24,10 +24,11 @@ import { renderWithTheme } from '@googleforcreators/test-utils';
 /**
  * Internal dependencies
  */
-import Color from '../color';
-import applyOpacityChange from '../applyOpacityChange';
 import { ConfigProvider } from '../../../../app/config';
 import getDefaultConfig from '../../../../getDefaultConfig';
+import { MULTIPLE_VALUE } from '../../../../constants';
+import Color from '../color';
+import applyOpacityChange from '../applyOpacityChange';
 
 jest.mock('../applyOpacityChange', () => jest.fn());
 
@@ -39,9 +40,13 @@ function arrange(props = {}) {
     </ConfigProvider>
   );
   const colorPreview = screen.getByRole('button', { name: 'Color' });
+  const colorSection = screen.getByRole('region', {
+    name: 'Color input: Color',
+  });
   const opacityInput = screen.queryByLabelText(/Opacity/);
   return {
     colorPreview,
+    colorSection,
     opacityInput,
     onChange,
   };
@@ -75,5 +80,35 @@ describe('<Color />', () => {
     );
 
     expect(onChange).toHaveBeenCalledWith(createSolid(255, 0, 0, 0.3));
+  });
+
+  it("should pass 300 as width prop to the color's section when width is specified and current value is not mixed", () => {
+    const { colorSection } = arrange({
+      value: createSolid(255, 0, 0),
+      width: 300,
+    });
+    expect(colorSection.getAttribute('width')).toBe('300');
+  });
+
+  it("should pass false as width prop to the color's section when width is specified and current value is mixed", () => {
+    const { colorSection } = arrange({
+      value: MULTIPLE_VALUE,
+      width: 300,
+    });
+    expect(colorSection.getAttribute('width')).toBe(null);
+  });
+
+  it("should pass null as width prop to the color's section when width is not specified and current value is mixed", () => {
+    const { colorSection } = arrange({
+      value: MULTIPLE_VALUE,
+    });
+    expect(colorSection.getAttribute('width')).toBe(null);
+  });
+
+  it("should pass null as width prop to the color's section when width is not specified and current value is not mixed", () => {
+    const { colorSection } = arrange({
+      value: createSolid(255, 0, 0),
+    });
+    expect(colorSection.getAttribute('width')).toBe(null);
   });
 });

--- a/packages/story-editor/src/components/form/color/test/color.js
+++ b/packages/story-editor/src/components/form/color/test/color.js
@@ -87,7 +87,7 @@ describe('<Color />', () => {
       value: createSolid(255, 0, 0),
       width: 300,
     });
-    expect(colorSection.getAttribute('width')).toBe('300');
+    expect(colorSection).toHaveAttribute('width', '300');
   });
 
   it("should pass false as width prop to the color's section when width is specified and current value is mixed", () => {
@@ -95,20 +95,20 @@ describe('<Color />', () => {
       value: MULTIPLE_VALUE,
       width: 300,
     });
-    expect(colorSection.getAttribute('width')).toBe(null);
+    expect(colorSection).not.toHaveAttribute('width');
   });
 
   it("should pass null as width prop to the color's section when width is not specified and current value is mixed", () => {
     const { colorSection } = arrange({
       value: MULTIPLE_VALUE,
     });
-    expect(colorSection.getAttribute('width')).toBe(null);
+    expect(colorSection).not.toHaveAttribute('width');
   });
 
   it("should pass null as width prop to the color's section when width is not specified and current value is not mixed", () => {
     const { colorSection } = arrange({
       value: createSolid(255, 0, 0),
     });
-    expect(colorSection.getAttribute('width')).toBe(null);
+    expect(colorSection).not.toHaveAttribute('width');
   });
 });


### PR DESCRIPTION
## Context

Re-adding #11025 which had changes that were overwritten in a rebase that are necessary to avoid crashing the editor. 

## Summary

See that these are the same changes as previously added: https://github.com/GoogleForCreators/web-stories-wp/pull/11025/files#diff-3e101509bd8aebce46f213f43dc1e13358fabc6f9cccef75d7d4cce88f8de35c

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

Adding border colors via floating menu no longer crashes editor

## Testing Instructions

Give elements borders and border colors and see that it doesn't crash.

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11019
