### PR TITLE
Fix center snapping

### DIFF
--- a/packages/design-system/src/components/keyboard/index.js
+++ b/packages/design-system/src/components/keyboard/index.js
@@ -25,6 +25,7 @@ import {
   useState,
   useContext,
   useBatchingCallback,
+  useCallback,
 } from '@googleforcreators/react';
 /**
  * Internal dependencies
@@ -181,6 +182,17 @@ export function useKeyUpEffect(
  */
 export function useIsKeyPressed(refOrNode, keyNameOrSpec, deps = undefined) {
   const [isKeyPressed, setIsKeyPressed] = useState(false);
+
+  const handleBlur = useCallback(() => {
+    setIsKeyPressed(false);
+  }, []);
+  useEffect(() => {
+    window.addEventListener('blur', handleBlur);
+    return function () {
+      window.removeEventListener('blur', handleBlur);
+    };
+  }, [handleBlur]);
+
   //eslint-disable-next-line react-hooks/exhaustive-deps -- Pass through provided deps.
   useKeyDownEffect(refOrNode, keyNameOrSpec, () => setIsKeyPressed(true), deps);
   //eslint-disable-next-line react-hooks/exhaustive-deps -- Pass through provided deps.

--- a/packages/story-editor/src/components/canvas/karma/snapping.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/snapping.karma.js
@@ -57,5 +57,17 @@ describe('Snapping integration', () => {
 
       await fixture.snapshot('Design space guideline hidden');
     });
+
+    it('should show canvas center guidelines when moved to the center', async () => {
+      await fixture.events.mouse.seq(({ moveRel, moveBy, down }) => [
+        moveRel(frame1, 10, 10),
+        down(),
+        moveBy(10, 150, { steps: 6 }),
+      ]);
+
+      await fixture.snapshot('Canvas center guidelines visible');
+
+      await fixture.events.mouse.up();
+    });
   });
 });

--- a/packages/story-editor/src/components/canvas/utils/useSnapping.js
+++ b/packages/story-editor/src/components/canvas/utils/useSnapping.js
@@ -106,12 +106,28 @@ function useSnapping({
     ? [...otherNodes, designSpaceGuideline]
     : [];
 
+  const snapDirections = {
+    left: true,
+    top: true,
+    right: true,
+    bottom: true,
+    center: true,
+    middle: true,
+  };
+  const elementSnapDirections = {
+    left: true,
+    top: true,
+    right: true,
+    bottom: true,
+    center: true,
+    middle: true,
+  };
+
   return {
     snappable: canSnap,
-    snapHorizontal: canSnap,
-    snapVertical: canSnap,
-    snapCenter: canSnap,
     snapGap: canSnap,
+    snapDirections,
+    elementSnapDirections,
     isDisplaySnapDigit: false,
     onSnap: handleSnap,
     horizontalGuidelines,

--- a/packages/story-editor/src/components/canvas/utils/useSnapping.js
+++ b/packages/story-editor/src/components/canvas/utils/useSnapping.js
@@ -114,20 +114,12 @@ function useSnapping({
     center: true,
     middle: true,
   };
-  const elementSnapDirections = {
-    left: true,
-    top: true,
-    right: true,
-    bottom: true,
-    center: true,
-    middle: true,
-  };
 
   return {
     snappable: canSnap,
     snapGap: canSnap,
     snapDirections,
-    elementSnapDirections,
+    elementSnapDirections: snapDirections,
     isDisplaySnapDigit: false,
     onSnap: handleSnap,
     horizontalGuidelines,


### PR DESCRIPTION
## Summary

This PR fixes two issues with snapping:

 ### 1) Center/middle snapping
`react-moveable` replaced `snapCenter` with `snapDirections` ([and others](https://github.com/daybrush/moveable/releases/tag/0.27.0)) which has `(default: { left: true, top: true, right: true, bottom: true })` without `center/middle`. The upstream change was made on 2021-11-09 and it went unnoticed.
If they had used proper semantic versioning it wouldn't have happened? @swissspidy 

Before:

https://user-images.githubusercontent.com/21036224/161091050-1758cc40-5588-4395-88d6-1b0ff5cfc138.mp4

After:

https://user-images.githubusercontent.com/21036224/161091406-32e63891-7a3e-4350-a7c3-2de793fa46e1.mp4

 ### 2) Bugged "Disable snapping and drop targeting"

Especially when the user switched windows using MOD+TAB, the MOD key state was still set to pressed even if that was no longer the case (and that caused no snapping and drop targeting at all). A temporary "workaround" was to press MOD once after you return to the window. Fix in this PR sets the key state to not-pressed when you blur the window - not sure if there is any better solution?

https://user-images.githubusercontent.com/21036224/161091826-a7d8b013-dda5-4631-bfc5-aa55b11c5909.mp4


3.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Check if the centerline snapping of the element is working.
2. Try to reproduce the issue with the "sticky" MOD key.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11053 
