### PR TITLE
Settings: Change selected font upon click

### DIFF
--- a/packages/e2e-tests/src/specs/dashboard/settings/adminUser/customFonts.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/adminUser/customFonts.js
@@ -99,6 +99,16 @@ describe('Custom Fonts', () => {
     await takeSnapshot(page, 'Custom Fonts Settings');
   });
 
+  it('should select font when clicked', async () => {
+    await addCustomFont(OPEN_SANS_CONDENSED_LIGHT_ITALIC_URL);
+    await addCustomFont(OPEN_SANS_CONDENSED_BOLD_URL);
+    await addCustomFont(OPEN_SANS_CONDENSED_LIGHT_URL);
+    const fonts = await getFontList();
+    await page.click('div[role=listbox] [role=option]:last-child');
+    const selected = await getSelectedFont();
+    expect(selected.name).toStrictEqual(fonts[2].name);
+  });
+
   it('should show error on trying add font twice', async () => {
     await addCustomFont(OPEN_SANS_CONDENSED_LIGHT_URL);
     await addCustomFont(OPEN_SANS_CONDENSED_LIGHT_URL);

--- a/packages/wp-dashboard/src/components/editorSettings/customFonts/index.js
+++ b/packages/wp-dashboard/src/components/editorSettings/customFonts/index.js
@@ -368,6 +368,7 @@ function CustomFontsSettings({
               }
             >
               {customFonts.map(({ id, family, url }, index) => (
+                // eslint-disable-next-line styled-components-a11y/click-events-have-key-events, styled-components-a11y/interactive-supports-focus -- keyboard handling is via the parent
                 <FontRow
                   id={`font-${id}`}
                   ref={
@@ -375,6 +376,9 @@ function CustomFontsSettings({
                   }
                   key={family}
                   role="option"
+                  onClick={() => {
+                    setCurrentFontsFocusIndex(index);
+                  }}
                   aria-selected={isListBoxActiveRow(index)}
                 >
                   <FontData>


### PR DESCRIPTION
## Context

Clicking an option under Custom Fonts doesn't select the option

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Adds a onClick hander for font options 

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.  Visit Settings `wp-admin/edit.php?post_type=web-story&page=stories-dashboard#/editor-settings`
2. Add multiple custom fonts

```
http://localhost:8899/wp-content/e2e-assets/OpenSansCondensed-Bold.ttf
http://localhost:8899/wp-content/e2e-assets/OpenSansCondensed-Light.ttf
http://localhost:8899/wp-content/e2e-assets/OpenSansCondensed-LightItalic.ttf
```

3. Click to select a font


## Reviews

### Does this PR have a security-related impact?

No

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

No

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

No

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11148
