### PR TITLE
Design System: DataList partial search support

### DIFF
--- a/packages/design-system/src/components/datalist/utils.js
+++ b/packages/design-system/src/components/datalist/utils.js
@@ -15,7 +15,7 @@
  */
 export const createOptionFilter = (options) => (keyword) =>
   options.filter(({ name }) =>
-    name.toLowerCase().startsWith(keyword.toLowerCase())
+    name.toLowerCase().includes(keyword.toLowerCase())
   );
 
 export const isKeywordFilterable = (keyword) => keyword.trim().length >= 2;

--- a/packages/story-editor/src/components/panels/design/textStyle/test/fontPicker.js
+++ b/packages/story-editor/src/components/panels/design/textStyle/test/fontPicker.js
@@ -212,14 +212,14 @@ describe('DropDown: Font Picker', () => {
       availableCuratedFonts.length
     );
 
-    // Search for "Ab" which is the prefix of 3 fonts, but the substring of 5 fonts
-    // only the 3 with prefix should match
+    // Search for "Ab" which is the prefix of 3 font, and the substring of another 2 fonts
+    // should match all 5 fonts
     fireEvent.change(screen.getByRole('combobox'), {
       target: { value: 'Ab' },
     });
 
     await waitFor(
-      () => expect(screen.queryAllByRole('option')).toHaveLength(3),
+      () => expect(screen.queryAllByRole('option')).toHaveLength(5),
       {
         timeout: 500,
       }


### PR DESCRIPTION
## Context
The search util used by `DataList` was limited to filtering on the start of a string. Instead, we want to filter search so that if any portion of the option is present we still see it. 

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Updates option filtering function to include any portion of the option string. 
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Any search field using `DataList` should now be able to search for any part of the option. For example, in Fonts dropdown you can search for `shade` and see result for `bungee shade`. This should also work in the Dashboard's author dropdown search. We can now find authors by last name. 


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10675 
