### PR TITLE
Checklist: Focus checklist when opened from the publish modal

### DIFF
--- a/packages/story-editor/src/components/checklist/checklist.js
+++ b/packages/story-editor/src/components/checklist/checklist.js
@@ -65,15 +65,32 @@ const ThroughputPopup = forwardRef(function ThroughputPopup(
   { isOpen, children, close },
   ref
 ) {
-  const { isChecklistMounted, setIsChecklistMounted } = useChecklist(
+  const closeButtonRef = useRef();
+  const {
+    checklistFocused,
+    isChecklistMounted,
+    resetChecklistFocused,
+    setIsChecklistMounted,
+  } = useChecklist(
     ({
-      state: { isChecklistMounted },
-      actions: { setIsChecklistMounted },
+      state: { isChecklistMounted, checklistFocused },
+      actions: { setIsChecklistMounted, resetChecklistFocused },
     }) => ({
+      checklistFocused,
       isChecklistMounted,
+      resetChecklistFocused,
       setIsChecklistMounted,
     })
   );
+
+  // focus checklist
+  useEffect(() => {
+    if (checklistFocused && closeButtonRef.current) {
+      closeButtonRef.current.focus();
+    }
+
+    resetChecklistFocused();
+  }, [checklistFocused, resetChecklistFocused]);
 
   return (
     <Popup
@@ -87,10 +104,10 @@ const ThroughputPopup = forwardRef(function ThroughputPopup(
       {isChecklistMounted ? (
         <StyledNavigationWrapper ref={ref} isOpen={isOpen}>
           <TopNavigation
+            ref={closeButtonRef}
             onClose={close}
             label={CHECKLIST_TITLE}
             popupId={POPUP_ID}
-            isOpen={isOpen}
           />
           <Tablist
             id="pre-publish-checklist"

--- a/packages/story-editor/src/components/checklist/checklist.js
+++ b/packages/story-editor/src/components/checklist/checklist.js
@@ -90,6 +90,7 @@ const ThroughputPopup = forwardRef(function ThroughputPopup(
             onClose={close}
             label={CHECKLIST_TITLE}
             popupId={POPUP_ID}
+            isOpen={isOpen}
           />
           <Tablist
             id="pre-publish-checklist"

--- a/packages/story-editor/src/components/checklist/checklistContext/provider.js
+++ b/packages/story-editor/src/components/checklist/checklistContext/provider.js
@@ -28,6 +28,7 @@ import Context from './context';
 
 const ChecklistProvider = ({ children }) => {
   const [isOpen, setIsOpen] = useState(false);
+  const [checklistFocused, setChecklistFocused] = useState(false);
   const [openPanel, _setOpenPanel] = useState();
   const [isChecklistMounted, setIsChecklistMounted] = useState(false);
 
@@ -57,11 +58,18 @@ const ChecklistProvider = ({ children }) => {
       status: 'open',
     });
     setIsOpen(true);
+    setChecklistFocused(true);
   }, []);
+
+  const resetChecklistFocused = useCallback(
+    () => setChecklistFocused(false),
+    []
+  );
 
   const contextValue = useMemo(
     () => ({
       state: {
+        checklistFocused,
         isOpen,
         isChecklistMounted,
         openPanel,
@@ -70,15 +78,18 @@ const ChecklistProvider = ({ children }) => {
         toggle,
         close,
         open,
+        resetChecklistFocused,
         setIsChecklistMounted,
         setOpenPanel,
       },
     }),
     [
+      checklistFocused,
       close,
       openPanel,
       isOpen,
       open,
+      resetChecklistFocused,
       toggle,
       setOpenPanel,
       setIsChecklistMounted,

--- a/packages/story-editor/src/components/checklist/checklistContext/provider.js
+++ b/packages/story-editor/src/components/checklist/checklistContext/provider.js
@@ -58,6 +58,7 @@ const ChecklistProvider = ({ children }) => {
       status: 'open',
     });
     setIsOpen(true);
+    // focus checklist even if checklist is already open
     setChecklistFocused(true);
   }, []);
 

--- a/packages/story-editor/src/components/header/buttons/buttonWithChecklistWarning.js
+++ b/packages/story-editor/src/components/header/buttons/buttonWithChecklistWarning.js
@@ -54,13 +54,24 @@ function InnerButton({
   text,
   checkpoint,
   hasHighPriorityIssues = false,
+  onClick,
   ...buttonProps
 }) {
+  const handleClick = (evt) => {
+    // https://github.com/reactjs/react-modal/issues/680#issuecomment-413422345
+    // React Modal restores input on last focused element on close.
+    // Blur button so that it doesn't steal focus back when opening the checklist.
+    evt.currentTarget.blur();
+
+    onClick?.(evt);
+  };
+
   return (
     <Button
       variant={BUTTON_VARIANTS.RECTANGLE}
       type={BUTTON_TYPES.PRIMARY}
       size={BUTTON_SIZES.SMALL}
+      onClick={handleClick}
       {...buttonProps}
     >
       {text}
@@ -70,9 +81,10 @@ function InnerButton({
 }
 
 InnerButton.propTypes = {
-  text: PropTypes.node.isRequired,
   checkpoint: PropTypes.oneOf(Object.values(PPC_CHECKPOINT_STATE)),
   hasHighPriorityIssues: PropTypes.bool,
+  onClick: PropTypes.func,
+  text: PropTypes.node.isRequired,
 };
 
 function ButtonWithChecklistWarning({

--- a/packages/story-editor/src/components/header/buttons/publish.js
+++ b/packages/story-editor/src/components/header/buttons/publish.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { useCallback, useState } from '@googleforcreators/react';
+import { useCallback, useRef, useState } from '@googleforcreators/react';
 import {
   toDate,
   isAfter,
@@ -58,6 +58,7 @@ function PublishButton({ forceIsSaving }) {
   );
 
   const [showDialog, setShowDialog] = useState(false);
+  const publishButtonRef = useRef();
 
   const refreshPostEditURL = useRefreshPostEditURL(storyId, editLink);
   // Offset the date by one minute to accommodate for network latency.
@@ -92,11 +93,18 @@ function PublishButton({ forceIsSaving }) {
     setShowDialog(true);
   }, [showPriorityIssues]);
 
-  const closeDialog = useCallback(() => setShowDialog(false), []);
+  const closeDialog = useCallback(({ focusPublishButton = true } = {}) => {
+    setShowDialog(false);
+
+    if (focusPublishButton) {
+      publishButtonRef.current.focus();
+    }
+  }, []);
 
   return (
     <>
       <ButtonWithChecklistWarning
+        ref={publishButtonRef}
         onClick={handlePublish}
         disabled={forceIsSaving}
         hasFutureDate={hasFutureDate}

--- a/packages/story-editor/src/components/publishModal/karma/publishModal.karma.js
+++ b/packages/story-editor/src/components/publishModal/karma/publishModal.karma.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { within } from '@testing-library/react';
+import { waitFor, within } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -67,11 +67,14 @@ describe('Publish Story Modal', () => {
       const closeButton = await getPublishModalElement('button', /Close/);
       await fixture.events.click(closeButton);
 
-      publishModal = await fixture.screen.findByRole('dialog', {
-        name: /^Story details$/,
+      let publish;
+      await waitFor(async () => {
+        // modal may still be mounted, so wait until publish button is visible
+        // this is a `getBy` call, so it will throw an error if it fails
+        publish = await fixture.editor.titleBar.publish;
       });
 
-      expect(document.activeElement).toBe(fixture.editor.titleBar.publish);
+      expect(document.activeElement).toBe(publish);
     });
 
     it('should close the publish modal and open (and focus) the checklist when checklist button is clicked', async () => {

--- a/packages/story-editor/src/components/publishModal/karma/publishModal.karma.js
+++ b/packages/story-editor/src/components/publishModal/karma/publishModal.karma.js
@@ -63,7 +63,18 @@ describe('Publish Story Modal', () => {
   });
 
   describe('Functionality', () => {
-    it('should close publish modal and open (and focus) the checklist when checklist button is clicked', async () => {
+    it('should close the publish modal and focus the publish button', async () => {
+      const closeButton = await getPublishModalElement('button', /Close/);
+      await fixture.events.click(closeButton);
+
+      publishModal = await fixture.screen.findByRole('dialog', {
+        name: /^Story details$/,
+      });
+
+      expect(document.activeElement).toBe(fixture.editor.titleBar.publish);
+    });
+
+    it('should close the publish modal and open (and focus) the checklist when checklist button is clicked', async () => {
       const checklistButton = await getPublishModalElement(
         'button',
         'Checklist'

--- a/packages/story-editor/src/components/publishModal/karma/publishModal.karma.js
+++ b/packages/story-editor/src/components/publishModal/karma/publishModal.karma.js
@@ -63,7 +63,7 @@ describe('Publish Story Modal', () => {
   });
 
   describe('Functionality', () => {
-    it('should close publish modal and open the checklist when checklist button is clicked', async () => {
+    it('should close publish modal and open (and focus) the checklist when checklist button is clicked', async () => {
       const checklistButton = await getPublishModalElement(
         'button',
         'Checklist'

--- a/packages/story-editor/src/components/publishModal/karma/publishModal.karma.js
+++ b/packages/story-editor/src/components/publishModal/karma/publishModal.karma.js
@@ -78,6 +78,9 @@ describe('Publish Story Modal', () => {
       expect(
         fixture.editor.checklist.issues.getAttribute('data-isexpanded')
       ).toBe('true');
+
+      // Checklist should be focused
+      expect(document.activeElement).toBe(fixture.editor.checklist.closeButton);
     });
 
     it('should not update story permalink when title is updated if permalink already exists', async () => {

--- a/packages/story-editor/src/components/publishModal/publishModal.js
+++ b/packages/story-editor/src/components/publishModal/publishModal.js
@@ -57,7 +57,7 @@ function PublishModal({
 
   const handleReviewChecklist = useCallback(() => {
     trackEvent('review_prepublish_checklist');
-    onClose();
+    onClose({ focusPublishButton: false });
     openChecklist();
   }, [onClose, openChecklist]);
 

--- a/packages/story-editor/src/components/secondaryPopup/topNavigation.js
+++ b/packages/story-editor/src/components/secondaryPopup/topNavigation.js
@@ -19,7 +19,7 @@
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { __ } from '@googleforcreators/i18n';
-import { useEffect, useRef } from '@googleforcreators/react';
+import { forwardRef } from '@googleforcreators/react';
 import {
   BUTTON_SIZES,
   BUTTON_TYPES,
@@ -47,22 +47,16 @@ const Label = styled(Headline).attrs({
   font-weight: ${({ theme }) => theme.typography.weight.regular};
 `;
 
-export function TopNavigation({ isOpen, onClose, label, popupId }) {
-  const buttonRef = useRef();
-  // focus the checklist on open
-  // Necessary because the checklist can be opened from the publish modal.
-  useEffect(() => {
-    if (isOpen) {
-      buttonRef.current.focus();
-    }
-  }, [isOpen]);
-
+export const TopNavigation = forwardRef(function TopNavigation(
+  { onClose, label, popupId },
+  ref
+) {
   return (
     <NavBar>
       <Label>{label}</Label>
       <TopNavButtons>
         <NavButton
-          ref={buttonRef}
+          ref={ref}
           aria-label={__('Close', 'web-stories')}
           onClick={() => {
             forceFocusCompanionToggle(popupId);
@@ -77,7 +71,7 @@ export function TopNavigation({ isOpen, onClose, label, popupId }) {
       </TopNavButtons>
     </NavBar>
   );
-}
+});
 
 TopNavigation.propTypes = {
   isOpen: PropTypes.bool,

--- a/packages/story-editor/src/components/secondaryPopup/topNavigation.js
+++ b/packages/story-editor/src/components/secondaryPopup/topNavigation.js
@@ -19,6 +19,7 @@
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { __ } from '@googleforcreators/i18n';
+import { useEffect, useRef } from '@googleforcreators/react';
 import {
   BUTTON_SIZES,
   BUTTON_TYPES,
@@ -46,12 +47,22 @@ const Label = styled(Headline).attrs({
   font-weight: ${({ theme }) => theme.typography.weight.regular};
 `;
 
-export function TopNavigation({ onClose, label, popupId }) {
+export function TopNavigation({ isOpen, onClose, label, popupId }) {
+  const buttonRef = useRef();
+  // focus the checklist on open
+  // Necessary because the checklist can be opened from the publish modal.
+  useEffect(() => {
+    if (isOpen) {
+      buttonRef.current.focus();
+    }
+  }, [isOpen]);
+
   return (
     <NavBar>
       <Label>{label}</Label>
       <TopNavButtons>
         <NavButton
+          ref={buttonRef}
           aria-label={__('Close', 'web-stories')}
           onClick={() => {
             forceFocusCompanionToggle(popupId);
@@ -69,6 +80,7 @@ export function TopNavigation({ onClose, label, popupId }) {
 }
 
 TopNavigation.propTypes = {
+  isOpen: PropTypes.bool,
   onClose: PropTypes.func.isRequired,
   label: PropTypes.string.isRequired,
   popupId: PropTypes.string.isRequired,


### PR DESCRIPTION
## Context

This is a [React Modal](https://github.com/reactjs/react-modal/issues/680) issue. Focus is always returned to the element that lost focus when the modal was opened.

## Summary

Blur the button when opening the publish modal. This allows the checklist to steal focus when the checklist is opened from the publish modal.

## Relevant Technical Choices

n/a

## To-do

n/a

## User-facing changes

![focus](https://user-images.githubusercontent.com/22185279/162802280-a45f4cb0-29ef-41fd-8c71-c3e4a2f9de59.gif)

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Open the publish modal
2. Use the keyboard to press the checklist button in the modal
3. Verify that the checklist has focus
4. Open the publish modal again
5. Press the `close` button with the keyboard
6. Verify that the `Publish` button in the editor has focus

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11196
