### PR TITLE
Image Capture: Initial implementation

### DIFF
--- a/packages/story-editor/src/components/library/panes/media/local/mediaRecording/imageCapture.js
+++ b/packages/story-editor/src/components/library/panes/media/local/mediaRecording/imageCapture.js
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { __ } from '@googleforcreators/i18n';
+import styled from 'styled-components';
+import { useState } from '@googleforcreators/react';
+import {
+  blobToFile,
+  getImageFromVideo,
+  createBlob,
+} from '@googleforcreators/media';
+import PropTypes from 'prop-types';
+import {
+  Button,
+  BUTTON_TYPES,
+  BUTTON_SIZES,
+} from '@googleforcreators/design-system';
+
+/**
+ * Internal dependencies
+ */
+import { MEDIA_POSTER_IMAGE_MIME_TYPE } from '../../../../../../constants/media';
+
+const Photo = styled.img`
+  display: block;
+  width: 240px;
+  margin: 0 auto;
+`;
+
+const Actions = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: 20px;
+`;
+
+export const ImageCapture = ({ videoRef, onCapture, onClear }) => {
+  const [src, setSrc] = useState('');
+
+  const clear = () => {
+    setSrc('');
+    onClear();
+  };
+
+  const captureImage = async () => {
+    if (!videoRef.current) {
+      return;
+    }
+    const blob = await getImageFromVideo(videoRef.current);
+    const imageSrc = await createBlob(blob);
+    setSrc(imageSrc);
+    onCapture(
+      blobToFile(blob, 'image-capture.jpeg', MEDIA_POSTER_IMAGE_MIME_TYPE)
+    );
+  };
+
+  return (
+    <>
+      {src && <Photo src={src} alt={__('Image capture', 'web-stories')} />}
+      <Actions>
+        <Button
+          type={BUTTON_TYPES.PRIMARY}
+          size={BUTTON_SIZES.SMALL}
+          onClick={captureImage}
+          disabled={onClear !== null}
+        >
+          {__('Capture Image', 'web-stories')}
+        </Button>
+        <Button
+          type={BUTTON_TYPES.TERTIARY}
+          size={BUTTON_SIZES.SMALL}
+          onClick={clear}
+          disabled={onClear === null}
+        >
+          {__('Clear Image', 'web-stories')}
+        </Button>
+      </Actions>
+    </>
+  );
+};
+
+ImageCapture.propTypes = {
+  videoRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  onCapture: PropTypes.func.isRequired,
+  onClear: PropTypes.oneOfType([PropTypes.func], null),
+};


### PR DESCRIPTION
## Context

Adds initial `Capture Image` functionality 

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
- Adds 'Capture Image' & 'Clear Image' buttons
- Uses the existing Modal, setFile & Insert action from  #10958

| Start   |      Recording + Capture button     |  
|----------|:-------------:|
| <img width="219" alt="1" src="https://user-images.githubusercontent.com/62242/160812862-c0a0af72-0e18-4a88-8b2f-f92c5787d5c7.png">|  <img width="200" alt="2-a" src="https://user-images.githubusercontent.com/62242/160812926-6809de69-e5ec-4dbd-aa3b-9fbedbc494f7.png"> | 
| Captured Image   |      Insert     |  
| <img width="250" alt="Screen Shot 2022-03-30 at 6 44 02 AM" src="https://user-images.githubusercontent.com/62242/160814104-5a2ff07b-4fd1-4276-ab49-8918d60f547f.png"> |    <img width="250" alt="4" src="https://user-images.githubusercontent.com/62242/160813441-72b7dbb0-739f-40a7-b885-b9d0c74642aa.png">   |  


<!-- A brief description of what this PR does. -->

## Relevant Technical Choices


## To-do
Outside of this PR there's an issue "resetting" the video capture back to a starting state. 
 
- start recording 
- stop recording
- start recording --- you can't see the video preview only a black screen (but it still records).

Thinking that's something we can troubleshoot as the UI for these features get figured out.


<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

- Start a recording
- Press Capture image button
--- Clear the image + recapture as needed
- Press insert
- Resulting image should now be on the canvas

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---


<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10962
