### PR TITLE
Discovery: Splitting apart Popup, Tooltip and Dropdown

### DIFF
--- a/packages/design-system/src/components/index.js
+++ b/packages/design-system/src/components/index.js
@@ -30,6 +30,8 @@ export { NumericInput } from './input/numericInput';
 export * from './menu';
 export * from './pill';
 export { Popup, PLACEMENT } from './popup';
+export { PopupContainer } from './popup/constants';
+export { getOffset } from './popup/utils';
 export * from './radio';
 export * from './search';
 export * from './slider';

--- a/packages/design-system/src/components/popup/constants.js
+++ b/packages/design-system/src/components/popup/constants.js
@@ -14,6 +14,16 @@
  * limitations under the License.
  */
 
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import { getTransforms } from './utils';
+
 export const PLACEMENT = {
   // TOP
   TOP: 'top',
@@ -51,3 +61,30 @@ export const RTL_PLACEMENT = {
   [PLACEMENT.LEFT_START]: PLACEMENT.RIGHT_START,
   [PLACEMENT.LEFT_END]: PLACEMENT.RIGHT_END,
 };
+
+export const PopupContainer = styled.div.attrs(
+  ({
+    $offset: { x, y, width, height },
+    fillWidth,
+    fillHeight,
+    placement,
+    isRTL,
+    invisible,
+    zIndex,
+  }) => ({
+    style: {
+      transform: `translate(${x}px, ${y}px) ${getTransforms(placement, isRTL)}`,
+      ...(fillWidth ? { width: `${width}px` } : {}),
+      ...(fillHeight ? { height: `${height}px` } : {}),
+      ...(invisible ? { visibility: 'hidden' } : {}),
+      zIndex,
+    },
+  })
+)`
+  /*! @noflip */
+  left: 0px;
+  top: 0px;
+  position: fixed;
+  ${({ noOverFlow }) => (noOverFlow ? '' : `overflow-y: auto;`)};
+  max-height: ${({ topOffset }) => `calc(100vh - ${topOffset}px)`};
+`;

--- a/packages/design-system/src/components/popup/constants.js
+++ b/packages/design-system/src/components/popup/constants.js
@@ -64,9 +64,8 @@ export const RTL_PLACEMENT = {
 
 export const PopupContainer = styled.div.attrs(
   ({
-    $offset: { x, y, width, height },
+    $offset: { x, y, width },
     fillWidth,
-    fillHeight,
     placement,
     isRTL,
     invisible,
@@ -75,7 +74,6 @@ export const PopupContainer = styled.div.attrs(
     style: {
       transform: `translate(${x}px, ${y}px) ${getTransforms(placement, isRTL)}`,
       ...(fillWidth ? { width: `${width}px` } : {}),
-      ...(fillHeight ? { height: `${height}px` } : {}),
       ...(invisible ? { visibility: 'hidden' } : {}),
       zIndex,
     },

--- a/packages/design-system/src/components/popup/index.js
+++ b/packages/design-system/src/components/popup/index.js
@@ -62,7 +62,8 @@ function Popup({
   topOffset = DEFAULT_TOPOFFSET,
   // dropdown and one tooltip - used in dashboard due to the document.body getting set to a weird height.
   // ignoreMaxOffsetY, removed!
-  // color input - docking or floating
+  // color input - docking or floating ??? mainly needed because we are getting weird x values in the
+  // layer panel popup which has tooltip inside.
   resetXOffset = false,
   // tooltip only
   //  onPositionUpdate = noop, removed!

--- a/packages/design-system/src/components/popup/index.js
+++ b/packages/design-system/src/components/popup/index.js
@@ -53,7 +53,7 @@ function Popup({
   renderContents,
 
   // color input
-  // invisible = false, removed!
+  // invisible = false, removed! -- If we leave color input as is, using this we will need to keep it.
 
   //data list, dropdown, search,
   fillWidth = false,
@@ -62,7 +62,7 @@ function Popup({
   // fillHeight = false, removed!
 
   // dropdown and color input
-  // refCallback = noop, removed!
+  // refCallback = noop, removed!  -- If we leave color input as is, using this we will need to keep it.
 
   //PlayPauseButton - all direct popup uses, style text, canvas elements, publish time, etc -
   topOffset = DEFAULT_TOPOFFSET,
@@ -72,7 +72,7 @@ function Popup({
 
   // color input - docking or floating ??? mainly needed because we are getting weird x values in the
   // layer panel popup which has tooltip inside.
-  // resetXOffset = false, removed!
+  // resetXOffset = false, removed!  -- If we leave color input as is, using this we will need to keep it. Or just fix that layers panel issue
 
   // tooltip only
   //  onPositionUpdate = noop, removed!

--- a/packages/design-system/src/components/popup/index.js
+++ b/packages/design-system/src/components/popup/index.js
@@ -31,7 +31,6 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { noop } from '../../utils';
 import { getOffset } from './utils';
 import { PLACEMENT, PopupContainer } from './constants';
 const DEFAULT_TOPOFFSET = 0;
@@ -46,25 +45,35 @@ function Popup({
   children,
   zIndex = DEFAULT_POPUP_Z_INDEX,
   // the above are used by all implementations
+
   //color input, style presets
   dock,
+
   //data list, color input, text style, style presets, publish time,
   renderContents,
+
   // color input
-  invisible = false,
+  // invisible = false, removed!
+
   //data list, dropdown, search,
   fillWidth = false,
+
   // none
   // fillHeight = false, removed!
+
   // dropdown and color input
-  refCallback = noop,
+  // refCallback = noop, removed!
+
   //PlayPauseButton - all direct popup uses, style text, canvas elements, publish time, etc -
   topOffset = DEFAULT_TOPOFFSET,
+
   // dropdown and one tooltip - used in dashboard due to the document.body getting set to a weird height.
   // ignoreMaxOffsetY, removed!
+
   // color input - docking or floating ??? mainly needed because we are getting weird x values in the
   // layer panel popup which has tooltip inside.
-  resetXOffset = false,
+  // resetXOffset = false, removed!
+
   // tooltip only
   //  onPositionUpdate = noop, removed!
 }) {
@@ -98,13 +107,12 @@ function Popup({
               popup,
               isRTL,
               topOffset,
-              resetXOffset,
             })
           : {},
         height: popup.current?.getBoundingClientRect()?.height,
       });
     },
-    [anchor, placement, spacing, dock, isRTL, topOffset, resetXOffset]
+    [anchor, placement, spacing, dock, isRTL, topOffset]
   );
   useEffect(() => {
     // If the popup height changes meanwhile, let's update the popup, too.
@@ -130,14 +138,6 @@ function Popup({
     };
   }, [isOpen, positionPopup]);
 
-  useLayoutEffect(() => {
-    if (!isMounted.current) {
-      return;
-    }
-
-    refCallback(popup);
-  }, [popupState, refCallback]);
-
   useResizeEffect({ current: document.body }, positionPopup, [positionPopup]);
   return popupState && isOpen
     ? createPortal(
@@ -146,7 +146,6 @@ function Popup({
           fillWidth={fillWidth}
           placement={placement}
           $offset={popupState.offset}
-          invisible={invisible}
           topOffset={topOffset}
           isRTL={isRTL}
           zIndex={zIndex}

--- a/packages/design-system/src/components/popup/index.js
+++ b/packages/design-system/src/components/popup/index.js
@@ -17,7 +17,6 @@
 /**
  * External dependencies
  */
-import styled from 'styled-components';
 import {
   useLayoutEffect,
   useEffect,
@@ -33,36 +32,11 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { noop } from '../../utils';
-import { getTransforms, getOffset } from './utils';
-import { PLACEMENT } from './constants';
+import { getOffset } from './utils';
+import { PLACEMENT, PopupContainer } from './constants';
 const DEFAULT_TOPOFFSET = 0;
 const DEFAULT_POPUP_Z_INDEX = 2;
-const Container = styled.div.attrs(
-  ({
-    $offset: { x, y, width, height },
-    fillWidth,
-    fillHeight,
-    placement,
-    isRTL,
-    invisible,
-    zIndex,
-  }) => ({
-    style: {
-      transform: `translate(${x}px, ${y}px) ${getTransforms(placement, isRTL)}`,
-      ...(fillWidth ? { width: `${width}px` } : {}),
-      ...(fillHeight ? { height: `${height}px` } : {}),
-      ...(invisible ? { visibility: 'hidden' } : {}),
-      zIndex,
-    },
-  })
-)`
-  /*! @noflip */
-  left: 0px;
-  top: 0px;
-  position: fixed;
-  ${({ noOverFlow }) => (noOverFlow ? '' : `overflow-y: auto;`)};
-  max-height: ${({ topOffset }) => `calc(100vh - ${topOffset}px)`};
-`;
+
 function Popup({
   isRTL = false,
   anchor,
@@ -82,15 +56,12 @@ function Popup({
   fillWidth = false,
   // none
   fillHeight = false,
-  // tooltip
-  onPositionUpdate = noop,
   // dropdown and color input
   refCallback = noop,
-  //PlayPauseButton - loads straight popup use, style text, canvas elements, publish time, etc
+  //PlayPauseButton - all straight up popup uses, style text, canvas elements, publish time, etc -
+  // tooltip technically only needs it for getOffset util, but we could just pass in 0.
   topOffset = DEFAULT_TOPOFFSET,
-  //tooltip
-  noOverFlow = false,
-  // dropdown and one tooltip
+  // dropdown and one tooltip - used in dashboard due to the document.body getting set to a weird height.
   ignoreMaxOffsetY,
   // color input - docking or floating
   resetXOffset = false,
@@ -172,14 +143,13 @@ function Popup({
       return;
     }
 
-    onPositionUpdate(popupState);
     refCallback(popup);
-  }, [popupState, onPositionUpdate, refCallback]);
+  }, [popupState, refCallback]);
 
   useResizeEffect({ current: document.body }, positionPopup, [positionPopup]);
   return popupState && isOpen
     ? createPortal(
-        <Container
+        <PopupContainer
           ref={popup}
           fillWidth={fillWidth}
           fillHeight={fillHeight}
@@ -187,14 +157,13 @@ function Popup({
           $offset={popupState.offset}
           invisible={invisible}
           topOffset={topOffset}
-          noOverFlow={noOverFlow}
           isRTL={isRTL}
           zIndex={zIndex}
         >
           {renderContents
             ? renderContents({ propagateDimensionChange: positionPopup })
             : children}
-        </Container>,
+        </PopupContainer>,
         document.body
       )
     : null;

--- a/packages/design-system/src/components/popup/index.js
+++ b/packages/design-system/src/components/popup/index.js
@@ -66,21 +66,33 @@ const Container = styled.div.attrs(
 function Popup({
   isRTL = false,
   anchor,
-  dock,
-  children,
-  renderContents,
   placement = PLACEMENT.BOTTOM,
   spacing,
   isOpen,
-  invisible = false,
-  fillWidth = false,
-  fillHeight = false,
-  onPositionUpdate = noop,
-  refCallback = noop,
-  topOffset = DEFAULT_TOPOFFSET,
+  children,
+  //data list, tooltip, dropdown, search, publish time
   zIndex = DEFAULT_POPUP_Z_INDEX,
+  //color input, style presets
+  dock,
+  //data list, color input, text style, style presets, publish time,
+  renderContents,
+  // color input
+  invisible = false,
+  //data list, dropdown, search,
+  fillWidth = false,
+  // none
+  fillHeight = false,
+  // tooltip
+  onPositionUpdate = noop,
+  // dropdown and color input
+  refCallback = noop,
+  //PlayPauseButton - loads straight popup use, style text, canvas elements, publish time, etc
+  topOffset = DEFAULT_TOPOFFSET,
+  //tooltip
   noOverFlow = false,
+  // dropdown and one tooltip
   ignoreMaxOffsetY,
+  // color input - docking or floating
   resetXOffset = false,
 }) {
   const [popupState, setPopupState] = useState(null);

--- a/packages/design-system/src/components/popup/index.js
+++ b/packages/design-system/src/components/popup/index.js
@@ -44,8 +44,8 @@ function Popup({
   spacing,
   isOpen,
   children,
-  //data list, tooltip, dropdown, search, publish time
   zIndex = DEFAULT_POPUP_Z_INDEX,
+  // the above are used by all implementations
   //color input, style presets
   dock,
   //data list, color input, text style, style presets, publish time,
@@ -55,16 +55,17 @@ function Popup({
   //data list, dropdown, search,
   fillWidth = false,
   // none
-  fillHeight = false,
+  // fillHeight = false, removed!
   // dropdown and color input
   refCallback = noop,
-  //PlayPauseButton - all straight up popup uses, style text, canvas elements, publish time, etc -
-  // tooltip technically only needs it for getOffset util, but we could just pass in 0.
+  //PlayPauseButton - all direct popup uses, style text, canvas elements, publish time, etc -
   topOffset = DEFAULT_TOPOFFSET,
   // dropdown and one tooltip - used in dashboard due to the document.body getting set to a weird height.
-  ignoreMaxOffsetY,
+  // ignoreMaxOffsetY, removed!
   // color input - docking or floating
   resetXOffset = false,
+  // tooltip only
+  //  onPositionUpdate = noop, removed!
 }) {
   const [popupState, setPopupState] = useState(null);
   const isMounted = useRef(false);
@@ -96,23 +97,13 @@ function Popup({
               popup,
               isRTL,
               topOffset,
-              ignoreMaxOffsetY,
               resetXOffset,
             })
           : {},
         height: popup.current?.getBoundingClientRect()?.height,
       });
     },
-    [
-      anchor,
-      placement,
-      spacing,
-      dock,
-      isRTL,
-      topOffset,
-      ignoreMaxOffsetY,
-      resetXOffset,
-    ]
+    [anchor, placement, spacing, dock, isRTL, topOffset, resetXOffset]
   );
   useEffect(() => {
     // If the popup height changes meanwhile, let's update the popup, too.
@@ -152,7 +143,6 @@ function Popup({
         <PopupContainer
           ref={popup}
           fillWidth={fillWidth}
-          fillHeight={fillHeight}
           placement={placement}
           $offset={popupState.offset}
           invisible={invisible}

--- a/packages/design-system/src/components/popup/index.js
+++ b/packages/design-system/src/components/popup/index.js
@@ -70,6 +70,9 @@ function Popup({
   // dropdown and one tooltip - used in dashboard due to the document.body getting set to a weird height.
   // ignoreMaxOffsetY, removed!
 
+  //tooltip only
+  // noOverFlow, - removed!
+
   // color input - docking or floating ??? mainly needed because we are getting weird x values in the
   // layer panel popup which has tooltip inside.
   // resetXOffset = false, removed!  -- If we leave color input as is, using this we will need to keep it. Or just fix that layers panel issue

--- a/packages/design-system/src/components/popup/utils/getOffset.js
+++ b/packages/design-system/src/components/popup/utils/getOffset.js
@@ -115,7 +115,7 @@ export function getOffset({
   dock,
   popup,
   isRTL,
-  topOffset,
+  topOffset = 0, // set default then we won't have to send it in with Tooltip
   ignoreMaxOffsetY,
   resetXOffset,
 }) {

--- a/packages/design-system/src/components/popup/utils/getOffset.js
+++ b/packages/design-system/src/components/popup/utils/getOffset.js
@@ -149,10 +149,12 @@ export function getOffset({
   const offsetY = getYOffset(placement, spacingV, anchorRect);
   const maxOffsetY =
     bodyRect.height + bodyRect.y - height - getYTransforms(placement) * height;
+  // maybe pull in leftOffset from config to account to LTR wp-admin bar?
+  const leftEdge = popupRect?.left <= 0 ? (popupRect?.width + spacingH) / 2 : 0;
 
   // Clamp values
   return {
-    x: Math.max(0, Math.min(offsetX(), maxOffsetX)),
+    x: Math.max(leftEdge, Math.min(offsetX(), maxOffsetX)),
     y: ignoreMaxOffsetY
       ? offsetY
       : Math.max(topOffset, Math.min(offsetY, maxOffsetY)),

--- a/packages/design-system/src/components/popup/utils/getOffset.js
+++ b/packages/design-system/src/components/popup/utils/getOffset.js
@@ -135,7 +135,10 @@ export function getOffset({
 
   // Horizontal
   const offsetX = () => {
-    if (resetXOffset && popupRect?.left <= 0) {
+    // resetXOffset was added because the layers panel popup is getting weird x values in the negative range. So if we
+    // just check for popupRect.left <= 0 we end up pushing the tooltips inside the layers panel off to the edge. We
+    // should figure out why the layer's panel is getting whacked values.
+    if (resetXOffset && popupRect && popupRect.left <= 0) {
       return isRTL ? width : 0;
     }
     return getXOffset(placement, spacingH, anchorRect, dockRect, isRTL);

--- a/packages/design-system/src/components/tooltip/index.js
+++ b/packages/design-system/src/components/tooltip/index.js
@@ -64,6 +64,7 @@ const TooltipContainer = styled.div`
   transition: 0.4s opacity;
   opacity: ${({ shown }) => (shown ? 1 : 0)};
   pointer-events: ${({ shown }) => (shown ? 'all' : 'none')};
+  // why is this hardcoded?
   z-index: 9999;
   border-radius: 4px;
   background-color: ${({ theme }) => theme.colors.inverted.bg.primary};
@@ -118,6 +119,7 @@ function Tooltip({
   isDelayed = false,
   // forceAnchorRef = null, needed for WithLink so that the url tooltip hovers the element, and isn't anchor
   // to just the canvas. Also used in Slider, but I couldn't trigger it.
+  // could remove tooltipProps, do we need it anymore
   tooltipProps = null,
   className = null,
   popupZIndexOverride,

--- a/packages/design-system/src/components/tooltip/index.js
+++ b/packages/design-system/src/components/tooltip/index.js
@@ -161,6 +161,7 @@ function Tooltip({
       case PLACEMENT.TOP_START:
       case PLACEMENT.RIGHT_START:
         // {placement}-START shouldn't ever appear in overflow so do nothing
+        //  in RTL mode, it is getting cutoff on the left when screen is too small possibly cause rtl is switch in editor's tooltip
         break;
       case PLACEMENT.BOTTOM_END:
       case PLACEMENT.TOP_END:

--- a/packages/design-system/src/components/tooltip/index.js
+++ b/packages/design-system/src/components/tooltip/index.js
@@ -161,7 +161,6 @@ function Tooltip({
       case PLACEMENT.TOP_START:
       case PLACEMENT.RIGHT_START:
         // {placement}-START shouldn't ever appear in overflow so do nothing
-        //  in RTL mode, it is getting cutoff on the left when screen is too small possibly cause rtl is switch in editor's tooltip
         break;
       case PLACEMENT.BOTTOM_END:
       case PLACEMENT.TOP_END:
@@ -210,6 +209,8 @@ function Tooltip({
           setDynamicPlacement(PLACEMENT.TOP);
         }
       } else if (isOverFlowingLeft) {
+        //  in RTL mode, it is getting cutoff on the left when screen is too small possibly cause rtl is switch in editor's tooltip
+        // maybe fix getOffset to not let this happen instead of changing placement 🤔?
         updatePlacement();
       }
     },

--- a/packages/story-editor/src/components/panels/design/layer/layer.js
+++ b/packages/story-editor/src/components/panels/design/layer/layer.js
@@ -342,6 +342,7 @@ function Layer({ element }) {
               title={__('Duplicate Layer', 'web-stories')}
               hasTail
               isDelayed
+              placement={'bottom-end'}
             >
               <LayerAction
                 aria-label={__('Duplicate', 'web-stories')}


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
With `Popup` having to deal with `Tooltip`, `Dropdown` `Search` and "basic" implementations like `Color input`, `PublishTime` `DataList` etc. it has become a bit complicated to maintain each use case. Looking to see what splitting it apart would look like. 

## Relevant Technical Choices
`Dropdown` `Color Input` and `Tooltip` now each have there own implementations of a `Popup`

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->
- ~~pull out Dropdown~~
- ~~pull out Search~~
- ~~What about Color Input ?~~
- RTL tooltip are a bit whacky. 
- getOffset should account for the edge of a screen whether or not in RTL
- Investigate `Search` and `DataList` - should these really be `Dropdown`s or does `Popup` still make sense? Or should these uses also be their own implementation? 


Fixes #6921 
