### PR TITLE
Simplify `useElementsWithLinks`

### DIFF
--- a/packages/story-editor/src/components/panels/design/link/link.js
+++ b/packages/story-editor/src/components/panels/design/link/link.js
@@ -39,7 +39,7 @@ import {
  * Internal dependencies
  */
 import { MULTIPLE_VALUE, MULTIPLE_DISPLAY_VALUE } from '../../../../constants';
-import { useStory, useAPI, useCanvas } from '../../../../app';
+import { useAPI, useCanvas } from '../../../../app';
 import useElementsWithLinks from '../../../../utils/useElementsWithLinks';
 import { Row, LinkInput, LinkIcon } from '../../../form';
 import { createLink } from '../../../elementLink';
@@ -76,10 +76,6 @@ function LinkPanel({ selectedElements, pushUpdateForObject }) {
       displayLinkGuidelines: state.state.displayLinkGuidelines,
     }));
 
-  const { currentPage } = useStory((state) => ({
-    currentPage: state.state.currentPage,
-  }));
-
   const { highlight, resetHighlight, cancelHighlight } = useHighlights(
     (state) => ({
       highlight: state[states.LINK],
@@ -88,10 +84,7 @@ function LinkPanel({ selectedElements, pushUpdateForObject }) {
     })
   );
 
-  const { getElementsInAttachmentArea } = useElementsWithLinks();
-  const hasElementsInAttachmentArea =
-    getElementsInAttachmentArea(selectedElements).length > 0 &&
-    currentPage?.pageAttachment?.url?.length > 0;
+  const { hasElementsInAttachmentArea } = useElementsWithLinks();
 
   const defaultLink = useMemo(() => createLink({ icon: null, desc: null }), []);
 

--- a/packages/story-editor/src/components/panels/design/pageAttachment/pageAttachment.js
+++ b/packages/story-editor/src/components/panels/design/pageAttachment/pageAttachment.js
@@ -90,9 +90,7 @@ function PageAttachmentPanel() {
   const [displayWarning, setDisplayWarning] = useState(false);
   const [fetchingMetadata, setFetchingMetadata] = useState(false);
 
-  const { getLinksInAttachmentArea } = useElementsWithLinks();
-  const linksInAttachmentArea = getLinksInAttachmentArea();
-  const hasLinksInAttachmentArea = linksInAttachmentArea.length > 0;
+  const { hasLinksInAttachmentArea } = useElementsWithLinks();
 
   // Stop displaying guidelines when unmounting.
   useEffect(() => {

--- a/packages/story-editor/src/utils/useElementsWithLinks.js
+++ b/packages/story-editor/src/utils/useElementsWithLinks.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { useCallback, useMemo } from '@googleforcreators/react';
+import { useCallback } from '@googleforcreators/react';
 import { isElementBelowLimit } from '@googleforcreators/elements';
 
 /**
@@ -26,55 +26,40 @@ import { isElementBelowLimit } from '@googleforcreators/elements';
 import { useStory, useCanvas } from '../app';
 
 function useElementsWithLinks() {
-  const { currentPage, selectedElements } = useStory((state) => ({
-    currentPage: state.state.currentPage,
-    selectedElements: state.state.selectedElements,
-  }));
   const { pageAttachmentContainer } = useCanvas((state) => ({
     pageAttachmentContainer: state.state.pageAttachmentContainer,
   }));
+  const {
+    hasLinksInAttachmentArea,
+    hasInvalidLinkSelected,
+    hasPageAttachment,
+    hasElementsInAttachmentArea,
+  } = useStory(({ state }) => {
+    const elementHasLink = ({ link }) => link?.url?.length;
+    const elementsWithLinks = state.currentPage.elements.filter(elementHasLink);
 
-  const { elements } = currentPage;
-  const elementsWithLinks = useMemo(
-    () => elements.filter(({ link }) => link?.url?.length),
-    [elements]
-  );
+    const hasPageAttachment = Boolean(
+      state.currentPage?.pageAttachment?.url?.length
+    );
 
-  // Checks if there is a link with invalid position among the selection.
-  const hasInvalidLinkSelected = useCallback(() => {
-    if (!pageAttachmentContainer) {
-      return false;
-    }
-    if (!currentPage?.pageAttachment?.url?.length) {
-      return false;
-    }
-    const linksInActivePageAttachment = selectedElements
-      .filter(({ link }) => link?.url?.length)
-      .filter((element) => {
-        return isElementBelowLimit(element);
-      });
-    return linksInActivePageAttachment.length > 0;
-  }, [currentPage, selectedElements, pageAttachmentContainer]);
-
-  /**
-   * Returns the elements that were found in the attachment area.
-   */
-  const getElementsInAttachmentArea = useCallback(
-    (els, verifyLink = false) => {
-      if (!pageAttachmentContainer) {
-        return [];
-      }
-      return els.filter((element) => {
-        return isElementBelowLimit(element, verifyLink);
-      });
-    },
-    [pageAttachmentContainer]
-  );
-
-  // Checks if a link is in the attachment area, even if there's no active attachment.
-  const getLinksInAttachmentArea = useCallback(() => {
-    return getElementsInAttachmentArea(elementsWithLinks, true);
-  }, [elementsWithLinks, getElementsInAttachmentArea]);
+    return {
+      hasInvalidLinkSelected:
+        pageAttachmentContainer &&
+        hasPageAttachment &&
+        state.selectedElements.filter(elementHasLink).some(isElementBelowLimit),
+      hasLinksInAttachmentArea:
+        pageAttachmentContainer &&
+        elementsWithLinks.filter((element) =>
+          isElementBelowLimit(element, true)
+        ),
+      hasElementsInAttachmentArea:
+        pageAttachmentContainer &&
+        hasPageAttachment &&
+        state.selectedElements.filter((element) =>
+          isElementBelowLimit(element, true)
+        ),
+    };
+  });
 
   const isElementInAttachmentArea = useCallback(
     (element) => {
@@ -82,20 +67,21 @@ function useElementsWithLinks() {
         return false;
       }
       // If there is no Page Attachment present, return.
-      if (!currentPage?.pageAttachment?.url.length) {
+      if (!hasPageAttachment) {
         return false;
       }
       // If the node is inside the page attachment container.
       return isElementBelowLimit(element, false);
     },
-    [pageAttachmentContainer, currentPage]
+    [pageAttachmentContainer, hasPageAttachment]
   );
 
   return {
-    getLinksInAttachmentArea,
-    hasInvalidLinkSelected: hasInvalidLinkSelected(),
+    hasLinksInAttachmentArea,
+    hasInvalidLinkSelected,
     isElementInAttachmentArea,
-    getElementsInAttachmentArea,
+    hasElementsInAttachmentArea,
+    hasPageAttachment,
   };
 }
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

While working on another PR I noticed that the `useElementsWithLinks` hook was written a bit overly complicated and could use some simplification.

## Summary

<!-- A brief description of what this PR does. -->

Instead of getting all the information via callbacks, information about links and page attachments can be derived from the `useStory` selector.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

None

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
