### PR TITLE
Code Quality: Remove `customFonts` and `notifyDeletedFonts` feature flag code

### DIFF
--- a/docs/third-party-integration/story-editor/integration-layer.md
+++ b/docs/third-party-integration/story-editor/integration-layer.md
@@ -166,9 +166,6 @@ You can also provide an external link in the description of the tip.
     - `enableSVG`
         - type: `boolean`
         - description: Enables SVG support in link icons.
-    - `customFonts`
-        - type: `boolean`
-        - description: Enables custom fonts in rich text elements.
     - `enableExperimentalAnimationEffects`
         - type: `boolean`
         - description: Enables experimental animations effects.

--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -323,19 +323,6 @@ class Experiments extends Service_Base implements HasRequirements {
 				'group'       => 'editor',
 				'default'     => true,
 			],
-
-			/**
-			 * Author: @miina
-			 * Issue: #9880
-			 * Creation date: 2021-12-15
-			 */
-			[
-				'name'        => 'customFonts',
-				'label'       => __( 'Custom Fonts', 'web-stories' ),
-				'description' => __( 'Enable adding custom fonts', 'web-stories' ),
-				'group'       => 'general',
-				'default'     => true,
-			],
 			/**
 			 * Author: @spacedmonkey
 			 * Issue: #8821
@@ -357,18 +344,6 @@ class Experiments extends Service_Base implements HasRequirements {
 				'name'        => 'floatingMenu',
 				'label'       => __( 'Floating Menu', 'web-stories' ),
 				'description' => __( 'Enable the new floating design menu', 'web-stories' ),
-				'group'       => 'editor',
-				'default'     => true,
-			],
-			/**
-			 * Author: @timarney
-			 * Issue: #10014
-			 * Creation date: 2022-03-03
-			 */
-			[
-				'name'        => 'notifyDeletedFonts',
-				'label'       => __( 'Deleted Fonts', 'web-stories' ),
-				'description' => __( 'Notify user about deleted fonts in story', 'web-stories' ),
 				'group'       => 'editor',
 				'default'     => true,
 			],

--- a/packages/e2e-tests/src/specs/dashboard/settings/adminUser/customFonts.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/adminUser/customFonts.js
@@ -18,7 +18,6 @@
  * External dependencies
  */
 import {
-  withExperimentalFeatures,
   visitSettings,
   addCustomFont,
   removeAllFonts,
@@ -42,8 +41,6 @@ const OPEN_SANS_CONDENSED_LIGHT_ITALIC_URL = `${FONT_BASE_URL}/OpenSansCondensed
 const findByUrl = (arr, val) => arr.find((o) => o.url === val);
 
 describe('Custom Fonts', () => {
-  withExperimentalFeatures(['customFonts']);
-
   let removeResourceErrorMessage;
 
   beforeAll(() => {

--- a/packages/e2e-tests/src/specs/editor/fontCheck/fontCheck.js
+++ b/packages/e2e-tests/src/specs/editor/fontCheck/fontCheck.js
@@ -17,7 +17,6 @@
  * External dependencies
  */
 import {
-  withExperimentalFeatures,
   createNewStory,
   editStoryWithTitle,
   insertStoryTitle,
@@ -88,8 +87,6 @@ async function storyWithFontCheckDialog(title) {
 }
 
 describe('Font Check', () => {
-  withExperimentalFeatures(['customFonts', 'notifyDeletedFonts']);
-
   beforeAll(async () => {
     await visitSettings();
     await removeAllFonts();

--- a/packages/story-editor/src/app/font/fontProvider.js
+++ b/packages/story-editor/src/app/font/fontProvider.js
@@ -21,7 +21,6 @@ import PropTypes from 'prop-types';
 import { useCallback, useRef, useState } from '@googleforcreators/react';
 import { CURATED_FONT_NAMES } from '@googleforcreators/fonts';
 import { loadStylesheet } from '@googleforcreators/dom';
-import { useFeature } from 'flagged';
 
 /**
  * Internal dependencies
@@ -34,7 +33,6 @@ import useLoadFontFiles from './actions/useLoadFontFiles';
 export const GOOGLE_MENU_FONT_URL = 'https://fonts.googleapis.com/css';
 
 function FontProvider({ children }) {
-  const isCustomFontsEnabled = useFeature('customFonts');
   const [queriedFonts, setQueriedFonts] = useState([]);
   const [curatedFonts, setCuratedFonts] = useState([]);
   const [recentFonts, setRecentFonts] = useState([]);
@@ -46,7 +44,7 @@ function FontProvider({ children }) {
   const fonts = queriedFonts.length > 0 ? queriedFonts : curatedFonts;
 
   const getCustomFonts = useCallback(async () => {
-    if (customFonts || !getFonts || !isCustomFontsEnabled) {
+    if (customFonts || !getFonts) {
       return;
     }
 
@@ -67,7 +65,7 @@ function FontProvider({ children }) {
     }));
 
     setCustomFonts(formattedFonts);
-  }, [getFonts, customFonts, isCustomFontsEnabled]);
+  }, [getFonts, customFonts]);
 
   const getCuratedFonts = useCallback(async () => {
     if (curatedFonts.length || !getFonts) {
@@ -109,11 +107,7 @@ function FontProvider({ children }) {
         return [];
       }
 
-      // If there are custom fonts in the DB, we should not include those to search when custom fonts are not enabled.
-      const newFonts = await getFonts({
-        search,
-        service: isCustomFontsEnabled ? null : 'builtin',
-      });
+      const newFonts = await getFonts({ search });
 
       const formattedFonts = newFonts.map((font) => ({
         ...font,
@@ -125,7 +119,7 @@ function FontProvider({ children }) {
       setQueriedFonts(formattedFonts);
       return formattedFonts;
     },
-    [getFonts, isCustomFontsEnabled]
+    [getFonts]
   );
 
   const getFontWeight = useCallback(

--- a/packages/wp-dashboard/src/components/editorSettings/editorSettings.js
+++ b/packages/wp-dashboard/src/components/editorSettings/editorSettings.js
@@ -26,7 +26,6 @@ import {
   MIN_IMG_HEIGHT,
   useConfig,
 } from '@googleforcreators/dashboard';
-import { useFeature } from 'flagged';
 
 /**
  * Internal dependencies
@@ -127,8 +126,6 @@ function EditorSettings() {
       publisherLogos,
     })
   );
-
-  const isCustomFontsEnabled = useFeature('customFonts');
 
   const {
     capabilities: { canUploadFiles, canManageSettings } = {},
@@ -334,13 +331,11 @@ function EditorSettings() {
                 />
               </>
             )}
-            {isCustomFontsEnabled && (
-              <CustomFontsSettings
-                customFonts={customFonts}
-                addCustomFont={addCustomFont}
-                deleteCustomFont={deleteCustomFont}
-              />
-            )}
+            <CustomFontsSettings
+              customFonts={customFonts}
+              addCustomFont={addCustomFont}
+              deleteCustomFont={deleteCustomFont}
+            />
             <TelemetrySettings
               disabled={disableOptedIn}
               onCheckboxSelected={toggleWebStoriesTrackingOptIn}

--- a/packages/wp-story-editor/src/components/fontCheck/index.js
+++ b/packages/wp-story-editor/src/components/fontCheck/index.js
@@ -27,12 +27,10 @@ import {
 /**
  * Internal dependencies
  */
-import { useFeature } from 'flagged';
 import { FontCheckDialog } from './fontCheckDialog';
 
 export const FontCheck = () => {
   const { dashboardLink } = useConfig();
-  const notifyDeletedFonts = useFeature('notifyDeletedFonts');
   const { isStoryLoaded } = useStory(({ state: { pages } }) => ({
     isStoryLoaded: pages.length > 0,
   }));
@@ -70,10 +68,6 @@ export const FontCheck = () => {
       }
     })();
   }, [isStoryLoaded, storyPages, getFonts]);
-
-  if (!notifyDeletedFonts) {
-    return null;
-  }
 
   return (
     <FontCheckDialog


### PR DESCRIPTION
## Context

Custom fonts were enabled by default in #11100

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Removes `customFonts` and `notifyDeletedFonts` feature flags 

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Check `Experimental Settings` page --- note that Custom Fonts & Notify Deleted Fonts options no longer exist
2. Ensure adding / deleting custom fonts to a story functions as normal


## Reviews

### Does this PR have a security-related impact?

No

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

No

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

No

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11129
