### PR TITLE
Canvas: Remove empty text elements when exiting editing mode

### DIFF
--- a/packages/element-library/src/text/edit.js
+++ b/packages/element-library/src/text/edit.js
@@ -129,6 +129,7 @@ function TextEdit({
   editWrapper,
   onResize,
   updateElementById,
+  deleteSelectedElements,
   maybeEnqueueFontStyle,
 }) {
   const {
@@ -256,8 +257,15 @@ function TextEdit({
     }
   }, [editorToDataX, editorToDataY, setProperties]);
 
-  // Update content for element on unmount.
-  useUnmount(updateContent);
+  // Update content or delete the whole element (if empty) on unmount.
+  const handleUnmount = useCallback(() => {
+    if (contentRef.current) {
+      updateContent();
+    } else {
+      deleteSelectedElements();
+    }
+  }, [updateContent, deleteSelectedElements]);
+  useUnmount(handleUnmount);
 
   useEffect(() => {
     // If there are any moveable actions happening, let's update the content
@@ -426,6 +434,7 @@ TextEdit.propTypes = {
   onResize: PropTypes.func,
   editWrapper: PropTypes.object,
   updateElementById: PropTypes.func,
+  deleteSelectedElements: PropTypes.func,
   maybeEnqueueFontStyle: PropTypes.func,
 };
 

--- a/packages/rich-text/src/editor.js
+++ b/packages/rich-text/src/editor.js
@@ -58,9 +58,7 @@ function RichTextEditor({ content, onChange }, ref) {
       return;
     }
     const newContent = getContentFromState(editorState);
-    if (newContent) {
-      onChange(newContent);
-    }
+    onChange(newContent);
   }, [onChange, getContentFromState, editorState]);
 
   const hasEditorState = Boolean(editorState);

--- a/packages/story-editor/src/components/canvas/editElement.js
+++ b/packages/story-editor/src/components/canvas/editElement.js
@@ -60,8 +60,9 @@ const EditElement = memo(
 
     // Update the true global properties of the current element
     // This now only happens on unmount
-    const { updateElementById } = useStory((state) => ({
+    const { updateElementById, deleteSelectedElements } = useStory((state) => ({
       updateElementById: state.actions.updateElementById,
+      deleteSelectedElements: state.actions.deleteSelectedElements,
     }));
     const { isTrimMode, resource, setVideoNode } = useVideoTrim(
       ({ state: { isTrimMode, videoData }, actions: { setVideoNode } }) => ({
@@ -95,6 +96,7 @@ const EditElement = memo(
           resource={resource}
           setVideoNode={setVideoNode}
           updateElementById={updateElementById}
+          deleteSelectedElements={deleteSelectedElements}
           maybeEnqueueFontStyle={maybeEnqueueFontStyle}
           zIndexCanvas={Z_INDEX_CANVAS}
         />

--- a/packages/story-editor/src/karma/element-library/text/edit.karma.js
+++ b/packages/story-editor/src/karma/element-library/text/edit.karma.js
@@ -81,6 +81,23 @@ describe('TextEdit integration', () => {
       );
     });
 
+    it('should delete the element if content is empty', async () => {
+      expect(fixture.querySelector('[data-testid="textEditor"]')).toBeNull();
+      await fixture.events.focus(
+        fixture.editor.canvas.framesLayer.frames[1].node
+      );
+      await fixture.events.keyboard.press('Enter');
+      expect(fixture.querySelector('[data-testid="textEditor"]')).toBeDefined();
+      // Remove all text
+      await fixture.events.keyboard.press('Backspace');
+      // Exit edit mode using the Esc key
+      await fixture.events.keyboard.press('Esc');
+      // The element should be deleted.
+      const layerPanel = fixture.editor.footer.layerPanel;
+      await fixture.events.click(layerPanel.togglePanel);
+      expect(layerPanel.layers.length).toBe(1);
+    });
+
     describe('edit mode', () => {
       let editor;
       let editLayer;


### PR DESCRIPTION
## Summary

This was reported as a bug, but now it's a feature 😃 
More context: https://github.com/GoogleForCreators/web-stories-wp/issues/11035

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add any text element
2. Remove all contents
3. Exit edit mode
4. The element should be gone

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11035
