### PR TITLE
Animations: remove panel when multiple elements are selected

### DIFF
--- a/packages/story-editor/src/components/panels/design/animation/animation.js
+++ b/packages/story-editor/src/components/panels/design/animation/animation.js
@@ -29,7 +29,6 @@ import PropTypes from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
 import { __ } from '@googleforcreators/i18n';
 import styled from 'styled-components';
-import { Text, THEME_CONSTANTS } from '@googleforcreators/design-system';
 import {
   BACKGROUND_ANIMATION_EFFECTS,
   BG_MAX_SCALE,
@@ -56,10 +55,6 @@ const ANIMATION_PROPERTY = 'animation';
 
 const StyledRow = styled(Row)`
   margin-bottom: -1px;
-`;
-
-const Note = styled(Text)`
-  color: ${({ theme }) => theme.colors.fg.secondary};
 `;
 
 const GroupWrapper = styled.div`
@@ -233,18 +228,7 @@ function AnimationPanel({
   }, [selectedElements]);
 
   const selectedEffectTitle = getEffectName(updatedAnimations[0]?.type);
-  return selectedElements.length > 1 ? (
-    <SimplePanel name="animation" title={__('Animation', 'web-stories')}>
-      <Row>
-        <Note
-          forwardedAs="span"
-          size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}
-        >
-          {__('Group animation support coming soon.', 'web-stories')}
-        </Note>
-      </Row>
-    </SimplePanel>
-  ) : (
+  return selectedElements.length > 1 ? null : (
     <SimplePanel
       name="animation"
       title={__('Animation', 'web-stories')}

--- a/packages/story-editor/src/components/panels/design/animation/karma/animation.karma.js
+++ b/packages/story-editor/src/components/panels/design/animation/karma/animation.karma.js
@@ -52,6 +52,29 @@ describe('Animation Panel', function () {
     expect(panel).not.toBeNull();
   });
 
+  it('should not render the animation panel when multiple elements are selected.', async function () {
+    // add shape to canvas
+    await fixture.editor.library.shapesTab.click();
+    await fixture.events.click(fixture.editor.library.shapes.shape('Triangle'));
+
+    // add text to canvas
+    await fixture.editor.library.textTab.click();
+    await fixture.events.click(fixture.editor.library.text.preset('Paragraph'));
+    await fixture.editor.canvas.framesLayer.waitFocusedWithin();
+
+    // select both text and shape elements
+    await fixture.events.keyboard.down('Shift');
+    const triangle = fixture.editor.canvas.framesLayer.frames[1].node;
+    await fixture.events.click(triangle);
+    await fixture.events.keyboard.up('Shift');
+
+    await fixture.events.click(fixture.editor.sidebar.designTab);
+    const panel = await fixture.screen.queryByRole('region', {
+      name: /^Animation$/,
+    });
+    expect(panel).toBeNull();
+  });
+
   // TODO #6953
   // eslint-disable-next-line jasmine/no-disabled-tests
   xit('can click the animation chooser and select an effect.', async function () {


### PR DESCRIPTION
## Context
If multiple elements are selected, we shouldn't be showing the animations panel since we can't animate more than one element yet. 
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Only shows `Animation` panel if one element is selected. 
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
|Before|After|
|--|--|
|![Screen Shot 2022-04-07 at 10 49 18 AM](https://user-images.githubusercontent.com/1820266/162255730-843e4339-7ef8-484b-badf-f8aa3df210e2.png)|![Screen Shot 2022-04-07 at 10 48 13 AM](https://user-images.githubusercontent.com/1820266/162255736-5e76ee3c-4e12-448c-b8c5-df171b021c62.png)|

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Select multiple elements and open style pane
2. see that the animations panel is no longer shown. 


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11185 
