### PR TITLE
Editor: Removed superfluous data load

### DIFF
--- a/packages/story-editor/src/components/videoTrim/useVideoTrimMode.js
+++ b/packages/story-editor/src/components/videoTrim/useVideoTrimMode.js
@@ -17,12 +17,7 @@
 /**
  * External dependencies
  */
-import {
-  useCallback,
-  useMemo,
-  useState,
-  useEffect,
-} from '@googleforcreators/react';
+import { useCallback, useMemo, useState } from '@googleforcreators/react';
 import { trackEvent } from '@googleforcreators/tracking';
 import { getMsFromHMS } from '@googleforcreators/media';
 
@@ -93,12 +88,6 @@ function useVideoTrimMode() {
       setVideoData(defaultVideoData);
     }
   }, [getMediaById, selectedElement]);
-
-  useEffect(() => {
-    if (selectedElement?.resource?.trimData) {
-      getVideoData();
-    }
-  }, [selectedElement, getVideoData]);
 
   const toggleTrimMode = useCallback(() => {
     if (isEditing) {


### PR DESCRIPTION
## Summary

I'm not sure why this effect was ever there? Maybe a kind of premature optimization or just for debugging purposes? Anyway, it doesn't seem to be required in any case (regardless of a video having an original or not).

## Testing Instructions


<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #10246
