### PR TITLE
Fix regression in `useElementsWithLinks`

### DIFF
--- a/packages/elements/src/utils/isElementBelowLimit.js
+++ b/packages/elements/src/utils/isElementBelowLimit.js
@@ -30,6 +30,6 @@ function isElementBelowLimit(element, verifyLink = true) {
   const limit = FULLBLEED_HEIGHT * 0.8 - DANGER_ZONE_HEIGHT;
   const { x, y, width, height, rotationAngle } = element;
   const points = getCorners(rotationAngle, x, y, width, height);
-  return Object.keys(points).find((point) => points[point].y > limit);
+  return Boolean(Object.keys(points).find((point) => points[point].y > limit));
 }
 export default isElementBelowLimit;

--- a/packages/story-editor/src/utils/test/useElementsWithLinks.js
+++ b/packages/story-editor/src/utils/test/useElementsWithLinks.js
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react-hooks';
+import { DANGER_ZONE_HEIGHT, FULLBLEED_HEIGHT } from '@googleforcreators/units';
+
+/**
+ * Internal dependencies
+ */
+import StoryContext from '../../app/story/context';
+import CanvasContext from '../../app/canvas/context';
+import useElementsWithLinks from '../useElementsWithLinks';
+
+const ELEMENT_WITH_LINK = {
+  id: 'elementWithLink',
+  type: 'unknown',
+  link: {
+    url: 'https://example.com',
+  },
+  content: 'Example Link',
+  width: 40,
+  height: 40,
+  rotationAngle: 0,
+  x: 10,
+  y: 10,
+};
+
+const ELEMENT_WITH_LINK_BELOW_LIMIT = {
+  id: 'elementWithLinkBelowLimit',
+  type: 'unknown',
+  link: {
+    url: 'https://example.com',
+  },
+  content: 'Example Link',
+  width: 40,
+  height: 40,
+  rotationAngle: 0,
+  x: 10,
+  y: FULLBLEED_HEIGHT * 0.8 + DANGER_ZONE_HEIGHT + 10,
+};
+
+const ELEMENT = {
+  id: 'element',
+  type: 'unknown',
+  content: 'Example Link',
+  width: 40,
+  height: 40,
+  rotationAngle: 0,
+  x: 10,
+  y: 10,
+};
+
+const ELEMENT_BELOW_LIMIT = {
+  id: 'elementBelowLimit',
+  type: 'unknown',
+  content: 'Example Link',
+  width: 40,
+  height: 40,
+  rotationAngle: 0,
+  x: 10,
+  y: FULLBLEED_HEIGHT * 0.8 + DANGER_ZONE_HEIGHT + 10,
+};
+
+function render({
+  pageAttachmentContainer = null,
+  pageAttachment = '',
+  elements = [],
+  selectedElements = [],
+}) {
+  const storyContextValue = {
+    state: {
+      currentPage: {
+        elements,
+        pageAttachment: {
+          url: pageAttachment,
+        },
+      },
+      selectedElements,
+    },
+  };
+
+  const canvasContext = {
+    state: {
+      pageAttachmentContainer,
+    },
+    actions: {},
+  };
+
+  const Wrapper = ({ children }) => (
+    <StoryContext.Provider value={storyContextValue}>
+      <CanvasContext.Provider value={canvasContext}>
+        {children}
+      </CanvasContext.Provider>
+    </StoryContext.Provider>
+  );
+
+  return renderHook(() => useElementsWithLinks(), {
+    wrapper: Wrapper,
+    initialProps: true,
+  });
+}
+
+describe('useElementsWithLinks', () => {
+  describe('hasLinksInAttachmentArea', () => {
+    it('returns true if there are links in the page attachment area', () => {
+      const { result } = render({
+        pageAttachmentContainer: document.body,
+        pageAttachment: 'https://example.com',
+        elements: [ELEMENT_WITH_LINK_BELOW_LIMIT],
+      });
+      expect(result.current.hasLinksInAttachmentArea).toBeTrue();
+    });
+
+    it('returns true even if there is no page attachment', () => {
+      const { result } = render({
+        pageAttachmentContainer: document.body,
+        pageAttachment: '',
+        elements: [ELEMENT_WITH_LINK_BELOW_LIMIT],
+      });
+      expect(result.current.hasLinksInAttachmentArea).toBeTrue();
+    });
+
+    it('returns false if links are not in the page attachment area', () => {
+      const { result } = render({
+        pageAttachmentContainer: document.body,
+        pageAttachment: 'https://example.com',
+        elements: [ELEMENT_WITH_LINK],
+      });
+      expect(result.current.hasLinksInAttachmentArea).toBeFalse();
+    });
+
+    it('returns false if there is no page attachment container', () => {
+      const { result } = render({
+        pageAttachment: 'https://example.com',
+        elements: [ELEMENT_WITH_LINK_BELOW_LIMIT],
+      });
+      expect(result.current.hasLinksInAttachmentArea).toBeFalse();
+    });
+  });
+
+  describe('hasElementsInAttachmentArea', () => {
+    it('returns true if the selected elements are in the page attachment area', () => {
+      const { result } = render({
+        pageAttachmentContainer: document.body,
+        pageAttachment: 'https://example.com',
+        selectedElements: [ELEMENT_WITH_LINK_BELOW_LIMIT],
+      });
+      expect(result.current.hasElementsInAttachmentArea).toBeTrue();
+    });
+
+    it('returns false if there is no page attachment', () => {
+      const { result } = render({
+        pageAttachmentContainer: document.body,
+        pageAttachment: '',
+        selectedElements: [ELEMENT_WITH_LINK_BELOW_LIMIT],
+      });
+      expect(result.current.hasElementsInAttachmentArea).toBeFalse();
+    });
+
+    it('returns false if the selected elements are not in the page attachment area', () => {
+      const { result } = render({
+        pageAttachmentContainer: document.body,
+        pageAttachment: 'https://example.com',
+        selectedElements: [ELEMENT_WITH_LINK],
+      });
+      expect(result.current.hasElementsInAttachmentArea).toBeFalse();
+    });
+
+    it('returns false if there is no page attachment container', () => {
+      const { result } = render({
+        pageAttachment: 'https://example.com',
+        selectedElements: [ELEMENT_WITH_LINK_BELOW_LIMIT],
+      });
+      expect(result.current.hasElementsInAttachmentArea).toBeFalse();
+    });
+  });
+
+  describe('hasInvalidLinkSelected', () => {
+    it('returns true if the selected elements are in the page attachment area', () => {
+      const { result } = render({
+        pageAttachmentContainer: document.body,
+        pageAttachment: 'https://example.com',
+        selectedElements: [ELEMENT_WITH_LINK_BELOW_LIMIT],
+      });
+      expect(result.current.hasInvalidLinkSelected).toBeTrue();
+    });
+
+    it('returns false if there is no page attachment', () => {
+      const { result } = render({
+        pageAttachmentContainer: document.body,
+        pageAttachment: '',
+        selectedElements: [ELEMENT_WITH_LINK_BELOW_LIMIT],
+      });
+      expect(result.current.hasInvalidLinkSelected).toBeFalse();
+    });
+
+    it('returns false if the selected elements are not in the page attachment area', () => {
+      const { result } = render({
+        pageAttachmentContainer: document.body,
+        pageAttachment: 'https://example.com',
+        selectedElements: [ELEMENT_WITH_LINK],
+      });
+      expect(result.current.hasInvalidLinkSelected).toBeFalse();
+    });
+
+    it('returns false if there is no page attachment container', () => {
+      const { result } = render({
+        pageAttachment: 'https://example.com',
+        selectedElements: [ELEMENT_WITH_LINK_BELOW_LIMIT],
+      });
+      expect(result.current.hasInvalidLinkSelected).toBeFalse();
+    });
+  });
+
+  describe('isElementInAttachmentArea', () => {
+    it('returns true if the given element is in the page attachment area', () => {
+      const { result } = render({
+        pageAttachmentContainer: document.body,
+        pageAttachment: 'https://example.com',
+      });
+      expect(
+        result.current.isElementInAttachmentArea(ELEMENT_BELOW_LIMIT)
+      ).toBeTrue();
+    });
+
+    it('returns false if there is no page attachment', () => {
+      const { result } = render({
+        pageAttachmentContainer: document.body,
+        pageAttachment: '',
+      });
+      expect(
+        result.current.isElementInAttachmentArea(ELEMENT_BELOW_LIMIT)
+      ).toBeFalse();
+    });
+
+    it('returns false if the given element is not in the page attachment area', () => {
+      const { result } = render({
+        pageAttachmentContainer: document.body,
+        pageAttachment: 'https://example.com',
+      });
+      expect(result.current.isElementInAttachmentArea(ELEMENT)).toBeFalse();
+    });
+
+    it('returns false if there is no page attachment container', () => {
+      const { result } = render({
+        pageAttachment: 'https://example.com',
+      });
+      expect(
+        result.current.isElementInAttachmentArea(ELEMENT_BELOW_LIMIT)
+      ).toBeFalse();
+    });
+  });
+});

--- a/packages/story-editor/src/utils/useElementsWithLinks.js
+++ b/packages/story-editor/src/utils/useElementsWithLinks.js
@@ -25,6 +25,11 @@ import { isElementBelowLimit } from '@googleforcreators/elements';
  */
 import { useStory, useCanvas } from '../app';
 
+/**
+ * Custom hook to aid with detecting links conflicting with page attachments.
+ *
+ * @return {{hasElementsInAttachmentArea: boolean, isElementInAttachmentArea: (Object) => (boolean), hasLinksInAttachmentArea: boolean, hasInvalidLinkSelected: boolean}} Hook result.
+ */
 function useElementsWithLinks() {
   const { pageAttachmentContainer } = useCanvas((state) => ({
     pageAttachmentContainer: state.state.pageAttachmentContainer,
@@ -43,21 +48,27 @@ function useElementsWithLinks() {
     );
 
     return {
-      hasInvalidLinkSelected:
+      hasInvalidLinkSelected: Boolean(
         pageAttachmentContainer &&
-        hasPageAttachment &&
-        state.selectedElements.filter(elementHasLink).some(isElementBelowLimit),
-      hasLinksInAttachmentArea:
+          hasPageAttachment &&
+          state.selectedElements
+            .filter(elementHasLink)
+            .some(isElementBelowLimit)
+      ),
+      hasLinksInAttachmentArea: Boolean(
         pageAttachmentContainer &&
-        elementsWithLinks.filter((element) =>
-          isElementBelowLimit(element, true)
-        ),
-      hasElementsInAttachmentArea:
+          elementsWithLinks.some((element) =>
+            isElementBelowLimit(element, true)
+          )
+      ),
+      hasElementsInAttachmentArea: Boolean(
         pageAttachmentContainer &&
-        hasPageAttachment &&
-        state.selectedElements.filter((element) =>
-          isElementBelowLimit(element, true)
-        ),
+          hasPageAttachment &&
+          state.selectedElements.some((element) =>
+            isElementBelowLimit(element, true)
+          )
+      ),
+      hasPageAttachment,
     };
   });
 
@@ -66,11 +77,11 @@ function useElementsWithLinks() {
       if (!pageAttachmentContainer) {
         return false;
       }
-      // If there is no Page Attachment present, return.
+
       if (!hasPageAttachment) {
         return false;
       }
-      // If the node is inside the page attachment container.
+
       return isElementBelowLimit(element, false);
     },
     [pageAttachmentContainer, hasPageAttachment]
@@ -81,7 +92,6 @@ function useElementsWithLinks() {
     hasInvalidLinkSelected,
     isElementInAttachmentArea,
     hasElementsInAttachmentArea,
-    hasPageAttachment,
   };
 }
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

This is a follow-up to #11169 which accidentally caused a regression in when page attachment / link warnings are displayed.

Without this PR, you'll get a `Links cannot reside below the dashed line when a page attachment is present` when trying to add a page attachment, even if there are no links at all.

## Summary

<!-- A brief description of what this PR does. -->

Fixes said regression, adds unit tests to prevent the same mistake from happening again in the future.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

Sort of (no false positive warnings anymore)

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

(This can easily be verified by an eng)

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Create a new story
2. Click on the page
3. Add a page attachment
4. There should be no link warning present


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
Ensure boolean values and existence of `hasPageAttachment`