### PR TITLE
CORS Check: Only show dialog once

### DIFF
--- a/packages/design-system/src/utils/localStore.js
+++ b/packages/design-system/src/utils/localStore.js
@@ -33,7 +33,7 @@ export const LOCAL_STORAGE_PREFIX = {
   DEFAULT_VIEW_PAGE_TEMPLATE_LAYOUT: 'web_stories_default_template_view',
   BACKGROUND_IS_SET_DIALOG_DISMISSED:
     'web_stories_background_is_set_dialog_dismissed',
-  CORS_WARNING_DIALOG_DISMISSED: 'web_stories_cors_warning_dialog_dismissed',
+  CORS_CHECK_DIALOG_DISMISSED: 'web_stories_cors_check_dialog_dismissed',
 };
 
 function getItemByKey(key) {

--- a/packages/design-system/src/utils/localStore.js
+++ b/packages/design-system/src/utils/localStore.js
@@ -33,6 +33,7 @@ export const LOCAL_STORAGE_PREFIX = {
   DEFAULT_VIEW_PAGE_TEMPLATE_LAYOUT: 'web_stories_default_template_view',
   BACKGROUND_IS_SET_DIALOG_DISMISSED:
     'web_stories_background_is_set_dialog_dismissed',
+  CORS_WARNING_DIALOG_DISMISSED: 'web_stories_cors_warning_dialog_dismissed',
 };
 
 function getItemByKey(key) {

--- a/packages/wp-story-editor/src/components/corsCheck/corsCheck.js
+++ b/packages/wp-story-editor/src/components/corsCheck/corsCheck.js
@@ -18,6 +18,10 @@
  */
 import { useEffect, useCallback, useState } from '@googleforcreators/react';
 import { useAPI } from '@googleforcreators/story-editor';
+import {
+  LOCAL_STORAGE_PREFIX,
+  localStore,
+} from '@googleforcreators/design-system';
 import { trackError } from '@googleforcreators/tracking';
 import { useFeature } from 'flagged';
 
@@ -26,16 +30,24 @@ import { useFeature } from 'flagged';
  */
 import CorsCheckFailed from './corsCheckFailed';
 
+const storageKey = LOCAL_STORAGE_PREFIX.CORS_WARNING_DIALOG_DISMISSED;
+
 function CorsCheck() {
   const [showDialog, setShowDialog] = useState(false);
-  const closeDialog = useCallback(() => setShowDialog(false), []);
   const {
     actions: { getMediaForCorsCheck },
   } = useAPI();
   const enableCORSCheck = useFeature('enableCORSCheck');
+
+  const closeDialog = useCallback(() => {
+    setShowDialog(false);
+    localStore.setItemByKey(storageKey, true);
+  }, []);
+
+  const isDialogDismissed = Boolean(localStore.getItemByKey(storageKey));
   useEffect(() => {
     (async () => {
-      if (!enableCORSCheck) {
+      if (!enableCORSCheck || isDialogDismissed) {
         return;
       }
       let mediaItems;

--- a/packages/wp-story-editor/src/components/corsCheck/corsCheck.js
+++ b/packages/wp-story-editor/src/components/corsCheck/corsCheck.js
@@ -30,7 +30,7 @@ import { useFeature } from 'flagged';
  */
 import CorsCheckFailed from './corsCheckFailed';
 
-const storageKey = LOCAL_STORAGE_PREFIX.CORS_WARNING_DIALOG_DISMISSED;
+const storageKey = LOCAL_STORAGE_PREFIX.CORS_CHECK_DIALOG_DISMISSED;
 
 function CorsCheck() {
   const [showDialog, setShowDialog] = useState(false);

--- a/packages/wp-story-editor/src/components/corsCheck/test/corsCheck.js
+++ b/packages/wp-story-editor/src/components/corsCheck/test/corsCheck.js
@@ -138,7 +138,7 @@ describe('corsCheck', () => {
 
     setup();
     expect(localStore.getItemByKey).toHaveBeenCalledWith(
-      LOCAL_STORAGE_PREFIX.CORS_WARNING_DIALOG_DISMISSED
+      LOCAL_STORAGE_PREFIX.CORS_CHECK_DIALOG_DISMISSED
     );
 
     const dialog = await screen.findByRole('dialog');
@@ -152,7 +152,7 @@ describe('corsCheck', () => {
 
     await waitFor(() =>
       expect(localStore.setItemByKey).toHaveBeenCalledWith(
-        LOCAL_STORAGE_PREFIX.CORS_WARNING_DIALOG_DISMISSED,
+        LOCAL_STORAGE_PREFIX.CORS_CHECK_DIALOG_DISMISSED,
         true
       )
     );

--- a/packages/wp-story-editor/src/components/corsCheck/test/corsCheck.js
+++ b/packages/wp-story-editor/src/components/corsCheck/test/corsCheck.js
@@ -19,9 +19,14 @@
 import {
   fireEvent,
   screen,
+  waitFor,
   waitForElementToBeRemoved,
 } from '@testing-library/react';
-import { setAppElement } from '@googleforcreators/design-system';
+import {
+  LOCAL_STORAGE_PREFIX,
+  localStore,
+  setAppElement,
+} from '@googleforcreators/design-system';
 import { APIContext } from '@googleforcreators/story-editor';
 import { FlagsProvider } from 'flagged';
 import { renderWithTheme } from '@googleforcreators/test-utils';
@@ -32,6 +37,15 @@ import { renderWithTheme } from '@googleforcreators/test-utils';
 import CorsCheck from '../corsCheck.js';
 
 const getMediaForCorsCheck = jest.fn();
+
+jest.mock('@googleforcreators/design-system', () => ({
+  __esModule: true,
+  ...jest.requireActual('@googleforcreators/design-system'),
+  localStore: {
+    setItemByKey: jest.fn(),
+    getItemByKey: jest.fn(() => false),
+  },
+}));
 
 function setup() {
   const apiData = {
@@ -123,6 +137,9 @@ describe('corsCheck', () => {
     fetchSpy.mockRejectedValue(() => new Error('request failed'));
 
     setup();
+    expect(localStore.getItemByKey).toHaveBeenCalledWith(
+      LOCAL_STORAGE_PREFIX.CORS_WARNING_DIALOG_DISMISSED
+    );
 
     const dialog = await screen.findByRole('dialog');
     expect(dialog).toBeInTheDocument();
@@ -132,5 +149,12 @@ describe('corsCheck', () => {
     fireEvent.click(dismiss);
 
     await waitForElementToBeRemoved(dialog);
+
+    await waitFor(() =>
+      expect(localStore.setItemByKey).toHaveBeenCalledWith(
+        LOCAL_STORAGE_PREFIX.CORS_WARNING_DIALOG_DISMISSED,
+        true
+      )
+    );
   });
 });


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

The CORS check warning, currently shows everytime the editor loads. This change makes the dialog dismissible. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10947
