### PR TITLE
Floating menu: Keyboard Navigation to Enter and Exit

### DIFF
--- a/packages/design-system/src/components/contextMenu/contextMenu.js
+++ b/packages/design-system/src/components/contextMenu/contextMenu.js
@@ -17,7 +17,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useMemo } from '@googleforcreators/react';
+import { useMemo, forwardRef } from '@googleforcreators/react';
 import { __ } from '@googleforcreators/i18n';
 /**
  * Internal dependencies
@@ -28,48 +28,53 @@ import Menu, { MenuPropTypes } from './menu';
 import AnimationContainer from './animationContainer';
 import { ContextMenuProvider } from './contextMenuProvider';
 
-const ContextMenu = ({
-  animate,
-  'aria-label': ariaLabel = __('Menu', 'web-stories'),
-  children,
-  id,
-  isAlwaysVisible,
-  isIconMenu = false,
-  isHorizontal = false,
-  isInline = false,
-  onDismiss = noop,
-  popoverZIndex,
-  ...props
-}) => {
-  const { isRTL } = props;
-  const Wrapper = useMemo(
-    () => (animate ? AnimationContainer : SmartPopover),
-    [animate]
-  );
+const ContextMenu = forwardRef(
+  (
+    {
+      animate,
+      'aria-label': ariaLabel = __('Menu', 'web-stories'),
+      children,
+      id,
+      isAlwaysVisible,
+      isIconMenu = false,
+      isHorizontal = false,
+      isInline = false,
+      onDismiss = noop,
+      popoverZIndex,
+      ...props
+    },
+    ref
+  ) => {
+    const { isRTL } = props;
+    const Wrapper = useMemo(
+      () => (animate ? AnimationContainer : SmartPopover),
+      [animate]
+    );
 
-  return (
-    <ContextMenuProvider
-      isIconMenu={isIconMenu}
-      isHorizontal={isHorizontal}
-      onDismiss={onDismiss}
-    >
-      <Wrapper
-        aria-label={ariaLabel}
-        isInline={isInline}
-        role={isAlwaysVisible ? null : 'dialog'}
-        isOpen={isAlwaysVisible || props.isOpen}
-        isRTL={isRTL}
-        popoverZIndex={popoverZIndex}
+    return (
+      <ContextMenuProvider
+        isIconMenu={isIconMenu}
+        isHorizontal={isHorizontal}
+        onDismiss={onDismiss}
       >
-        <Menu aria-expanded={props.isOpen} {...props}>
-          {children}
-        </Menu>
-        {/* <AnimationContainer /> has a <Shadow />. Don't double the shadow. */}
-        {!animate && <Shadow $isHorizontal={isHorizontal} />}
-      </Wrapper>
-    </ContextMenuProvider>
-  );
-};
+        <Wrapper
+          aria-label={ariaLabel}
+          isInline={isInline}
+          role={isAlwaysVisible ? null : 'dialog'}
+          isOpen={isAlwaysVisible || props.isOpen}
+          isRTL={isRTL}
+          popoverZIndex={popoverZIndex}
+        >
+          <Menu ref={ref} aria-expanded={props.isOpen} {...props}>
+            {children}
+          </Menu>
+          {/* <AnimationContainer /> has a <Shadow />. Don't double the shadow. */}
+          {!animate && <Shadow $isHorizontal={isHorizontal} />}
+        </Wrapper>
+      </ContextMenuProvider>
+    );
+  }
+);
 ContextMenu.propTypes = {
   ...MenuPropTypes,
   animate: PropTypes.bool,

--- a/packages/design-system/src/components/contextMenu/menu.js
+++ b/packages/design-system/src/components/contextMenu/menu.js
@@ -167,8 +167,11 @@ const Menu = forwardRef(
     const handleKeyboardNav = useCallback(
       (evt) => {
         const { key } = evt;
-        if (dismissOnEscape && key === 'Escape') {
-          onDismiss(evt);
+        if (key === 'Escape') {
+          if (dismissOnEscape) {
+            onDismiss(evt);
+          }
+
           return;
         }
 

--- a/packages/design-system/src/components/contextMenu/menu.js
+++ b/packages/design-system/src/components/contextMenu/menu.js
@@ -145,10 +145,11 @@ const Menu = forwardRef(
       (evt) => {
         onFocus(evt);
         const menuChildren = menuRef.current.children || [];
-        if (
-          menuRef.current === evt.target &&
-          ![...menuChildren].some((child) => child.contains(evt.target))
-        ) {
+        const isFocusOutsideMenu =
+          menuChildren.length &&
+          ![...menuChildren].some((child) => child.contains(evt.target));
+
+        if (menuRef.current === evt.target && isFocusOutsideMenu) {
           const focusableChildren = getFocusableChildren(menuRef.current);
           focusableChildren?.[0]?.focus();
         }

--- a/packages/design-system/src/components/contextMenu/menu.js
+++ b/packages/design-system/src/components/contextMenu/menu.js
@@ -114,6 +114,7 @@ const Menu = forwardRef(
       isSecondary = false,
       parentMenuRef,
       onCloseSubMenu = noop,
+      dismissOnEscape = true,
       ...props
     },
     ref
@@ -166,7 +167,7 @@ const Menu = forwardRef(
     const handleKeyboardNav = useCallback(
       (evt) => {
         const { key } = evt;
-        if (key === 'Escape') {
+        if (dismissOnEscape && key === 'Escape') {
           onDismiss(evt);
           return;
         }
@@ -228,6 +229,7 @@ const Menu = forwardRef(
         isHorizontal,
         onCloseSubMenu,
         parentMenuRef,
+        dismissOnEscape,
       ]
     );
 
@@ -291,6 +293,7 @@ export const MenuPropTypes = {
   isSecondary: PropTypes.bool,
   isRTL: PropTypes.bool,
   parentMenuRef: PropTypes.object,
+  dismissOnEscape: PropTypes.bool,
 };
 
 Menu.propTypes = MenuPropTypes;

--- a/packages/design-system/src/components/contextMenu/menu.js
+++ b/packages/design-system/src/components/contextMenu/menu.js
@@ -168,10 +168,7 @@ const Menu = forwardRef(
       (evt) => {
         const { key } = evt;
         if (key === 'Escape') {
-          if (dismissOnEscape) {
-            onDismiss(evt);
-          }
-
+          onDismiss(evt);
           return;
         }
 
@@ -232,7 +229,6 @@ const Menu = forwardRef(
         isHorizontal,
         onCloseSubMenu,
         parentMenuRef,
-        dismissOnEscape,
       ]
     );
 
@@ -258,9 +254,13 @@ const Menu = forwardRef(
 
     useKeyDownEffect(
       menuRef,
-      { key: ['esc', 'down', 'up', 'left', 'right'] },
+      {
+        key: dismissOnEscape
+          ? ['esc', 'down', 'up', 'left', 'right']
+          : ['down', 'up', 'left', 'right'],
+      },
       handleKeyboardNav,
-      [handleKeyboardNav]
+      [handleKeyboardNav, dismissOnEscape]
     );
 
     useKeyDownEffect(menuRef, keySpec, onDismiss, [keySpec, onDismiss]);

--- a/packages/element-library/src/text/edit.js
+++ b/packages/element-library/src/text/edit.js
@@ -25,8 +25,6 @@ import {
   useCallback,
   useMemo,
   useUnmount,
-  useCombinedRefs,
-  forwardRef,
 } from '@googleforcreators/react';
 import PropTypes from 'prop-types';
 import { generatePatternStyles } from '@googleforcreators/patterns';
@@ -75,9 +73,7 @@ import {
 const Wrapper = styled.div`
   ${elementFillContent}
   ${elementWithBackgroundColor}
-
   --faux-selection-color: inherit;
-
   span {
     box-decoration-break: clone;
   }
@@ -89,7 +85,6 @@ const Wrapper = styled.div`
 const TextBox = styled.div`
   ${elementWithFont}
   ${elementWithTextParagraphStyle}
-
   opacity: ${({ opacity }) =>
     typeof opacity !== 'undefined' ? opacity / 100 : null};
   position: absolute;
@@ -127,18 +122,15 @@ const OutsideBorder = styled.div`
   overflow: hidden;
 `;
 
-const TextEdit = forwardRef(function TextEdit(
-  {
-    element,
-    box: { x, y, height, rotationAngle },
-    editWrapper,
-    onResize,
-    updateElementById,
-    deleteSelectedElements,
-    maybeEnqueueFontStyle,
-  },
-  ref
-) {
+function TextEdit({
+  element,
+  box: { x, y, height, rotationAngle },
+  editWrapper,
+  onResize,
+  updateElementById,
+  deleteSelectedElements,
+  maybeEnqueueFontStyle,
+}) {
   const {
     id,
     content,
@@ -402,9 +394,7 @@ const TextEdit = forwardRef(function TextEdit(
     >
       {/* eslint-disable-next-line styled-components-a11y/click-events-have-key-events, styled-components-a11y/no-static-element-interactions -- Needed here to ensure the editor keeps focus, e.g. after setting inline colour. */}
       <Wrapper
-        tabIndex={-1}
-        ref={useCombinedRefs(wrapperRef, ref)}
-        onFocus={() => editorRef.current?.focus()}
+        ref={wrapperRef}
         onClick={onClick}
         data-testid="textEditor"
         {...wrapperProps}
@@ -435,7 +425,7 @@ const TextEdit = forwardRef(function TextEdit(
       </Wrapper>
     </OutsideBorder>
   );
-});
+}
 
 TextEdit.propTypes = {
   element: StoryPropTypes.elements.text.isRequired,

--- a/packages/element-library/src/text/edit.js
+++ b/packages/element-library/src/text/edit.js
@@ -25,6 +25,8 @@ import {
   useCallback,
   useMemo,
   useUnmount,
+  useCombinedRefs,
+  forwardRef,
 } from '@googleforcreators/react';
 import PropTypes from 'prop-types';
 import { generatePatternStyles } from '@googleforcreators/patterns';
@@ -125,15 +127,18 @@ const OutsideBorder = styled.div`
   overflow: hidden;
 `;
 
-function TextEdit({
-  element,
-  box: { x, y, height, rotationAngle },
-  editWrapper,
-  onResize,
-  updateElementById,
-  deleteSelectedElements,
-  maybeEnqueueFontStyle,
-}) {
+const TextEdit = forwardRef(function TextEdit(
+  {
+    element,
+    box: { x, y, height, rotationAngle },
+    editWrapper,
+    onResize,
+    updateElementById,
+    deleteSelectedElements,
+    maybeEnqueueFontStyle,
+  },
+  ref
+) {
   const {
     id,
     content,
@@ -397,7 +402,9 @@ function TextEdit({
     >
       {/* eslint-disable-next-line styled-components-a11y/click-events-have-key-events, styled-components-a11y/no-static-element-interactions -- Needed here to ensure the editor keeps focus, e.g. after setting inline colour. */}
       <Wrapper
-        ref={wrapperRef}
+        tabIndex={-1}
+        ref={useCombinedRefs(wrapperRef, ref)}
+        onFocus={() => editorRef.current?.focus()}
         onClick={onClick}
         data-testid="textEditor"
         {...wrapperProps}
@@ -428,7 +435,7 @@ function TextEdit({
       </Wrapper>
     </OutsideBorder>
   );
-}
+});
 
 TextEdit.propTypes = {
   element: StoryPropTypes.elements.text.isRequired,

--- a/packages/story-editor/src/components/canvas/editElement.js
+++ b/packages/story-editor/src/components/canvas/editElement.js
@@ -34,7 +34,6 @@ import {
 import useCORSProxy from '../../utils/useCORSProxy';
 import { useConfig, useStory, useFont } from '../../app';
 import useVideoTrim from '../videoTrim/useVideoTrim';
-import { FOCUS_GROUPS, useFocusGroupRef } from './editLayerFocusManager';
 
 const Z_INDEX_CANVAS = {
   FLOAT_PANEL: 11,
@@ -49,7 +48,6 @@ const Wrapper = styled.div`
 
 const EditElement = memo(
   forwardRef(function EditElement({ element, editWrapper, onResize }, ref) {
-    const focusGroupRef = useFocusGroupRef(FOCUS_GROUPS.EDIT_ELEMENT);
     const { id, type } = element;
     const { getBox } = useUnits((state) => ({
       getBox: state.actions.getBox,
@@ -86,7 +84,6 @@ const EditElement = memo(
     return (
       <Wrapper aria-labelledby={`layer-${id}`} {...box} ref={ref}>
         <Edit
-          ref={focusGroupRef}
           element={elementWithLocal}
           box={box}
           editWrapper={editWrapper}

--- a/packages/story-editor/src/components/canvas/editElement.js
+++ b/packages/story-editor/src/components/canvas/editElement.js
@@ -34,6 +34,7 @@ import {
 import useCORSProxy from '../../utils/useCORSProxy';
 import { useConfig, useStory, useFont } from '../../app';
 import useVideoTrim from '../videoTrim/useVideoTrim';
+import { FOCUS_GROUPS, useFocusGroupRef } from './editLayerFocusManager';
 
 const Z_INDEX_CANVAS = {
   FLOAT_PANEL: 11,
@@ -48,6 +49,7 @@ const Wrapper = styled.div`
 
 const EditElement = memo(
   forwardRef(function EditElement({ element, editWrapper, onResize }, ref) {
+    const focusGroupRef = useFocusGroupRef(FOCUS_GROUPS.EDIT_ELEMENT);
     const { id, type } = element;
     const { getBox } = useUnits((state) => ({
       getBox: state.actions.getBox,
@@ -84,6 +86,7 @@ const EditElement = memo(
     return (
       <Wrapper aria-labelledby={`layer-${id}`} {...box} ref={ref}>
         <Edit
+          ref={focusGroupRef}
           element={elementWithLocal}
           box={box}
           editWrapper={editWrapper}

--- a/packages/story-editor/src/components/canvas/editLayerFocusManager/keyBindings.js
+++ b/packages/story-editor/src/components/canvas/editLayerFocusManager/keyBindings.js
@@ -66,6 +66,14 @@ function KeyBindings({ uuid, node, activeFocusGroup, exitCurrentFocusGroup }) {
     [activeFocusGroup, uuid]
   );
 
+  const exitFocusGroup = useCallback(
+    (e) => {
+      e.preventDefault();
+      exitCurrentFocusGroup();
+    },
+    [exitCurrentFocusGroup]
+  );
+
   useKeyDownEffect(
     node,
     { key: ['tab'], allowDefault: true, editable: true, shift: true },
@@ -76,8 +84,8 @@ function KeyBindings({ uuid, node, activeFocusGroup, exitCurrentFocusGroup }) {
   useKeyDownEffect(
     node,
     { key: ['esc'], allowDefault: true, editable: true },
-    exitCurrentFocusGroup,
-    [exitCurrentFocusGroup]
+    exitFocusGroup,
+    [exitFocusGroup]
   );
 
   return null;

--- a/packages/story-editor/src/components/canvas/frameElement.js
+++ b/packages/story-editor/src/components/canvas/frameElement.js
@@ -36,6 +36,10 @@ import {
   elementWithRotation,
 } from '@googleforcreators/element-library';
 import { FrameWithMask as WithMask } from '@googleforcreators/masks';
+import {
+  useLiveRegion,
+  useKeyDownEffect,
+} from '@googleforcreators/design-system';
 
 /**
  * Internal dependencies
@@ -51,7 +55,11 @@ import WithLink from '../elementLink/frame';
 import useDoubleClick from '../../utils/useDoubleClick';
 import usePerformanceTracking from '../../utils/usePerformanceTracking';
 import { TRACKING_EVENTS } from '../../constants';
-import { FOCUS_GROUPS, useFocusGroupRef } from './editLayerFocusManager';
+import {
+  FOCUS_GROUPS,
+  useFocusGroupRef,
+  useEditLayerFocusManager,
+} from './editLayerFocusManager';
 
 // @todo: should the frame borders follow clip lines?
 
@@ -83,6 +91,9 @@ const EmptyFrame = styled.div`
 const NOOP = () => {};
 
 function FrameElement({ id }) {
+  const enterFocusGroup = useEditLayerFocusManager(
+    ({ enterFocusGroup }) => enterFocusGroup
+  );
   const [isTransforming, setIsTransforming] = useState(false);
   const focusGroupRef = useFocusGroupRef(FOCUS_GROUPS.ELEMENT_SELECTION);
 
@@ -213,6 +224,18 @@ function FrameElement({ id }) {
     },
     eventType: 'pointerdown',
   });
+
+  useKeyDownEffect(
+    elementRef,
+    { key: ['enter'] },
+    () => {
+      enterFocusGroup({
+        groupId: FOCUS_GROUPS.EDIT_ELEMENT,
+        cleanup: () => elementRef.current?.focus(),
+      });
+    },
+    [enterFocusGroup]
+  );
 
   return (
     <WithLink element={element} active={isLinkActive} anchorRef={elementRef}>

--- a/packages/story-editor/src/components/canvas/frameElement.js
+++ b/packages/story-editor/src/components/canvas/frameElement.js
@@ -227,7 +227,7 @@ function FrameElement({ id }) {
 
   useKeyDownEffect(
     elementRef,
-    { key: ['enter'] },
+    { key: ['ctrl+alt+p'] },
     () => {
       enterFocusGroup({
         groupId: FOCUS_GROUPS.EDIT_ELEMENT,

--- a/packages/story-editor/src/components/canvas/frameElement.js
+++ b/packages/story-editor/src/components/canvas/frameElement.js
@@ -18,6 +18,7 @@
  * External dependencies
  */
 import styled from 'styled-components';
+import { sprintf, __ } from '@googleforcreators/i18n';
 import {
   useCallback,
   useLayoutEffect,
@@ -37,8 +38,9 @@ import {
 } from '@googleforcreators/element-library';
 import { FrameWithMask as WithMask } from '@googleforcreators/masks';
 import {
-  useLiveRegion,
   useKeyDownEffect,
+  useLiveRegion,
+  prettifyShortcut,
 } from '@googleforcreators/design-system';
 
 /**
@@ -89,6 +91,16 @@ const EmptyFrame = styled.div`
 `;
 
 const NOOP = () => {};
+
+const FRAME_ELEMENT_MESSAGE = sprintf(
+  /* translators: 1: Ctrl Key 2: Alt Key */
+  __(
+    'To exit the canvas area, press Escape. Press Tab to move to the next group or element. To enter floating menu, press %1$s %2$s p.',
+    'web-stories'
+  ),
+  prettifyShortcut('ctrl'),
+  prettifyShortcut('alt')
+);
 
 function FrameElement({ id }) {
   const enterFocusGroup = useEditLayerFocusManager(

--- a/packages/story-editor/src/components/canvas/frameElement.js
+++ b/packages/story-editor/src/components/canvas/frameElement.js
@@ -103,6 +103,7 @@ const FRAME_ELEMENT_MESSAGE = sprintf(
 );
 
 function FrameElement({ id }) {
+  const speak = useLiveRegion();
   const enterFocusGroup = useEditLayerFocusManager(
     ({ enterFocusGroup }) => enterFocusGroup
   );
@@ -209,8 +210,15 @@ function FrameElement({ id }) {
       if (!isSelected) {
         handleSelectElement(id, evt);
       }
+
+      // no floating menu on background, so no need to announce
+      // possible floating menu keyboard navigation commands
+      if (isBackground) {
+        return;
+      }
+      speak(FRAME_ELEMENT_MESSAGE);
     },
-    [handleSelectElement, id, isSelected]
+    [handleSelectElement, id, isBackground, isSelected, speak]
   );
 
   const handleMouseDown = useCallback(

--- a/packages/story-editor/src/components/canvas/karma/elementKeyboardNavigation.js
+++ b/packages/story-editor/src/components/canvas/karma/elementKeyboardNavigation.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { Fixture } from '../../../karma';
+import { useStory } from '../../../app/story';
+
+fdescribe('Canvas Element - keyboard navigation', () => {
+  let fixture;
+
+  beforeEach(async () => {
+    fixture = new Fixture();
+    fixture.setFlags({ floatingMenu: true });
+
+    await fixture.render();
+    await fixture.collapseHelpCenter();
+  });
+
+  afterEach(() => {
+    fixture.restore();
+  });
+
+  function getCanvasElementWrapperById(id) {
+    return fixture.querySelector(
+      `[data-testid="frameElement"][data-element-id="${id}"]`
+    );
+  }
+
+  it('should be able to navigate in and out of the floating menu with ctrl+alt+p & esc', async () => {
+    // Insert an element
+    const shapeTab = fixture.editor.library.shapesTab;
+    await fixture.events.click(shapeTab);
+    const rectangleShape = fixture.editor.library.shapes.shape('Rectangle');
+    await fixture.events.click(rectangleShape);
+
+    // Click on one of the added shapes
+    const elementId = await fixture.renderHook(() =>
+      useStory(({ state }) => state.currentPage.elements[1].id)
+    );
+    const wrapperEl = getCanvasElementWrapperById(elementId);
+    await fixture.events.click(wrapperEl);
+    expect(document.activeElement).toBe(wrapperEl);
+
+    // Use Keyboard to navigate into the floating menu
+    const designMenu = fixture.editor.canvas.designMenu;
+    await fixture.events.keyboard.shortcut('control+alt+p');
+    expect(designMenu._node.contains(document.activeElement)).toBe(true);
+
+    // Use keyboard to navigate out of design menu
+    await fixture.events.keyboard.press('Esc');
+    expect(document.activeElement).toBe(wrapperEl);
+  });
+});

--- a/packages/story-editor/src/components/canvas/karma/elementKeyboardNavigation.js
+++ b/packages/story-editor/src/components/canvas/karma/elementKeyboardNavigation.js
@@ -15,12 +15,13 @@
  */
 
 /**
- * Internal dependencies
- */
-/**
  * External dependencies
  */
-import { waitFor } from '@testing-library/dom';
+import { waitFor } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
 import { Fixture } from '../../../karma';
 import { useStory } from '../../../app/story';
 

--- a/packages/story-editor/src/components/floatingMenu/elements/borderRadius.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/borderRadius.js
@@ -78,6 +78,7 @@ function BorderRadius() {
   return (
     <>
       <Input
+        tabIndex={-1}
         suffix={<Icons.Corner />}
         value={borderRadius.topLeft}
         aria-label={__('Corner Radius', 'web-stories')}

--- a/packages/story-editor/src/components/floatingMenu/elements/borderWidthAndColor.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/borderWidthAndColor.js
@@ -122,6 +122,7 @@ function BorderWidthAndColor() {
   return (
     <Container>
       <Input
+        tabIndex={-1}
         suffix={<Icons.BorderBox />}
         value={border.left || 0}
         aria-label={__('Border width', 'web-stories')}
@@ -131,6 +132,7 @@ function BorderWidthAndColor() {
         <>
           <Dash />
           <Color
+            tabIndex={-1}
             label={__('Border color', 'web-stories')}
             value={border.color || BLACK}
             onChange={handleColorChange}

--- a/packages/story-editor/src/components/floatingMenu/elements/fontFamily.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/fontFamily.js
@@ -38,6 +38,7 @@ const containerStyleOverrides = css`
 function FontFamily() {
   return (
     <StyledFontPicker
+      tabIndex={-1}
       listStyleOverrides={listStyleOverrides}
       containerStyleOverrides={containerStyleOverrides}
     />

--- a/packages/story-editor/src/components/floatingMenu/elements/fontSize.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/fontSize.js
@@ -73,6 +73,7 @@ function FontSize() {
 
   return (
     <Input
+      tabIndex={-1}
       aria-label={__('Font size', 'web-stories')}
       isFloat
       value={fontSize}

--- a/packages/story-editor/src/components/floatingMenu/elements/layerOpacity.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/layerOpacity.js
@@ -55,6 +55,7 @@ function LayerOpacity() {
 
   return (
     <Input
+      tabIndex={-1}
       suffix={<Icons.ColorDrop />}
       unit={_x('%', 'Percentage', 'web-stories')}
       value={opacity || 0}

--- a/packages/story-editor/src/components/floatingMenu/elements/loop.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/loop.js
@@ -47,7 +47,9 @@ function Loop() {
     });
   };
 
-  return <StyledLoopContent loop={loop} onChange={handleChange} />;
+  return (
+    <StyledLoopContent tabIndex={-1} loop={loop} onChange={handleChange} />
+  );
 }
 
 export default Loop;

--- a/packages/story-editor/src/components/floatingMenu/elements/shapeColor.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/shapeColor.js
@@ -51,6 +51,7 @@ function ShapeColor() {
 
   return (
     <Color
+      tabIndex={-1}
       label={__('Shape color', 'web-stories')}
       value={backgroundColor}
       allowsSavedColors

--- a/packages/story-editor/src/components/floatingMenu/elements/shared/icon.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/shared/icon.js
@@ -34,7 +34,7 @@ const IconButton = memo(
   forwardRef(function IconButton({ Icon, title, ...rest }, ref) {
     return (
       <Tooltip placement={TOOLTIP_PLACEMENT.BOTTOM} title={title}>
-        <ToggleButton ref={ref} {...rest}>
+        <ToggleButton ref={ref} tabIndex={-1} {...rest}>
           <ContextMenuComponents.MenuIcon title={title}>
             <Icon />
           </ContextMenuComponents.MenuIcon>

--- a/packages/story-editor/src/components/floatingMenu/elements/shared/text.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/shared/text.js
@@ -31,7 +31,7 @@ const Button = styled(ContextMenuComponents.MenuButton)`
 
 const TextButton = memo(function TextButton({ text, ...rest }) {
   return (
-    <Button forcePadding {...rest}>
+    <Button forcePadding {...rest} tabIndex={-1} {...rest}>
       {text}
     </Button>
   );

--- a/packages/story-editor/src/components/floatingMenu/elements/textAlign.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/textAlign.js
@@ -146,6 +146,7 @@ function TextAlign() {
     <>
       <Tooltip placement={TOOLTIP_PLACEMENT.BOTTOM} title={tooltip}>
         <StyledMenuButton
+          tabIndex={-1}
           ref={buttonRef}
           onClick={() => setMenuOpen((value) => !value)}
           aria-haspopup="menu"

--- a/packages/story-editor/src/components/floatingMenu/elements/textColor.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/textColor.js
@@ -54,6 +54,7 @@ function TextColor() {
 
   return (
     <Color
+      tabIndex={-1}
       label={__('Text color', 'web-stories')}
       value={color}
       allowsSavedColors

--- a/packages/story-editor/src/components/floatingMenu/elements/toggleBold.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/toggleBold.js
@@ -38,7 +38,7 @@ function ToggleBold() {
       Icon={Icons.LetterBBold}
       title={__('Toggle bold', 'web-stories')}
       onClick={toggle}
-      tabIndex="0"
+      tabIndex={-1}
     />
   );
 }

--- a/packages/story-editor/src/components/floatingMenu/elements/toggleItalics.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/toggleItalics.js
@@ -38,7 +38,7 @@ function ToggleItalics() {
       Icon={Icons.LetterIItalic}
       title={__('Toggle italic', 'web-stories')}
       onClick={toggle}
-      tabIndex="0"
+      tabIndex={-1}
     />
   );
 }

--- a/packages/story-editor/src/components/floatingMenu/elements/toggleUnderline.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/toggleUnderline.js
@@ -38,7 +38,7 @@ function ToggleUnderline() {
       Icon={Icons.LetterUUnderline}
       title={__('Toggle underline', 'web-stories')}
       onClick={toggle}
-      tabIndex="0"
+      tabIndex={-1}
     />
   );
 }

--- a/packages/story-editor/src/components/floatingMenu/menu.js
+++ b/packages/story-editor/src/components/floatingMenu/menu.js
@@ -79,6 +79,7 @@ const FloatingMenu = memo(
             isAlwaysVisible
             tabIndex={-1}
             ref={focusGroupRef}
+            dismissOnEscape={false}
             aria-label={__(
               'Design options for selected element',
               'web-stories'

--- a/packages/story-editor/src/components/floatingMenu/menu.js
+++ b/packages/story-editor/src/components/floatingMenu/menu.js
@@ -27,6 +27,10 @@ import { ContextMenu } from '@googleforcreators/design-system';
  * Internal dependencies
  */
 import { Z_INDEX_FLOATING_MENU } from '../../constants/zIndex';
+import {
+  useFocusGroupRef,
+  FOCUS_GROUPS,
+} from '../canvas/editLayerFocusManager';
 import { FloatingMenuProvider } from './context';
 import MenuSelector from './menus';
 
@@ -43,6 +47,7 @@ const FloatingMenu = memo(
     { selectionIdentifier, selectedElementType, handleDismiss, visuallyHidden },
     ref
   ) {
+    const focusGroupRef = useFocusGroupRef(FOCUS_GROUPS.EDIT_ELEMENT);
     useLayoutEffect(() => {
       const node = ref.current;
       const updateSize = () => {
@@ -72,7 +77,7 @@ const FloatingMenu = memo(
             isHorizontal
             isSecondary
             isAlwaysVisible
-            disableControlledTabNavigation
+            ref={focusGroupRef}
             aria-label={__(
               'Design options for selected element',
               'web-stories'

--- a/packages/story-editor/src/components/floatingMenu/menu.js
+++ b/packages/story-editor/src/components/floatingMenu/menu.js
@@ -17,11 +17,16 @@
 /**
  * External dependencies
  */
-import { forwardRef, useLayoutEffect, memo } from '@googleforcreators/react';
+import {
+  forwardRef,
+  useLayoutEffect,
+  useCallback,
+  memo,
+} from '@googleforcreators/react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { __ } from '@googleforcreators/i18n';
-import { ContextMenu } from '@googleforcreators/design-system';
+import { ContextMenu, useLiveRegion } from '@googleforcreators/design-system';
 
 /**
  * Internal dependencies
@@ -33,6 +38,11 @@ import {
 } from '../canvas/editLayerFocusManager';
 import { FloatingMenuProvider } from './context';
 import MenuSelector from './menus';
+
+const FLOATING_MENU_MESSAGE = __(
+  'To exit the floating menu, press Escape.',
+  'web-stories'
+);
 
 const MenuWrapper = styled.section`
   display: flex;
@@ -48,6 +58,12 @@ const FloatingMenu = memo(
     ref
   ) {
     const focusGroupRef = useFocusGroupRef(FOCUS_GROUPS.EDIT_ELEMENT);
+    const speak = useLiveRegion();
+
+    const announceKeyboardControls = useCallback(() => {
+      speak(FLOATING_MENU_MESSAGE);
+    }, [speak]);
+
     useLayoutEffect(() => {
       const node = ref.current;
       const updateSize = () => {
@@ -80,6 +96,7 @@ const FloatingMenu = memo(
             tabIndex={-1}
             ref={focusGroupRef}
             dismissOnEscape={false}
+            onFocus={announceKeyboardControls}
             aria-label={__(
               'Design options for selected element',
               'web-stories'

--- a/packages/story-editor/src/components/floatingMenu/menu.js
+++ b/packages/story-editor/src/components/floatingMenu/menu.js
@@ -77,6 +77,7 @@ const FloatingMenu = memo(
             isHorizontal
             isSecondary
             isAlwaysVisible
+            tabIndex={-1}
             ref={focusGroupRef}
             aria-label={__(
               'Design options for selected element',

--- a/packages/story-editor/src/components/fontPicker/index.js
+++ b/packages/story-editor/src/components/fontPicker/index.js
@@ -43,6 +43,7 @@ const FontPicker = forwardRef(function FontPicker(
     listStyleOverrides,
     containerStyleOverrides,
     className,
+    tabIndex,
   },
   ref
 ) {
@@ -154,6 +155,7 @@ const FontPicker = forwardRef(function FontPicker(
     <Datalist.DropDown
       ref={ref}
       zIndex={zIndex}
+      tabIndex={tabIndex}
       highlightStylesOverride={highlightStylesOverride}
       data-testid="font"
       title={__('Available font families', 'web-stories')}
@@ -189,6 +191,7 @@ FontPicker.propTypes = {
   listStyleOverrides: PropTypes.array,
   containerStyleOverrides: PropTypes.array,
   zIndex: PropTypes.number,
+  tabIndex: PropTypes.number,
 };
 
 export default FontPicker;

--- a/packages/story-editor/src/components/form/color/color.js
+++ b/packages/story-editor/src/components/form/color/color.js
@@ -109,6 +109,7 @@ const Color = forwardRef(function Color(
     isInDesignMenu = false,
     hasInputs = true,
     width,
+    tabIndex,
   },
   ref
 ) {
@@ -158,6 +159,7 @@ const Color = forwardRef(function Color(
           }
         >
           <EyeDropperButton
+            tabIndex={tabIndex}
             aria-label={tooltip}
             onClick={initEyedropper()}
             onPointerEnter={initEyedropper(false)}
@@ -171,6 +173,7 @@ const Color = forwardRef(function Color(
         <InputWrapper hasInputs={hasInputs}>
           <ColorInput
             ref={ref}
+            tabIndex={tabIndex}
             onChange={onChange}
             value={value}
             label={label}
@@ -198,6 +201,7 @@ const Color = forwardRef(function Color(
             <Space />
             <OpacityWrapper isInDesignMenu={isInDesignMenu}>
               <OpacityInput
+                tabIndex={tabIndex}
                 value={value}
                 onChange={handleOpacityChange}
                 isInDesignMenu={isInDesignMenu}

--- a/packages/story-editor/src/components/form/color/colorInput.js
+++ b/packages/story-editor/src/components/form/color/colorInput.js
@@ -169,6 +169,7 @@ const ColorInput = forwardRef(function ColorInput(
     pickerProps,
     spacing,
     tooltipPlacement,
+    ...props
   },
   ref
 ) {
@@ -217,6 +218,7 @@ const ColorInput = forwardRef(function ColorInput(
     'aria-label': label,
     onPointerEnter: () => loadReactColor(),
     onFocus: () => loadReactColor(),
+    tabIndex: props.tabIndex,
   };
 
   // Always hide color picker on unmount - note the double arrows
@@ -244,6 +246,7 @@ const ColorInput = forwardRef(function ColorInput(
             isIndeterminate={isMixed}
             placeholder={isMixed ? MULTIPLE_DISPLAY_VALUE : ''}
             containerStyleOverride={containerStyle}
+            {...props}
           />
           <ColorPreview>
             <Tooltip title={tooltip} hasTail placement={tooltipPlacement}>

--- a/packages/story-editor/src/components/form/color/opacityInput.js
+++ b/packages/story-editor/src/components/form/color/opacityInput.js
@@ -43,7 +43,7 @@ const minimalInputContainerStyleOverride = css`
   padding-right: 6px;
 `;
 
-function OpacityInput({ value, onChange, isInDesignMenu }) {
+function OpacityInput({ value, onChange, isInDesignMenu, ...props }) {
   const [inputValue, setInputValue] = useState('');
 
   // Allow any input, but only persist non-NaN values up-chain
@@ -80,6 +80,7 @@ function OpacityInput({ value, onChange, isInDesignMenu }) {
       allowEmpty={false}
       isFloat={false}
       containerStyleOverride={containerStyle}
+      {...props}
     />
   );
 }

--- a/packages/story-editor/src/components/panels/shared/loopPanelContent.js
+++ b/packages/story-editor/src/components/panels/shared/loopPanelContent.js
@@ -27,6 +27,7 @@ import {
 } from '@googleforcreators/design-system';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
+import { useInitializedValue } from '@googleforcreators/react';
 
 const StyledCheckbox = styled(Checkbox)`
   ${({ theme }) => `
@@ -41,12 +42,17 @@ const Wrapper = styled.div`
   gap: 12px;
 `;
 
-function LoopPanelContent({ loop, className = '', onChange }) {
-  const checkboxId = `cb-${uuidv4()}`;
+function LoopPanelContent({ loop, className = '', onChange, ...props }) {
+  const checkboxId = useInitializedValue(() => `cb-${uuidv4()}`);
 
   return (
     <Wrapper className={className}>
-      <StyledCheckbox id={checkboxId} checked={loop} onChange={onChange} />
+      <StyledCheckbox
+        id={checkboxId}
+        checked={loop}
+        onChange={onChange}
+        {...props}
+      />
       <label htmlFor={checkboxId}>
         <Text as="span" size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}>
           {__('Loop', 'web-stories')}


### PR DESCRIPTION
## Context
Part of accessibility work on canvas and floating menu
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Adds `ctrl+alt+p` to enter into the floating menu when an element is focused and selected, `esc` to return focus back to the original element in the frames layer.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
NA
<!-- Please describe your changes. -->

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
User can now navigate into the floating menu with keyboard by pressing `ctrl+alt+p` while an element is selected. They can navigate out of the floating menu and back to the element by pressing `esc`.
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. with an element selected & focused, press `ctrl+alt+p` and see that focus goes inside the floating menu
2. now press `esc` and see that focus leaves the floating menu


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10872
