### PR TITLE
Floating Menus: adjust input widths

### DIFF
--- a/packages/story-editor/src/components/floatingMenu/elements/fontSize.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/fontSize.js
@@ -18,8 +18,10 @@
  * External dependencies
  */
 import { __ } from '@googleforcreators/i18n';
+import styled from 'styled-components';
 import { useCallback } from '@googleforcreators/react';
 import { trackEvent } from '@googleforcreators/tracking';
+import { NumericInput } from '@googleforcreators/design-system';
 
 /**
  * Internal dependencies
@@ -32,8 +34,11 @@ import {
   inputContainerStyleOverride,
 } from '../../panels/shared/styles';
 import { MIN_MAX } from '../../panels/design/textStyle/font';
-// TODO: https://github.com/GoogleForCreators/web-stories-wp/issues/10799
-import { Input } from './shared';
+
+const Input = styled(NumericInput)`
+  width: 50px;
+  flex: 0 0 50px;
+`;
 
 function FontSize() {
   const { fontSize, updateSelectedElements } = useStory(

--- a/packages/story-editor/src/components/floatingMenu/elements/layerOpacity.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/layerOpacity.js
@@ -17,8 +17,9 @@
 /**
  * External dependencies
  */
-import { Icons } from '@googleforcreators/design-system';
-import { __ } from '@googleforcreators/i18n';
+import styled from 'styled-components';
+import { __, _x } from '@googleforcreators/i18n';
+import { Icons, NumericInput } from '@googleforcreators/design-system';
 import { trackEvent } from '@googleforcreators/tracking';
 
 /**
@@ -26,7 +27,12 @@ import { trackEvent } from '@googleforcreators/tracking';
  */
 import { useStory } from '../../../app';
 import { MIN_MAX } from '../../panels/design/sizePosition/opacity';
-import { Input, useProperties } from './shared';
+import { useProperties } from './shared';
+
+const Input = styled(NumericInput)`
+  width: 82px;
+  flex: 0 0 82px;
+`;
 
 function LayerOpacity() {
   const { opacity, type } = useProperties(['opacity', 'type']);
@@ -50,6 +56,7 @@ function LayerOpacity() {
   return (
     <Input
       suffix={<Icons.ColorDrop />}
+      unit={_x('%', 'Percentage', 'web-stories')}
       value={opacity || 0}
       aria-label={__('Opacity in percent', 'web-stories')}
       onChange={handleOpacityChange}

--- a/packages/story-editor/src/components/floatingMenu/elements/shared/color.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/shared/color.js
@@ -27,7 +27,7 @@ import PropTypes from 'prop-types';
 import Color from '../../../form/color';
 
 const EYEDROPPER_WIDTH = 38; // icon width + spacing
-const WIDTH_INCLUDING_INPUTS = 178;
+const WIDTH_INCLUDING_INPUTS = 184;
 const WIDTH_EXCLUDING_INPUTS = 60;
 
 const PICKER_MAX_HEIGHT = 362;

--- a/packages/story-editor/src/components/floatingMenu/elements/shared/text.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/shared/text.js
@@ -25,6 +25,8 @@ import { ContextMenuComponents } from '@googleforcreators/design-system';
 const Button = styled(ContextMenuComponents.MenuButton)`
   font-size: 14px;
   padding: 2px 12px;
+  font-weight: normal;
+  letter-spacing: normal;
 `;
 
 const TextButton = memo(function TextButton({ text, ...rest }) {

--- a/packages/story-editor/src/components/floatingMenu/elements/shared/text.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/shared/text.js
@@ -19,13 +19,19 @@
  */
 import PropTypes from 'prop-types';
 import { memo } from '@googleforcreators/react';
+import styled from 'styled-components';
 import { ContextMenuComponents } from '@googleforcreators/design-system';
+
+const Button = styled(ContextMenuComponents.MenuButton)`
+  font-size: 14px;
+  padding: 2px 12px;
+`;
 
 const TextButton = memo(function TextButton({ text, ...rest }) {
   return (
-    <ContextMenuComponents.MenuButton forcePadding {...rest}>
+    <Button forcePadding {...rest}>
       {text}
-    </ContextMenuComponents.MenuButton>
+    </Button>
   );
 });
 

--- a/packages/story-editor/src/components/floatingMenu/elements/shared/text.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/shared/text.js
@@ -24,7 +24,7 @@ import { ContextMenuComponents } from '@googleforcreators/design-system';
 
 const Button = styled(ContextMenuComponents.MenuButton)`
   font-size: 14px;
-  padding: 2px 12px;
+  padding: 0 12px;
   font-weight: normal;
   letter-spacing: normal;
 `;

--- a/packages/story-editor/src/components/form/color/opacityInput.js
+++ b/packages/story-editor/src/components/form/color/opacityInput.js
@@ -39,7 +39,7 @@ const Input = styled(NumericInput)`
 
 const minimalInputContainerStyleOverride = css`
   ${inputContainerStyleOverride};
-  width: 70px;
+  width: 76px;
   padding-right: 6px;
 `;
 
@@ -64,8 +64,6 @@ function OpacityInput({ value, onChange, isInDesignMenu }) {
 
   useEffect(() => updateFromValue(), [updateFromValue, value]);
 
-  const unit = isInDesignMenu ? null : _x('%', 'Percentage', 'web-stories');
-
   const containerStyle = isInDesignMenu
     ? minimalInputContainerStyleOverride
     : inputContainerStyleOverride;
@@ -75,7 +73,7 @@ function OpacityInput({ value, onChange, isInDesignMenu }) {
       aria-label={__('Opacity', 'web-stories')}
       onChange={handleChange}
       value={inputValue}
-      unit={unit}
+      unit={_x('%', 'Percentage', 'web-stories')}
       suffix={<Icons.ColorDrop />}
       min={0}
       max={100}


### PR DESCRIPTION
## Context
All of the numeric inputs were sharing styles, this was causing some inputs to be wider than necessary. Design also requested that the % unit be added to opacity and the `More` button have a larger font and smaller padding.  
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
||NEW|OLD|
|--|--|--|
|video|![video](https://user-images.githubusercontent.com/1820266/161832893-8e3967d4-08c8-4609-9346-2231a0db73ad.png)|![video old](https://user-images.githubusercontent.com/1820266/161833628-1fa8c495-054d-43d5-a5b6-e7772dec52df.png)|
|sticker|![sticker](https://user-images.githubusercontent.com/1820266/161832896-9ab358ec-55e6-4840-9a5d-d7ebdd65f0d9.png)|![sticker old](https://user-images.githubusercontent.com/1820266/161834171-c4ace044-708c-432c-929a-cc1ed62b73f4.png)|
|text|![text](https://user-images.githubusercontent.com/1820266/161832899-0f7ff529-1636-4db9-a8b4-a446aeb0a5c0.png)|![text old](https://user-images.githubusercontent.com/1820266/161833712-eb3d2daa-2e8c-4102-baff-0cc5e231e1e3.png)|
|image|![image](https://user-images.githubusercontent.com/1820266/161832900-8d24bc00-e63c-49a6-b97b-3ceb27bbb28c.png)|![image old](https://user-images.githubusercontent.com/1820266/161833759-a104effb-547c-4763-b1e8-715f674ee38d.png)|
|shape|![shape](https://user-images.githubusercontent.com/1820266/161832901-98a7e95f-93ae-4e54-8dbf-16dad76fee4e.png)|![shape old](https://user-images.githubusercontent.com/1820266/161833821-8583b5dc-d601-4822-acef-acd9c1b9fabd.png)|

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Open each different type of floating menu: image, text, shape, sticker, multiple, video. 
2. See the updated inputs.
3. `Font size`, `Opacity`, and `More`


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10799 
