### PR TITLE
Embeds: avoid empty `srcset` and `sizes` attributes

### DIFF
--- a/includes/Model/Story.php
+++ b/includes/Model/Story.php
@@ -109,21 +109,21 @@ class Story {
 	 *
 	 * @var string
 	 */
-	protected $poster_portrait;
+	protected $poster_portrait = '';
 
 	/**
 	 * Date for the story.
 	 *
 	 * @var string
 	 */
-	protected $date;
+	protected $date = '';
 
 	/**
 	 * Author of story.
 	 *
 	 * @var string
 	 */
-	protected $author;
+	protected $author = '';
 
 	/**
 	 * Story constructor.
@@ -212,7 +212,7 @@ class Story {
 	 * @since 1.18.0
 	 */
 	public function get_poster_sizes(): string {
-		return (string) $this->poster_sizes;
+		return $this->poster_sizes;
 	}
 
 	/**
@@ -221,7 +221,7 @@ class Story {
 	 * @since 1.18.0
 	 */
 	public function get_poster_srcset(): string {
-		return (string) $this->poster_srcset;
+		return $this->poster_srcset;
 	}
 
 	/**
@@ -230,14 +230,14 @@ class Story {
 	 * @since 1.0.0
 	 */
 	public function get_title(): string {
-		return (string) $this->title;
+		return $this->title;
 	}
 
 	/**
 	 * Getter for excerpt attribute.
 	 */
 	public function get_excerpt(): string {
-		return (string) $this->excerpt;
+		return $this->excerpt;
 	}
 
 	/**
@@ -246,7 +246,7 @@ class Story {
 	 * @since 1.0.0
 	 */
 	public function get_url(): string {
-		return (string) $this->url;
+		return $this->url;
 	}
 
 	/**
@@ -255,7 +255,7 @@ class Story {
 	 * @since 1.0.0
 	 */
 	public function get_markup(): string {
-		return (string) $this->markup;
+		return $this->markup;
 	}
 
 	/**
@@ -264,28 +264,28 @@ class Story {
 	 * @since 1.0.0
 	 */
 	public function get_poster_portrait(): string {
-		return (string) $this->poster_portrait;
+		return $this->poster_portrait;
 	}
 
 	/**
 	 * Get the story ID.
 	 */
 	public function get_id(): int {
-		return (int) $this->id;
+		return $this->id;
 	}
 
 	/**
 	 * Get author of the story.
 	 */
 	public function get_author(): string {
-		return (string) $this->author;
+		return $this->author;
 	}
 
 	/**
 	 * Date for the story.
 	 */
 	public function get_date(): string {
-		return (string) $this->date;
+		return $this->date;
 	}
 
 	/**

--- a/includes/Renderer/Stories/Renderer.php
+++ b/includes/Renderer/Stories/Renderer.php
@@ -557,7 +557,9 @@ abstract class Renderer implements RenderingInterface, Iterator {
 		 */
 		$story = $this->current();
 
-		$poster_url = $story->get_poster_portrait();
+		$poster_url    = $story->get_poster_portrait();
+		$poster_srcset = $story->get_poster_srcset();
+		$poster_sizes  = $story->get_poster_sizes();
 
 		if ( ! $poster_url ) {
 			?>
@@ -578,8 +580,12 @@ abstract class Renderer implements RenderingInterface, Iterator {
 						alt="<?php echo esc_attr( $story->get_title() ); ?>"
 						width="<?php echo absint( $this->width ); ?>"
 						height="<?php echo absint( $this->height ); ?>"
-						srcset="<?php echo esc_attr( $story->get_poster_srcset() ); ?>"
-						sizes="<?php echo esc_attr( $story->get_poster_sizes() ); ?>"
+						<?php if ( ! empty( $poster_srcset ) ) { ?>
+							srcset="<?php echo esc_attr( $poster_srcset ); ?>"
+						<?php } ?>
+						<?php if ( ! empty( $poster_sizes ) ) { ?>
+							sizes="<?php echo esc_attr( $poster_sizes ); ?>"
+						<?php } ?>
 						loading="lazy"
 						decoding="async"
 					>

--- a/includes/Renderer/Story/Embed.php
+++ b/includes/Renderer/Story/Embed.php
@@ -93,9 +93,9 @@ class Embed {
 		$class         = $args['class'];
 		$url           = $this->story->get_url();
 		$title         = $this->story->get_title();
-		$poster        = ! empty( $this->story->get_poster_portrait() ) ? $this->story->get_poster_portrait() : '';
-		$poster_srcset = ! empty( $this->story->get_poster_srcset() ) ? $this->story->get_poster_srcset() : '';
-		$poster_sizes  = ! empty( $this->story->get_poster_sizes() ) ? $this->story->get_poster_sizes() : '';
+		$poster        = $this->story->get_poster_portrait();
+		$poster_srcset = $this->story->get_poster_srcset();
+		$poster_sizes  = $this->story->get_poster_sizes();
 
 		$wrapper_style = sprintf(
 			'--aspect-ratio: %F; --width: %dpx; --height: %dpx',
@@ -123,8 +123,12 @@ class Embed {
 									width="<?php echo esc_attr( $args['width'] ); ?>"
 									height="<?php echo esc_attr( $args['height'] ); ?>"
 									alt="<?php echo esc_attr( $title ); ?>"
-									srcset="<?php echo esc_attr( $poster_srcset ); ?>"
-									sizes="<?php echo esc_attr( $poster_sizes ); ?>"
+									<?php if ( ! empty( $poster_srcset ) ) { ?>
+										srcset="<?php echo esc_attr( $poster_srcset ); ?>"
+									<?php } ?>
+									<?php if ( ! empty( $poster_sizes ) ) { ?>
+										sizes="<?php echo esc_attr( $poster_sizes ); ?>"
+									<?php } ?>
 									loading="lazy"
 									decoding="async"
 									data-amp-story-player-poster-img
@@ -157,8 +161,12 @@ class Embed {
 								width="<?php echo esc_attr( $args['width'] ); ?>"
 								height="<?php echo esc_attr( $args['height'] ); ?>"
 								alt="<?php echo esc_attr( $title ); ?>"
-								srcset="<?php echo esc_attr( $poster_srcset ); ?>"
-								sizes="<?php echo esc_attr( $poster_sizes ); ?>"
+								<?php if ( ! empty( $poster_srcset ) ) { ?>
+									srcset="<?php echo esc_attr( $poster_srcset ); ?>"
+								<?php } ?>
+								<?php if ( ! empty( $poster_sizes ) ) { ?>
+									sizes="<?php echo esc_attr( $poster_sizes ); ?>"
+								<?php } ?>
 								loading="lazy"
 								decoding="async"
 								data-amp-story-player-poster-img

--- a/includes/Renderer/Story/Embed.php
+++ b/includes/Renderer/Story/Embed.php
@@ -75,6 +75,8 @@ class Embed {
 	/**
 	 * Renders the block output in default context.
 	 *
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+	 *
 	 * @since 1.0.0
 	 *
 	 * @param array $args Array of Argument to render.

--- a/includes/Renderer/Story/Image.php
+++ b/includes/Renderer/Story/Image.php
@@ -70,23 +70,34 @@ class Image {
 		$align    = sprintf( 'align%s', $args['align'] );
 		$class    = $args['class'];
 
+		$url           = $this->story->get_url();
+		$title         = $this->story->get_title();
+		$poster        = $this->story->get_poster_portrait();
+		$poster_srcset = $this->story->get_poster_srcset();
+		$poster_sizes  = $this->story->get_poster_sizes();
+
 		ob_start();
 		?>
 		<div class="<?php echo esc_attr( $class ); ?> <?php echo esc_attr( $align ); ?>">
-			<a href="<?php echo esc_url( $this->story->get_url() ); ?>">
-				<?php
-				if ( ! empty( $this->story->get_poster_portrait() ) ) {
-					printf(
-						'<img src="%1$s" width="%2$d" height="%3$d" alt="%4$s" srcset="%5$s" sizes="%6$s" loading="lazy" decoding="async" />',
-						esc_url( $this->story->get_poster_portrait() ),
-						absint( $args['width'] ),
-						absint( $args['height'] ),
-						esc_attr( $this->story->get_title() ),
-						esc_attr( $this->story->get_poster_srcset() ),
-						esc_attr( $this->story->get_poster_sizes() )
-					);
+			<a href="<?php echo esc_url( $url ); ?>">
+				<?php if ( ! empty( $poster ) ) { ?>
+					<img
+						src="<?php echo esc_url( $poster ); ?>"
+						width="<?php echo esc_attr( $args['width'] ); ?>"
+						height="<?php echo esc_attr( $args['height'] ); ?>"
+						alt="<?php echo esc_attr( $title ); ?>"
+						<?php if ( ! empty( $poster_srcset ) ) { ?>
+							srcset="<?php echo esc_attr( $poster_srcset ); ?>"
+						<?php } ?>
+						<?php if ( ! empty( $poster_sizes ) ) { ?>
+							sizes="<?php echo esc_attr( $poster_sizes ); ?>"
+						<?php } ?>
+						loading="lazy"
+						decoding="async"
+					/>
+					<?php
 				} else {
-					echo esc_html( $this->story->get_title() );
+					echo esc_html( $title );
 				}
 				?>
 			</a>

--- a/tests/phpunit/integration/tests/Renderer/Story/Embed.php
+++ b/tests/phpunit/integration/tests/Renderer/Story/Embed.php
@@ -96,4 +96,49 @@ class Embed extends DependencyInjectedTestCase {
 		$this->assertStringContainsString( 'srcset=', $render );
 		$this->assertStringContainsString( 'sizes=', $render );
 	}
+
+	/**
+	 * @covers ::render
+	 */
+	public function test_render_with_image_missing_srcset_and_sizes(): void {
+		$post = self::factory()->post->create_and_get(
+			[
+				'post_title'   => 'test title',
+				'post_type'    => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
+				'post_content' => '<html><head></head><body><amp-story></amp-story></body></html>',
+			]
+		);
+
+		$poster_attachment_id = self::factory()->attachment->create_object(
+			[
+				'file'           => DIR_TESTDATA . '/images/canola.jpg',
+				'post_parent'    => 0,
+				'post_mime_type' => 'image/jpeg',
+				'post_title'     => 'Test Image',
+			]
+		);
+
+		set_post_thumbnail( $post->ID, $poster_attachment_id );
+
+		$story = new \Google\Web_Stories\Model\Story();
+		$story->load_from_post( $post );
+
+		$this->assertNotEmpty( $story->get_poster_portrait() );
+		$this->assertEmpty( $story->get_poster_sizes() );
+		$this->assertEmpty( $story->get_poster_srcset() );
+
+		$embed  = new \Google\Web_Stories\Renderer\Story\Embed( $story, $this->assets, $this->context );
+		$args   = [
+			'align'  => 'none',
+			'height' => 600,
+			'width'  => 360,
+		];
+		$render = $embed->render( $args );
+		$this->assertStringContainsString( 'test title', $render );
+		$this->assertStringContainsString( '<img', $render );
+		$this->assertStringContainsString( 'loading=', $render );
+		$this->assertStringContainsString( 'decoding=', $render );
+		$this->assertStringNotContainsString( 'srcset=', $render );
+		$this->assertStringNotContainsString( 'sizes=', $render );
+	}
 }

--- a/tests/phpunit/integration/tests/Renderer/Story/Image.php
+++ b/tests/phpunit/integration/tests/Renderer/Story/Image.php
@@ -76,4 +76,46 @@ class Image extends TestCase {
 		$this->assertStringContainsString( 'loading=', $render );
 		$this->assertStringContainsString( 'decoding=', $render );
 	}
+
+	/**
+	 * @covers ::render
+	 */
+	public function test_render_with_image_missing_srcset_and_sizes(): void {
+		$post = self::factory()->post->create_and_get(
+			[
+				'post_title'   => 'test title',
+				'post_type'    => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
+				'post_content' => '<html><head></head><body><amp-story></amp-story></body></html>',
+			]
+		);
+
+		$poster_attachment_id = self::factory()->attachment->create_object(
+			[
+				'file'           => DIR_TESTDATA . '/images/canola.jpg',
+				'post_parent'    => 0,
+				'post_mime_type' => 'image/jpeg',
+				'post_title'     => 'Test Image',
+			]
+		);
+
+		set_post_thumbnail( $post->ID, $poster_attachment_id );
+
+		$story = new \Google\Web_Stories\Model\Story();
+		$story->load_from_post( $post );
+
+		$this->assertNotEmpty( $story->get_poster_portrait() );
+		$this->assertEmpty( $story->get_poster_sizes() );
+		$this->assertEmpty( $story->get_poster_srcset() );
+
+		$image  = new \Google\Web_Stories\Renderer\Story\Image( $story );
+		$args   = [
+			'align'  => 'none',
+			'height' => 600,
+			'width'  => 360,
+		];
+		$render = $image->render( $args );
+		$this->assertStringContainsString( '<img', $render );
+		$this->assertStringNotContainsString( 'srcset=', $render );
+		$this->assertStringNotContainsString( 'sizes=', $render );
+	}
 }


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

@fellyph reported to me an issue with the Web Stories block and AMP validation.

AMP does not allow empty `srcset=""` attributes.

Introduced in #10531

## Summary

<!-- A brief description of what this PR does. -->

This PR prevents AMP validation errors due to such empty `srcset` and `sizes` attributes.

## Relevant Technical Choices

<!-- Please describe your changes. -->

Changed default properties of the `Story` model to use empty strings instead of `null`, to avoid having to check against `null` everywhere and to prevent the need for type casting.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

None

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Embed a single story using the Web Stories block
2. Preview the post
3. Verify that the story image does not have empty `srcset=""` and `sizes=""` attributes

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
