### PR TITLE
Story Details Modal: Remove Experiment 

### DIFF
--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -312,14 +312,26 @@ class Experiments extends Service_Base implements HasRequirements {
 				'default'     => true,
 			],
 			/**
-			 * Author: @brittanyirl
-			 * Issue: #10115
-			 * Creation date: 2022-02-02
+			 * Author: @miina
+			 * Issue: #9880
+			 * Creation date: 2021-12-15
 			 */
 			[
-				'name'        => 'enableUpdatedPublishStoryModal',
-				'label'       => __( 'Updated Publish Story Modal', 'web-stories' ),
-				'description' => __( 'Enable new pre-publish confirmation modal', 'web-stories' ),
+				'name'        => 'customFonts',
+				'label'       => __( 'Custom Fonts', 'web-stories' ),
+				'description' => __( 'Enable adding custom fonts', 'web-stories' ),
+				'group'       => 'general',
+				'default'     => true,
+			],
+			/**
+			 * Author: @spacedmonkey
+			 * Issue: #8821
+			 * Creation date: 2022-01-19
+			 */
+			[
+				'name'        => 'enhancedPageBackgroundAudio',
+				'label'       => __( 'Page Background Audio', 'web-stories' ),
+				'description' => __( 'Enable adding captions to background audio', 'web-stories' ),
 				'group'       => 'editor',
 				'default'     => true,
 			],

--- a/packages/story-editor/src/components/checklist/karma/checklist.karma.js
+++ b/packages/story-editor/src/components/checklist/karma/checklist.karma.js
@@ -352,13 +352,13 @@ describe('Checklist integration', () => {
     });
   });
 
-  it('should open the checklist after following "review checklist" button in dialog on publishing story', async () => {
+  it('should open the checklist after following "checklist" button in dialog on publishing story', async () => {
     fixture.events.click(fixture.editor.titleBar.publish);
     // Ensure the debounced callback has taken effect.
-    await fixture.events.sleep(800);
+    // await fixture.events.sleep(800);
 
     const reviewButton = await fixture.screen.getByRole('button', {
-      name: /^Review Checklist$/,
+      name: /^Checklist$/,
     });
     await fixture.events.click(reviewButton);
     // This is the initial load of the checklist tab so we need to wait for it to load

--- a/packages/story-editor/src/components/checklist/karma/checklist.karma.js
+++ b/packages/story-editor/src/components/checklist/karma/checklist.karma.js
@@ -354,8 +354,6 @@ describe('Checklist integration', () => {
 
   it('should open the checklist after following "checklist" button in dialog on publishing story', async () => {
     fixture.events.click(fixture.editor.titleBar.publish);
-    // Ensure the debounced callback has taken effect.
-    // await fixture.events.sleep(800);
 
     const reviewButton = await fixture.screen.getByRole('button', {
       name: /^Checklist$/,

--- a/packages/story-editor/src/components/header/buttons/publish.js
+++ b/packages/story-editor/src/components/header/buttons/publish.js
@@ -26,20 +26,16 @@ import {
 } from '@googleforcreators/date';
 import { trackEvent } from '@googleforcreators/tracking';
 import PropTypes from 'prop-types';
-import { useFeature } from 'flagged';
 /**
  * Internal dependencies
  */
 import { useStory } from '../../../app';
 import useRefreshPostEditURL from '../../../utils/useRefreshPostEditURL';
-import { useCheckpoint, ReviewChecklistDialog } from '../../checklist';
+import { useCheckpoint } from '../../checklist';
 import { PublishModal } from '../../publishModal';
 import ButtonWithChecklistWarning from './buttonWithChecklistWarning';
 
 function PublishButton({ forceIsSaving }) {
-  const isUpdatedPublishModalEnabled = useFeature(
-    'enableUpdatedPublishStoryModal'
-  );
   const { date, storyId, saveStory, title, editLink, canPublish } = useStory(
     ({
       state: {
@@ -57,14 +53,8 @@ function PublishButton({ forceIsSaving }) {
     })
   );
 
-  const { shouldReviewDialogBeSeen, showPriorityIssues } = useCheckpoint(
-    ({
-      state: { shouldReviewDialogBeSeen },
-      actions: { showPriorityIssues },
-    }) => ({
-      shouldReviewDialogBeSeen,
-      showPriorityIssues,
-    })
+  const showPriorityIssues = useCheckpoint(
+    ({ actions: { showPriorityIssues } }) => showPriorityIssues
   );
 
   const [showDialog, setShowDialog] = useState(false);
@@ -99,18 +89,8 @@ function PublishButton({ forceIsSaving }) {
 
   const handlePublish = useCallback(() => {
     showPriorityIssues();
-    if (shouldReviewDialogBeSeen || isUpdatedPublishModalEnabled) {
-      setShowDialog(true);
-      return;
-    }
-
-    publish();
-  }, [
-    showPriorityIssues,
-    shouldReviewDialogBeSeen,
-    isUpdatedPublishModalEnabled,
-    publish,
-  ]);
+    setShowDialog(true);
+  }, [showPriorityIssues]);
 
   const closeDialog = useCallback(() => setShowDialog(false), []);
 
@@ -121,22 +101,13 @@ function PublishButton({ forceIsSaving }) {
         disabled={forceIsSaving}
         hasFutureDate={hasFutureDate}
       />
-      {isUpdatedPublishModalEnabled ? (
-        <PublishModal
-          isOpen={showDialog}
-          onPublish={publish}
-          onClose={closeDialog}
-          hasFutureDate={hasFutureDate}
-          publishButtonDisabled={forceIsSaving}
-        />
-      ) : (
-        <ReviewChecklistDialog
-          isOpen={showDialog}
-          onIgnore={publish}
-          onClose={closeDialog}
-          onReview={closeDialog}
-        />
-      )}
+      <PublishModal
+        isOpen={showDialog}
+        onPublish={publish}
+        onClose={closeDialog}
+        hasFutureDate={hasFutureDate}
+        publishButtonDisabled={forceIsSaving}
+      />
     </>
   );
 }

--- a/packages/story-editor/src/components/header/buttons/test/publish.js
+++ b/packages/story-editor/src/components/header/buttons/test/publish.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, within } from '@testing-library/react';
 import MockDate from 'mockdate';
 import { setAppElement } from '@googleforcreators/design-system';
 import { renderWithTheme } from '@googleforcreators/test-utils';
@@ -134,12 +134,12 @@ describe('PublishButton', () => {
 
     expect(showPriorityIssues).toHaveBeenCalledTimes(1);
 
-    const publishButtons = screen.queryAllByRole('button', {
+    const publishModal = screen.getByRole('dialog');
+
+    const publishModalButton = within(publishModal).getByRole('button', {
       name: 'Publish',
     });
-    // story details modal is open, now there is a second publish button.
-    expect(publishButtons).toHaveLength(2);
-    fireEvent.click(publishButtons[1]);
+    fireEvent.click(publishModalButton);
 
     expect(saveStory).toHaveBeenCalledWith({
       status: 'publish',
@@ -161,12 +161,12 @@ describe('PublishButton', () => {
     expect(publishButton).toBeEnabled();
     fireEvent.click(publishButton);
 
-    const publishButtons = screen.queryAllByRole('button', {
+    const publishModal = screen.getByRole('dialog');
+
+    const publishModalButton = within(publishModal).getByRole('button', {
       name: 'Submit for review',
     });
-    // story details modal is open, now there is a second publish button.
-    expect(publishButtons).toHaveLength(2);
-    fireEvent.click(publishButtons[1]);
+    fireEvent.click(publishModalButton);
 
     expect(saveStory).toHaveBeenCalledWith({
       status: 'pending',
@@ -194,12 +194,12 @@ describe('PublishButton', () => {
     const publishButton = screen.getByRole('button', { name: 'Publish' });
 
     fireEvent.click(publishButton);
-    const publishButtons = screen.queryAllByRole('button', {
+    const publishModal = screen.getByRole('dialog');
+
+    const publishModalButton = within(publishModal).getByRole('button', {
       name: 'Publish',
     });
-    // story details modal is open, now there is a second publish button.
-    expect(publishButtons).toHaveLength(2);
-    fireEvent.click(publishButtons[1]);
+    fireEvent.click(publishModalButton);
 
     expect(saveStory).toHaveBeenCalledTimes(1);
     expect(window.location.href).toContain('post=123&action=edit');

--- a/packages/story-editor/src/components/header/buttons/test/publish.js
+++ b/packages/story-editor/src/components/header/buttons/test/publish.js
@@ -17,11 +17,7 @@
 /**
  * External dependencies
  */
-import {
-  fireEvent,
-  screen,
-  waitForElementToBeRemoved,
-} from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import MockDate from 'mockdate';
 import { setAppElement } from '@googleforcreators/design-system';
 import { renderWithTheme } from '@googleforcreators/test-utils';

--- a/packages/story-editor/src/components/header/buttons/test/publish.js
+++ b/packages/story-editor/src/components/header/buttons/test/publish.js
@@ -28,7 +28,6 @@ import { renderWithTheme } from '@googleforcreators/test-utils';
 import StoryContext from '../../../../app/story/context';
 import useIsUploadingToStory from '../../../../utils/useIsUploadingToStory';
 import ConfigContext from '../../../../app/config/context';
-import { renderWithTheme } from '../../../../testUtils';
 import {
   CheckpointContext,
   ChecklistCountProvider,

--- a/packages/story-editor/src/components/publishModal/content/storyPreview.js
+++ b/packages/story-editor/src/components/publishModal/content/storyPreview.js
@@ -32,6 +32,7 @@ import { getExtensionsFromMimeType } from '@googleforcreators/media';
  * Internal dependencies
  */
 import { useConfig, useStory } from '../../../app';
+import { STABLE_ARRAY } from '../../../constants';
 import { Media } from '../../form';
 
 // Set the available space for cover preview image + overlay
@@ -192,15 +193,13 @@ const StoryPreview = () => {
     })
   );
 
-  const {
-    allowedImageMimeTypes = [],
-    hasUploadMediaAction,
-    publisher,
-  } = useConfig(({ allowedMimeTypes, capabilities, metadata }) => ({
-    allowedImageMimeTypes: allowedMimeTypes?.image,
-    hasUploadMediaAction: capabilities?.hasUploadMediaAction,
-    publisher: metadata?.publisher,
-  }));
+  const { allowedImageMimeTypes, hasUploadMediaAction, publisher } = useConfig(
+    ({ allowedMimeTypes, capabilities, metadata }) => ({
+      allowedImageMimeTypes: allowedMimeTypes?.image || STABLE_ARRAY,
+      hasUploadMediaAction: capabilities?.hasUploadMediaAction,
+      publisher: metadata?.publisher,
+    })
+  );
 
   const allowedImageFileTypes = useMemo(
     () =>

--- a/packages/story-editor/src/components/publishModal/content/storyPreview.js
+++ b/packages/story-editor/src/components/publishModal/content/storyPreview.js
@@ -192,13 +192,15 @@ const StoryPreview = () => {
     })
   );
 
-  const { allowedImageMimeTypes, hasUploadMediaAction, publisher } = useConfig(
-    ({ allowedMimeTypes, capabilities, metadata }) => ({
-      allowedImageMimeTypes: allowedMimeTypes?.image,
-      hasUploadMediaAction: capabilities?.hasUploadMediaAction,
-      publisher: metadata?.publisher,
-    })
-  );
+  const {
+    allowedImageMimeTypes = [],
+    hasUploadMediaAction,
+    publisher,
+  } = useConfig(({ allowedMimeTypes, capabilities, metadata }) => ({
+    allowedImageMimeTypes: allowedMimeTypes?.image,
+    hasUploadMediaAction: capabilities?.hasUploadMediaAction,
+    publisher: metadata?.publisher,
+  }));
 
   const allowedImageFileTypes = useMemo(
     () =>

--- a/packages/story-editor/src/components/publishModal/karma/publishModal.karma.js
+++ b/packages/story-editor/src/components/publishModal/karma/publishModal.karma.js
@@ -36,7 +36,6 @@ describe('Publish Story Modal', () => {
 
   beforeEach(async () => {
     fixture = new Fixture();
-    fixture.setFlags({ enableUpdatedPublishStoryModal: true });
     await fixture.render();
 
     await openPublishModal();

--- a/packages/story-editor/src/components/sidebar/sidebarProvider.js
+++ b/packages/story-editor/src/components/sidebar/sidebarProvider.js
@@ -28,7 +28,6 @@ import {
 } from '@googleforcreators/react';
 import { __ } from '@googleforcreators/i18n';
 import { trackEvent } from '@googleforcreators/tracking';
-
 /**
  * Internal dependencies
  */

--- a/packages/story-editor/src/components/sidebar/sidebarProvider.js
+++ b/packages/story-editor/src/components/sidebar/sidebarProvider.js
@@ -28,7 +28,6 @@ import {
 } from '@googleforcreators/react';
 import { __ } from '@googleforcreators/i18n';
 import { trackEvent } from '@googleforcreators/tracking';
-import { useFeature } from 'flagged';
 
 /**
  * Internal dependencies
@@ -43,10 +42,6 @@ import Context from './context';
 
 const SIDEBAR_TAB_IDS = new Set([INSERT, DOCUMENT, STYLE]);
 function SidebarProvider({ sidebarTabs, children }) {
-  const isUpdatedPublishModalEnabled = useFeature(
-    'enableUpdatedPublishStoryModal'
-  );
-
   const {
     actions: { getAuthors },
   } = useAPI();
@@ -179,7 +174,7 @@ function SidebarProvider({ sidebarTabs, children }) {
     });
   }
 
-  if (sidebarTabs?.publishModal && isUpdatedPublishModalEnabled) {
+  if (sidebarTabs?.publishModal) {
     state.data.modalSidebarTab = {
       id: PUBLISH_MODAL_DOCUMENT,
       ...sidebarTabs.publishModal,

--- a/packages/wp-story-editor/src/components/header/buttons/test/buttons.js
+++ b/packages/wp-story-editor/src/components/header/buttons/test/buttons.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, within } from '@testing-library/react';
 import MockDate from 'mockdate';
 import { setAppElement } from '@googleforcreators/design-system';
 import {
@@ -224,12 +224,13 @@ describe('Buttons', () => {
     fireEvent.click(scheduleButton);
     expect(saveStory).not.toHaveBeenCalled();
 
-    const scheduleButtons = screen.queryAllByRole('button', {
+    const publishModal = screen.getByRole('dialog');
+
+    const publishModalButton = within(publishModal).getByRole('button', {
       name: 'Schedule',
     });
-    // story details modal is open, now there is a second publish button.
-    expect(scheduleButtons).toHaveLength(2);
-    fireEvent.click(scheduleButtons[1]);
+
+    fireEvent.click(publishModalButton);
     expect(saveStory).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/wp-story-editor/src/components/header/buttons/test/buttons.js
+++ b/packages/wp-story-editor/src/components/header/buttons/test/buttons.js
@@ -23,6 +23,8 @@ import { setAppElement } from '@googleforcreators/design-system';
 import {
   StoryContext,
   CheckpointContext,
+  ChecklistCountProvider,
+  ConfigContext,
 } from '@googleforcreators/story-editor';
 import { renderWithTheme } from '@googleforcreators/test-utils';
 
@@ -37,6 +39,7 @@ function arrange({
   storyState: extraStoryStateProps,
   meta: extraMetaProps,
   metaBoxes: extraMetaBoxesProps,
+  config: extraConfigProps,
 } = {}) {
   const saveStory = jest.fn();
   const autoSave = jest.fn();
@@ -50,6 +53,8 @@ function arrange({
       meta: { isSaving: false, isFreshlyPublished: false, ...extraMetaProps },
       story: {
         status: 'draft',
+        title: '',
+        excerpt: '',
         storyId: 123,
         date: null,
         editLink: 'http://localhost/wp-admin/post.php?post=123&action=edit',
@@ -70,21 +75,33 @@ function arrange({
       ...extraMetaBoxesProps,
     },
   };
+  const configValue = {
+    allowedMimeTypes: {},
+    capabilities: {},
+    metadata: {
+      publisher: 'publisher title',
+    },
+    ...extraConfigProps,
+  };
 
   renderWithTheme(
     <MetaBoxesContext.Provider value={metaBoxesValue}>
-      <StoryContext.Provider value={storyContextValue}>
-        <CheckpointContext.Provider
-          value={{
-            actions: {
-              showPriorityIssues: () => {},
-            },
-            state: { shouldReviewDialogBeSeen: false, checkpoint: 'all' },
-          }}
-        >
-          <Buttons />
-        </CheckpointContext.Provider>
-      </StoryContext.Provider>
+      <ConfigContext.Provider value={configValue}>
+        <StoryContext.Provider value={storyContextValue}>
+          <ChecklistCountProvider>
+            <CheckpointContext.Provider
+              value={{
+                actions: {
+                  showPriorityIssues: () => {},
+                },
+                state: { shouldReviewDialogBeSeen: false, checkpoint: 'all' },
+              }}
+            >
+              <Buttons />
+            </CheckpointContext.Provider>
+          </ChecklistCountProvider>
+        </StoryContext.Provider>
+      </ConfigContext.Provider>
     </MetaBoxesContext.Provider>
   );
   return {
@@ -205,6 +222,14 @@ describe('Buttons', () => {
     const scheduleButton = screen.getByRole('button', { name: 'Schedule' });
 
     fireEvent.click(scheduleButton);
+    expect(saveStory).not.toHaveBeenCalled();
+
+    const scheduleButtons = screen.queryAllByRole('button', {
+      name: 'Schedule',
+    });
+    // story details modal is open, now there is a second publish button.
+    expect(scheduleButtons).toHaveLength(2);
+    fireEvent.click(scheduleButtons[1]);
     expect(saveStory).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Removing experiment code now that feature has been enabled for a release cycle.

## Relevant Technical Choices

Sorry, this is a redo of https://github.com/GoogleForCreators/web-stories-wp/pull/10882 - which I closed because I wasn't sure when I'd get back to it and there were a lot of rebases, of course, once I did that I had time to actually come back. 

## To-do

Will clean up the checkpoint provider separately here: https://github.com/GoogleForCreators/web-stories-wp/issues/10470 (old dialog, names of state that control if that exclamation mark shows up on buttons)

## User-facing changes

None, experiment has been on for a release cycle by default - this is just removing the unneeded experiment code.

## Testing Instructions

When 'publish' in header is selected should see story details modal. Experiment should be gone from list of experiments. Clicking "Checklist" from detail stories modal will close modal and open checklist popup. 


<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10594 
