### PR TITLE
Dashboard: Add Default View to Router

### DIFF
--- a/packages/dashboard/src/app/router/route.js
+++ b/packages/dashboard/src/app/router/route.js
@@ -89,30 +89,25 @@ export function matchPath({
   // If there is and the current path fits 1 or less
   // of the available routes then render it as default
   if (isDefault) {
-    const availableRoutesPresentInCurrentPath = availableRoutes.filter(
-      (route) => currentPath.startsWith(route)
-    );
-    if (availableRoutesPresentInCurrentPath.length <= 1) {
+    const isValidDefaultRoute =
+      availableRoutes.filter((route) => currentPath.startsWith(route)).length <=
+      1;
+
+    if (isValidDefaultRoute) {
       return defaultRoute;
     }
   }
 
   const isExactMatch = currentPath === matchUrl;
-
   if (exact && !isExactMatch) {
     return null;
   }
-
   return matchUrl;
 }
 
 function Route({ component, path, exact = false, isDefault = false }) {
   const { availableRoutes, currentPath, defaultRoute } = useRouteHistory(
-    ({ state: { availableRoutes, currentPath, defaultRoute } }) => ({
-      availableRoutes,
-      currentPath,
-      defaultRoute,
-    })
+    ({ state }) => state
   );
 
   const match = matchPath({

--- a/packages/dashboard/src/app/router/route.js
+++ b/packages/dashboard/src/app/router/route.js
@@ -67,22 +67,63 @@ export function resolveRoute(route) {
   }
 }
 
-export function matchPath(currentPath, path, exact = false) {
+export function matchPath({
+  currentPath,
+  path,
+  availableRoutes,
+  defaultRoute,
+  isDefault = false,
+  exact = false,
+}) {
   const match = new RegExp(`^${path}`).exec(currentPath);
-  if (!match) {
+
+  // allow paths through that don't match if they are default, not narrowed out yet.
+  if (!match && !isDefault) {
     return null;
   }
-  const matchUrl = match[0];
+
+  // Find all available url matches
+  const matchUrl = match?.[0];
+
+  // Check if there is a default before looking for more exact matches
+  // If there is and the current path fits 1 or less
+  // of the available routes then render it as default
+  if (isDefault) {
+    const availableRoutesPresentInCurrentPath = availableRoutes.filter(
+      (route) => currentPath.startsWith(route)
+    );
+    if (availableRoutesPresentInCurrentPath.length <= 1) {
+      return defaultRoute;
+    }
+  }
+
   const isExactMatch = currentPath === matchUrl;
+
   if (exact && !isExactMatch) {
     return null;
   }
+
   return matchUrl;
 }
 
-function Route({ component, path, exact }) {
-  const { state } = useRouteHistory();
-  const match = matchPath(state.currentPath, path, exact);
+function Route({ component, path, exact = false, isDefault = false }) {
+  const { availableRoutes, currentPath, defaultRoute } = useRouteHistory(
+    ({ state: { availableRoutes, currentPath, defaultRoute } }) => ({
+      availableRoutes,
+      currentPath,
+      defaultRoute,
+    })
+  );
+
+  const match = matchPath({
+    currentPath,
+    availableRoutes,
+    defaultRoute,
+    path,
+    exact,
+    isDefault,
+  });
+
   if (!match) {
     return null;
   }

--- a/packages/dashboard/src/app/router/routerProvider.js
+++ b/packages/dashboard/src/app/router/routerProvider.js
@@ -26,6 +26,10 @@ import {
 } from '@googleforcreators/react';
 import PropTypes from 'prop-types';
 import { createHashHistory } from 'history';
+/**
+ * Internal dependencies
+ */
+import { APP_ROUTES } from '../../constants';
 
 export const RouterContext = createContext({ state: {}, actions: {} });
 
@@ -46,7 +50,7 @@ function RouterProvider({ children, ...props }) {
     history.current.location.pathname
   );
   const [availableRoutes, setAvailableRoutes] = useState([]);
-  const [defaultRoute, setDefaultRoute] = useState();
+  const defaultRoute = APP_ROUTES.DASHBOARD;
 
   const activeRoute = useMemo(
     () => getActiveRoute({ availableRoutes, currentPath, defaultRoute }),
@@ -82,7 +86,6 @@ function RouterProvider({ children, ...props }) {
         push: history.current.push,
         replace: history.current.replace,
         setAvailableRoutes,
-        setDefaultRoute,
       },
     }),
     [activeRoute, availableRoutes, currentPath, defaultRoute, queryParams]

--- a/packages/dashboard/src/app/router/routerProvider.js
+++ b/packages/dashboard/src/app/router/routerProvider.js
@@ -29,6 +29,17 @@ import { createHashHistory } from 'history';
 
 export const RouterContext = createContext({ state: {}, actions: {} });
 
+export const getActiveRoute = ({
+  availableRoutes,
+  currentPath,
+  defaultRoute,
+}) => {
+  const matchingRoutes = availableRoutes.filter((route) =>
+    currentPath.startsWith(route)
+  );
+  // this assumes that we have a route that's just the root path (/)
+  return matchingRoutes.length <= 1 ? defaultRoute : currentPath;
+};
 function RouterProvider({ children, ...props }) {
   const history = useRef(props.history || createHashHistory());
   const [currentPath, setCurrentPath] = useState(
@@ -37,13 +48,10 @@ function RouterProvider({ children, ...props }) {
   const [availableRoutes, setAvailableRoutes] = useState([]);
   const [defaultRoute, setDefaultRoute] = useState();
 
-  const activeRoute = useMemo(() => {
-    const matchingRoutes = availableRoutes.filter((route) =>
-      currentPath.startsWith(route)
-    );
-    // this assumes that we have a route that's just the root path (/)
-    return matchingRoutes.length <= 1 ? defaultRoute : currentPath;
-  }, [availableRoutes, currentPath, defaultRoute]);
+  const activeRoute = useMemo(
+    () => getActiveRoute({ availableRoutes, currentPath, defaultRoute }),
+    [availableRoutes, currentPath, defaultRoute]
+  );
 
   const parse = (search) => {
     const params = new URLSearchParams(search);

--- a/packages/dashboard/src/app/router/routerProvider.js
+++ b/packages/dashboard/src/app/router/routerProvider.js
@@ -36,6 +36,12 @@ function RouterProvider({ children, ...props }) {
   );
   const [availableRoutes, setAvailableRoutes] = useState([]);
   const [defaultRoute, setDefaultRoute] = useState();
+  const activeRoute = useMemo(() => {
+    const matchingRoutes = availableRoutes.filter((route) =>
+      currentPath.startsWith(route)
+    );
+    return matchingRoutes.length === 0 ? defaultRoute : currentPath;
+  }, [availableRoutes, currentPath, defaultRoute]);
 
   const parse = (search) => {
     const params = new URLSearchParams(search);
@@ -56,6 +62,7 @@ function RouterProvider({ children, ...props }) {
   const value = useMemo(
     () => ({
       state: {
+        activeRoute,
         currentPath,
         queryParams,
         availableRoutes,
@@ -68,7 +75,7 @@ function RouterProvider({ children, ...props }) {
         setDefaultRoute,
       },
     }),
-    [availableRoutes, currentPath, defaultRoute, queryParams]
+    [activeRoute, availableRoutes, currentPath, defaultRoute, queryParams]
   );
 
   return (

--- a/packages/dashboard/src/app/router/routerProvider.js
+++ b/packages/dashboard/src/app/router/routerProvider.js
@@ -36,11 +36,13 @@ function RouterProvider({ children, ...props }) {
   );
   const [availableRoutes, setAvailableRoutes] = useState([]);
   const [defaultRoute, setDefaultRoute] = useState();
+
   const activeRoute = useMemo(() => {
     const matchingRoutes = availableRoutes.filter((route) =>
       currentPath.startsWith(route)
     );
-    return matchingRoutes.length === 0 ? defaultRoute : currentPath;
+    // this assumes that we have a route that's just the root path (/)
+    return matchingRoutes.length <= 1 ? defaultRoute : currentPath;
   }, [availableRoutes, currentPath, defaultRoute]);
 
   const parse = (search) => {

--- a/packages/dashboard/src/app/router/routerProvider.js
+++ b/packages/dashboard/src/app/router/routerProvider.js
@@ -34,6 +34,8 @@ function RouterProvider({ children, ...props }) {
   const [currentPath, setCurrentPath] = useState(
     history.current.location.pathname
   );
+  const [availableRoutes, setAvailableRoutes] = useState([]);
+  const [defaultRoute, setDefaultRoute] = useState();
 
   const parse = (search) => {
     const params = new URLSearchParams(search);
@@ -56,13 +58,17 @@ function RouterProvider({ children, ...props }) {
       state: {
         currentPath,
         queryParams,
+        availableRoutes,
+        defaultRoute,
       },
       actions: {
         push: history.current.push,
         replace: history.current.replace,
+        setAvailableRoutes,
+        setDefaultRoute,
       },
     }),
-    [currentPath, queryParams]
+    [availableRoutes, currentPath, defaultRoute, queryParams]
   );
 
   return (

--- a/packages/dashboard/src/app/router/test/router.js
+++ b/packages/dashboard/src/app/router/test/router.js
@@ -24,6 +24,7 @@ import { createBrowserHistory } from 'history';
  * Internal dependencies
  */
 import { RouterProvider, Route, useRouteHistory } from '..';
+import { RouterContext } from '../routerProvider';
 
 describe('RouterProvider', () => {
   it('should render the first route by default', () => {
@@ -36,6 +37,46 @@ describe('RouterProvider', () => {
 
     expect(screen.getByText('Home')).toBeInTheDocument();
     expect(screen.queryByText('Second Route')).not.toBeInTheDocument();
+  });
+
+  it('should render the default route if currentPath has no matching route of its own', () => {
+    render(
+      <RouterContext.Provider
+        value={{
+          state: {
+            currentPath: 'wpbody-content',
+            availableRoutes: ['/', '/second-route'],
+            defaultRoute: '/',
+          },
+        }}
+      >
+        <Route path="/" exact isDefault component={<div>{'Home'}</div>} />
+        <Route path="/second-route" component={<div>{'Second Route'}</div>} />
+      </RouterContext.Provider>
+    );
+
+    expect(screen.getByText('Home')).toBeInTheDocument();
+    expect(screen.queryByText('Second Route')).not.toBeInTheDocument();
+  });
+
+  it('should render secondary route on a partial match', () => {
+    render(
+      <RouterContext.Provider
+        value={{
+          state: {
+            currentPath: '/second-route123',
+            availableRoutes: ['/', '/second-route'],
+            defaultRoute: '/',
+          },
+        }}
+      >
+        <Route path="/" exact isDefault component={<div>{'Home'}</div>} />
+        <Route path="/second-route" component={<div>{'Second Route'}</div>} />
+      </RouterContext.Provider>
+    );
+
+    expect(screen.queryByText('Home')).not.toBeInTheDocument();
+    expect(screen.getByText('Second Route')).toBeInTheDocument();
   });
 
   it('should render the second route when navigated to', async () => {

--- a/packages/dashboard/src/app/router/test/routerProvider.js
+++ b/packages/dashboard/src/app/router/test/routerProvider.js
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react-hooks';
+/**
+ * Internal dependencies
+ */
+import RouterProvider from '../routerProvider';
+import useRouteHistory from '../useRouteHistory';
+
+const DEFAULT_ROUTE = '/';
+const ROUTE_LIST = ['/templates-gallery', '/settings', '/custom-route'];
+
+describe('routerProvider', () => {
+  let result = null;
+
+  beforeEach(async () => {
+    const { result: _result } = renderHook(() => useRouteHistory(), {
+      wrapper: (props) => <RouterProvider {...props} />,
+    });
+
+    await act(async () => {
+      await _result.current.actions.setAvailableRoutes([
+        ...ROUTE_LIST,
+        DEFAULT_ROUTE,
+      ]);
+      await _result.current.actions.setDefaultRoute(DEFAULT_ROUTE);
+    });
+    result = _result;
+  });
+
+  it('should set available and default routes', () => {
+    expect(result.current.state.availableRoutes).toStrictEqual([
+      ...ROUTE_LIST,
+      DEFAULT_ROUTE,
+    ]);
+    expect(result.current.state.defaultRoute).toStrictEqual(DEFAULT_ROUTE);
+    expect(result.current.state.activeRoute).toStrictEqual(DEFAULT_ROUTE);
+  });
+
+  it('should keep activeRoute in sync even when route is not in our list of availableRoutes', async () => {
+    expect(result.current.state.activeRoute).toStrictEqual(DEFAULT_ROUTE);
+
+    await act(async () => {
+      await result.current.actions.push(ROUTE_LIST[0]);
+    });
+    expect(result.current.state.activeRoute).toStrictEqual(ROUTE_LIST[0]);
+
+    await act(async () => {
+      await result.current.actions.push('wpbody-content');
+    });
+    expect(result.current.state.activeRoute).toStrictEqual(DEFAULT_ROUTE);
+
+    await act(async () => {
+      await result.current.actions.push(`${ROUTE_LIST[0]}?id=51&isLocal=false`);
+    });
+    expect(result.current.state.activeRoute).toStrictEqual(ROUTE_LIST[0]);
+  });
+});

--- a/packages/dashboard/src/app/router/test/routerProvider.js
+++ b/packages/dashboard/src/app/router/test/routerProvider.js
@@ -36,14 +36,11 @@ describe('routerProvider', () => {
 
     await act(async () => {
       await result.current.actions.setAvailableRoutes(AVAILABLE_ROUTES);
-      await result.current.actions.setDefaultRoute(DEFAULT_ROUTE);
     });
 
     expect(result.current.state.availableRoutes).toStrictEqual(
       AVAILABLE_ROUTES
     );
-    expect(result.current.state.defaultRoute).toStrictEqual(DEFAULT_ROUTE);
-    expect(result.current.state.activeRoute).toStrictEqual(DEFAULT_ROUTE);
   });
 
   it.each`

--- a/packages/dashboard/src/components/interfaceSkeleton/index.js
+++ b/packages/dashboard/src/components/interfaceSkeleton/index.js
@@ -79,7 +79,9 @@ const InterfaceSkeleton = ({ additionalRoutes }) => {
     if (availableRoutes.length > 0) {
       return;
     }
-    const additionalPaths = additionalRoutes?.map(({ path }) => path);
+    const additionalPaths = additionalRoutes
+      ? additionalRoutes.map(({ path }) => path)
+      : [];
     setAvailableRoutes([...Object.values(APP_ROUTES), ...additionalPaths]);
     setDefaultRoute(APP_ROUTES.DASHBOARD);
   }, [additionalRoutes, availableRoutes, setAvailableRoutes, setDefaultRoute]);

--- a/packages/dashboard/src/components/interfaceSkeleton/index.js
+++ b/packages/dashboard/src/components/interfaceSkeleton/index.js
@@ -45,7 +45,7 @@ const InterfaceSkeleton = ({ additionalRoutes }) => {
       templateId: state.queryParams.id,
     })
   );
-  const { push, setAvailableRoutes, setDefaultRoute } = useRouteHistory(
+  const { push, setAvailableRoutes } = useRouteHistory(
     ({ actions }) => actions
   );
 
@@ -98,13 +98,7 @@ const InterfaceSkeleton = ({ additionalRoutes }) => {
       ? additionalRoutes.map(({ path }) => path)
       : [];
     setAvailableRoutes([...Object.values(APP_ROUTES), ...additionalPaths]);
-    setDefaultRoute(APP_ROUTES.DASHBOARD);
-  }, [
-    additionalRoutes,
-    availableRoutes.length,
-    setAvailableRoutes,
-    setDefaultRoute,
-  ]);
+  }, [additionalRoutes, availableRoutes.length, setAvailableRoutes]);
 
   useEffect(() => {
     if (!isRedirectComplete) {

--- a/packages/dashboard/src/components/interfaceSkeleton/index.js
+++ b/packages/dashboard/src/components/interfaceSkeleton/index.js
@@ -39,13 +39,15 @@ import useApi from '../../app/api/useApi';
 import { useConfig } from '../../app/config';
 
 const InterfaceSkeleton = ({ additionalRoutes }) => {
-  const {
-    state: {
-      currentPath,
-      queryParams: { id: templateId },
-    },
-    actions: { push },
-  } = useRouteHistory();
+  const { currentPath, templateId, availableRoutes } = useRouteHistory(
+    ({ state }) => ({
+      ...state,
+      templateId: state.queryParams.id,
+    })
+  );
+  const { push, setAvailableRoutes, setDefaultRoute } = useRouteHistory(
+    ({ actions }) => actions
+  );
 
   const {
     canViewDefaultTemplates,
@@ -71,6 +73,16 @@ const InterfaceSkeleton = ({ additionalRoutes }) => {
   const [isRedirectComplete, setIsRedirectComplete] = useState(
     !isFirstLoadOnMyStories.current
   );
+
+  // Only set the available routes & default route on initial mount
+  useEffect(() => {
+    if (availableRoutes.length > 0) {
+      return;
+    }
+    const additionalPaths = additionalRoutes?.map(({ path }) => path);
+    setAvailableRoutes([...Object.values(APP_ROUTES), ...additionalPaths]);
+    setDefaultRoute(APP_ROUTES.DASHBOARD);
+  }, [additionalRoutes, availableRoutes, setAvailableRoutes, setDefaultRoute]);
 
   // Direct user to templates on first load if they
   // have no stories created.
@@ -135,6 +147,7 @@ const InterfaceSkeleton = ({ additionalRoutes }) => {
         <PageContent>
           <Route
             exact
+            isDefault
             path={APP_ROUTES.DASHBOARD}
             component={<MyStoriesView />}
           />

--- a/packages/dashboard/src/components/interfaceSkeleton/index.js
+++ b/packages/dashboard/src/components/interfaceSkeleton/index.js
@@ -74,18 +74,6 @@ const InterfaceSkeleton = ({ additionalRoutes }) => {
     !isFirstLoadOnMyStories.current
   );
 
-  // Only set the available routes & default route on initial mount
-  useEffect(() => {
-    if (availableRoutes.length > 0) {
-      return;
-    }
-    const additionalPaths = additionalRoutes
-      ? additionalRoutes.map(({ path }) => path)
-      : [];
-    setAvailableRoutes([...Object.values(APP_ROUTES), ...additionalPaths]);
-    setDefaultRoute(APP_ROUTES.DASHBOARD);
-  }, [additionalRoutes, availableRoutes, setAvailableRoutes, setDefaultRoute]);
-
   // Direct user to templates on first load if they
   // have no stories created.
   useEffect(() => {
@@ -100,6 +88,23 @@ const InterfaceSkeleton = ({ additionalRoutes }) => {
       setIsRedirectComplete(true);
     });
   }, [addInitialFetchListener, push, currentPath, canViewDefaultTemplates]);
+
+  // Only set the available routes & default route on initial mount
+  useEffect(() => {
+    if (availableRoutes.length > 0) {
+      return;
+    }
+    const additionalPaths = additionalRoutes
+      ? additionalRoutes.map(({ path }) => path)
+      : [];
+    setAvailableRoutes([...Object.values(APP_ROUTES), ...additionalPaths]);
+    setDefaultRoute(APP_ROUTES.DASHBOARD);
+  }, [
+    additionalRoutes,
+    availableRoutes.length,
+    setAvailableRoutes,
+    setDefaultRoute,
+  ]);
 
   useEffect(() => {
     if (!isRedirectComplete) {

--- a/packages/dashboard/src/components/pageStructure/leftRail.js
+++ b/packages/dashboard/src/components/pageStructure/leftRail.js
@@ -57,7 +57,8 @@ const IconWrap = styled.div`
 `;
 
 function LeftRail() {
-  const { state } = useRouteHistory();
+  const activeRoute = useRouteHistory(({ state }) => state.activeRoute);
+
   const {
     newStoryURL,
     version,
@@ -147,13 +148,13 @@ function LeftRail() {
               return (
                 <NavListItem key={path.value}>
                   <NavLink
-                    active={path.value === state.currentPath}
+                    active={activeRoute === path.value}
                     href={resolveRoute(path.value)}
                     size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}
                     isBold
                     isIconLink={Boolean(Icon)}
                     aria-label={
-                      path.value === state.currentPath
+                      activeRoute === path.value
                         ? sprintf(
                             /* translators: %s: the current page, for example "Dashboard". */
                             __('%s (active view)', 'web-stories'),
@@ -185,11 +186,11 @@ function LeftRail() {
             {leftRailSecondaryNavigation.map((path) => (
               <NavListItem key={path.value}>
                 <NavLink
-                  active={path.value === state.currentPath}
+                  active={activeRoute === path.value}
                   href={resolveRoute(path.value)}
                   size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}
                   aria-label={
-                    path.value === state.currentPath
+                    activeRoute === path.value
                       ? sprintf(
                           /* translators: %s: the current page, for example "Dashboard". */
                           __('%s (active view)', 'web-stories'),

--- a/packages/e2e-tests/src/specs/dashboard/dashboard.js
+++ b/packages/e2e-tests/src/specs/dashboard/dashboard.js
@@ -62,6 +62,19 @@ describe('Stories Dashboard', () => {
     await expect(page).toMatchElement('h2', {
       text: /^Dashboard/,
     });
+    // Now let's make sure that the next focusable element is the link to create a new story
+    page.keyboard.press('Tab');
+
+    const activeElement = await page.evaluate(() => {
+      return {
+        text: document.activeElement.textContent,
+        element: document.activeElement.tagName.toLowerCase(),
+      };
+    });
+    await expect(activeElement).toMatchObject({
+      text: 'Create New Story',
+      element: 'a',
+    });
 
     await takeSnapshot(page, 'Stories Dashboard on Keyboard Navigation', {
       percyCSS,

--- a/packages/e2e-tests/src/specs/dashboard/dashboard.js
+++ b/packages/e2e-tests/src/specs/dashboard/dashboard.js
@@ -42,6 +42,27 @@ describe('Stories Dashboard', () => {
     await takeSnapshot(page, 'Stories Dashboard', { percyCSS });
   });
 
+  it('should be able to skip to main content of Dashboard', async () => {
+    await visitDashboard();
+
+    // If there are no existing stories, the app goes to the templates page instead.
+    // Account for both here, but then force-visit the dashboard.
+    await expect(page).toMatchElement('h2', {
+      text: /(Dashboard|Explore Templates)/,
+    });
+
+    // When navigating to Dashboard, immediately use keyboard to
+    // tab to WordPress shortcut of "Main Content"
+    page.keyboard.press('Tab');
+    page.keyboard.press('Enter');
+
+    await expect(page).toMatchElement('h2', {
+      text: /(Dashboard|Explore Templates)/,
+    });
+
+    await takeSnapshot(page, 'Stories Dashboard on Main Content', { percyCSS });
+  });
+
   it('should choose sort option for display', async () => {
     await visitDashboard();
     await expect(page).toClick('[aria-label="Dashboard"]', {

--- a/packages/e2e-tests/src/specs/dashboard/dashboard.js
+++ b/packages/e2e-tests/src/specs/dashboard/dashboard.js
@@ -42,11 +42,11 @@ describe('Stories Dashboard', () => {
     await takeSnapshot(page, 'Stories Dashboard', { percyCSS });
   });
 
-  it('should be able to skip to main content of Dashboard', async () => {
+  it('should be able to skip to main content of Dashboard for keyboard navigation', async () => {
     await visitDashboard();
 
     // If there are no existing stories, the app goes to the templates page instead.
-    // Account for both here, but then force-visit the dashboard.
+    // Either is fine since we're testing keyboard navigation.
     await expect(page).toMatchElement('h2', {
       text: /(Dashboard|Explore Templates)/,
     });
@@ -54,13 +54,18 @@ describe('Stories Dashboard', () => {
     // When navigating to Dashboard, immediately use keyboard to
     // tab to WordPress shortcut of "Main Content"
     page.keyboard.press('Tab');
+    // Verify that Main Content skip link is present
+    await expect(page).toMatchElement('a', { text: 'Skip to main content' });
+    // Use the keyboard to select skip link while it is present (since it's now focused)
     page.keyboard.press('Enter');
-
+    // Make sure we see the dashboard
     await expect(page).toMatchElement('h2', {
-      text: /(Dashboard|Explore Templates)/,
+      text: /^Dashboard/,
     });
 
-    await takeSnapshot(page, 'Stories Dashboard on Main Content', { percyCSS });
+    await takeSnapshot(page, 'Stories Dashboard on Keyboard Navigation', {
+      percyCSS,
+    });
   });
 
   it('should choose sort option for display', async () => {


### PR DESCRIPTION
## Context

This came up because when you skip to "main content" using `tab` when the dashboard loads as a keyboard user the Stories Dashboard doesn't actually allow the main content of the Dashboard  because the `Dashboard` has a path of `/` so it needs be an exact match otherwise it'll always show it since every other route has a path that will partially match `/`.

## Summary

Now `post_type=web-story&page=stories-dashboard#wpbody-content` will return the dashboard, as will `post_type=web-story&page=stories-dashboard#` and `post_type=web-story&page=stories-dashboard#/ajsdflkajdlkajsdfklasdf`.

## Relevant Technical Choices

Our router is an in-house solution because it is so minimal. I chose to add a new prop for `<Route>` called `isDefault`. This gave me the wiggle room necessary to have the dashboard base path of `/` be both `exact` and `isDefault` so that if it's exact it'll render and if it's not it will only render when no other routes also fit the criteria. I didn't want to mess with the base path for the entire dashboard. 

This means I also added complexity to the router provider and initial mount of the Dashboard. Now we track the available routes and tell the provider what the default path is so that we can use it when `<Route>` calls for it. 

## To-do

N/A

## User-facing changes

(note the `&page=stories-dashboard#wpbody-content` in the url path)

| Before | After | 
| --- | --- | 
| <img width="1153" alt="Screen Shot 2022-04-01 at 4 17 42 PM" src="https://user-images.githubusercontent.com/10720454/161353470-5f2a71cc-74c5-41f7-b94a-08569a9f887b.png"> |  <img width="1149" alt="Screen Shot 2022-04-01 at 4 17 13 PM" src="https://user-images.githubusercontent.com/10720454/161353478-e183cefe-588a-45af-bd27-a0fdd8c94497.png"> |

## Testing Instructions

Head to the Stories Dashboard and verify that Dashboard loads by default, that "Explore Templates" and "Template Details" still work as expected. 
Now use the keyboard to navigate to "Main Content" skip button (tab through WP admin toolbar, if you just loaded the page it'll be the first tab). Hit "Enter" on "Main Content" and you should still see the dashboard. 

Type in some wrong paths off of the dashboard base path `&page=stories-dashboard` like `&page=stories-dashboard#/jalkfjalkjflakdjflk` and see that the dashboard default view is still showing. 

Also test a user that has no stories yet. What happens there is on the first page load the user is sent to "Explore Templates", the user interacting with "Main Content" for keyboard user is no longer the initial load so it'll actually bring the user to Dashboard Stories instead. 


## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11055 
