### PR TITLE
Editor: Fix intersection calculation when right-clicking elements

### DIFF
--- a/packages/story-editor/src/app/rightClickMenu/useLayerSelect.js
+++ b/packages/story-editor/src/app/rightClickMenu/useLayerSelect.js
@@ -100,13 +100,15 @@ function useLayerSelect({ menuItemProps, menuPosition, isMenuOpen }) {
         return null;
       }
       const box = getBox(element);
-      const corner = new SAT.Vector(
+      // Note that we place the box at the center coordinate. We do this for the angle
+      // to apply correctly. We correct for this offset with `setOffset`` later.
+      const center = new SAT.Vector(
         bgPolygon.pos.x + box.x + box.width / 2,
         bgPolygon.pos.y + elementYOffset + box.y + box.height / 2
       );
-      const offset = new SAT.Vector(-box.width / 2, -box.height / 2);
-      const elementBox = new SAT.Box(corner, box.width, box.height);
+      const elementBox = new SAT.Box(center, box.width, box.height);
       const polygon = elementBox.toPolygon();
+      const offset = new SAT.Vector(-box.width / 2, -box.height / 2);
       polygon.setOffset(offset);
       polygon.setAngle((rotationAngle * Math.PI) / 180);
       return { element, polygon };


### PR DESCRIPTION
## Summary

This fixes the intersection calculation done when right-clicking on the canvas and will now correctly calculate the polygons for all elements (still not taking masks/shapes into consideration though).

This is only a partial fix for #10519, as it only addresses the right-click menu calculation.

## Relevant Technical Choices

- Manually creating polygons from original element sizes and positions rather than `getBoundingClientRect`, as it was trouble for rotated elements.
- Also utilizing a lot more features of the SAT library for easier polygon creation.

## User-facing changes

Clicking just above a rotated element will no longer show the element as being below the cursor (e.g. show a list of elements below the cursor, because there's only the background there):

| Before | After |
|-|-|
| ![Screen Shot 2022-04-01 at 16 11 58](https://user-images.githubusercontent.com/637548/161335312-dcc80396-8b38-4b07-a21a-289faf350ab6.png) | ![Screen Shot 2022-04-01 at 16 11 32](https://user-images.githubusercontent.com/637548/161335337-51cd22d2-f8c3-40ef-a82d-7f65afe274dd.png) |

## Testing Instructions

This PR can be tested by following these steps:

1. Add a number of (rectangular only) elements
2. Rotate, flip, and move them around so they overlap in various places
3. Right-click any position on the canvas and observe that a list of elements under the cursor only appears in the correct places and that the correct elements are in said list.

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Partially addresses #10519
