### PR TITLE
Settings: announce deleted custom font

### DIFF
--- a/packages/wp-dashboard/src/components/editorSettings/customFonts/index.js
+++ b/packages/wp-dashboard/src/components/editorSettings/customFonts/index.js
@@ -36,7 +36,9 @@ import {
   Tooltip,
   themeHelpers,
   useSnackbar,
+  useLiveRegion,
 } from '@googleforcreators/design-system';
+
 import styled from 'styled-components';
 import { trackEvent, trackError } from '@googleforcreators/tracking';
 
@@ -171,6 +173,7 @@ function CustomFontsSettings({
   addCustomFont,
   deleteCustomFont,
 }) {
+  const speak = useLiveRegion();
   const [fontUrl, setFontUrl] = useState('');
   const [inputError, setInputError] = useState('');
   const [showDialog, setShowDialog] = useState(false);
@@ -198,6 +201,7 @@ function CustomFontsSettings({
   const handleDelete = useCallback(async () => {
     try {
       await deleteCustomFont(toDelete);
+      speak(__('Font deleted', 'web-stories'));
     } catch (err) {
       trackError('remove_custom_font', err?.message);
       showSnackbar({
@@ -210,7 +214,7 @@ function CustomFontsSettings({
       setShowDialog(false);
       setInputError('');
     }
-  }, [deleteCustomFont, toDelete, showSnackbar]);
+  }, [deleteCustomFont, toDelete, showSnackbar, speak]);
 
   const handleOnSave = useCallback(async () => {
     if (canSave) {


### PR DESCRIPTION
## Context

When deleting a custom font it should announce for screen readers that the font has been deleted.

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Add live region - to speak "Font deleted"

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Visit Settings wp-admin/edit.php?post_type=web-story&page=stories-dashboard#/editor-settings
2. Add multiple custom fonts
```
http://localhost:8899/wp-content/e2e-assets/OpenSansCondensed-Bold.ttf
http://localhost:8899/wp-content/e2e-assets/OpenSansCondensed-Light.ttf
http://localhost:8899/wp-content/e2e-assets/OpenSansCondensed-LightItalic.ttf
```

3. Using VoiceOver or an alternative tool -- delete a custom font.  After deletion it should announce that a font was deleted


## Reviews

### Does this PR have a security-related impact?

No

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

No

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

No

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11149
