### PR TITLE
Peformance: Remove Empty Sidebar Renders on Selection

### DIFF
--- a/packages/story-editor/src/components/sidebar/sidebarContent.js
+++ b/packages/story-editor/src/components/sidebar/sidebarContent.js
@@ -34,10 +34,10 @@ const SidebarPanes = styled.section`
 `;
 
 function Sidebar() {
-  const {
-    state: { tab },
-    data: { tabs },
-  } = useSidebar();
+  const { tab, tabs } = useSidebar(({ state: { tab }, data: { tabs } }) => ({
+    tab,
+    tabs,
+  }));
 
   return (
     <SidebarPanes>

--- a/packages/story-editor/src/components/sidebar/sidebarLayout.js
+++ b/packages/story-editor/src/components/sidebar/sidebarLayout.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import styled from 'styled-components';
-import { useCallback, useEffect } from '@googleforcreators/react';
+import { useCallback } from '@googleforcreators/react';
 import { __ } from '@googleforcreators/i18n';
 import { trackEvent } from '@googleforcreators/tracking';
 import { useEscapeToBlurEffect } from '@googleforcreators/design-system';

--- a/packages/story-editor/src/components/sidebar/sidebarLayout.js
+++ b/packages/story-editor/src/components/sidebar/sidebarLayout.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import styled from 'styled-components';
-import { useCallback } from '@googleforcreators/react';
+import { useCallback, useEffect } from '@googleforcreators/react';
 import { __ } from '@googleforcreators/i18n';
 import { trackEvent } from '@googleforcreators/tracking';
 import { useEscapeToBlurEffect } from '@googleforcreators/design-system';
@@ -52,12 +52,22 @@ const UnjustifiedTabView = styled(TabView)`
 `;
 
 function SidebarLayout() {
-  const {
-    state: { tab, tabRefs },
-    actions: { setSidebarContentNode, setTab },
-    refs: { sidebar },
-    data: { tabs },
-  } = useSidebar();
+  const { tab, tabRefs, setSidebarContentNode, setTab, sidebar, tabs } =
+    useSidebar(
+      ({
+        state: { tab, tabRefs },
+        actions: { setSidebarContentNode, setTab },
+        refs: { sidebar },
+        data: { tabs },
+      }) => ({
+        tab,
+        tabRefs,
+        setSidebarContentNode,
+        setTab,
+        sidebar,
+        tabs,
+      })
+    );
 
   const onTabChange = useCallback(
     (id) => {

--- a/packages/story-editor/src/components/sidebar/sidebarProvider.js
+++ b/packages/story-editor/src/components/sidebar/sidebarProvider.js
@@ -155,12 +155,19 @@ function SidebarProvider({ sidebarTabs, children }) {
           id: DOCUMENT,
           ...sidebarTabs.document,
         },
-        sidebarTabs?.publishModal && {
-          id: PUBLISH_MODAL_DOCUMENT,
-          ...sidebarTabs.publishModal,
-        },
       ].filter(Boolean),
     [sidebarTabs]
+  );
+
+  const data = useMemo(
+    () => ({
+      tabs,
+      modalSidebarTab: sidebarTabs?.publishModal && {
+        id: PUBLISH_MODAL_DOCUMENT,
+        ...sidebarTabs.publishModal,
+      },
+    }),
+    [tabs, sidebarTabs]
   );
 
   const state = {
@@ -179,9 +186,7 @@ function SidebarProvider({ sidebarTabs, children }) {
       loadUsers,
       setSidebarContentNode,
     },
-    data: {
-      tabs: tabs,
-    },
+    data,
   };
 
   return <Context.Provider value={state}>{children}</Context.Provider>;

--- a/packages/story-editor/src/components/sidebar/sidebarProvider.js
+++ b/packages/story-editor/src/components/sidebar/sidebarProvider.js
@@ -39,6 +39,19 @@ import Style from '../style';
 import { DOCUMENT, STYLE, PUBLISH_MODAL_DOCUMENT, INSERT } from './constants';
 import Context from './context';
 
+const TABS = [
+  {
+    id: INSERT,
+    title: __('Insert', 'web-stories'),
+    Pane: Library,
+  },
+  {
+    id: STYLE,
+    title: __('Style', 'web-stories'),
+    Pane: Style,
+  },
+];
+
 const SIDEBAR_TAB_IDS = new Set([INSERT, DOCUMENT, STYLE]);
 function SidebarProvider({ sidebarTabs, children }) {
   const {
@@ -134,6 +147,22 @@ function SidebarProvider({ sidebarTabs, children }) {
     }
   }, [isUsersLoading, users.length, getAuthors]);
 
+  const tabs = useMemo(
+    () =>
+      [
+        ...TABS,
+        sidebarTabs?.document && {
+          id: DOCUMENT,
+          ...sidebarTabs.document,
+        },
+        sidebarTabs?.publishModal && {
+          id: PUBLISH_MODAL_DOCUMENT,
+          ...sidebarTabs.publishModal,
+        },
+      ].filter(Boolean),
+    [sidebarTabs]
+  );
+
   const state = {
     state: {
       tab,
@@ -151,34 +180,9 @@ function SidebarProvider({ sidebarTabs, children }) {
       setSidebarContentNode,
     },
     data: {
-      tabs: [
-        {
-          id: INSERT,
-          title: __('Insert', 'web-stories'),
-          Pane: Library,
-        },
-        {
-          id: STYLE,
-          title: __('Style', 'web-stories'),
-          Pane: Style,
-        },
-      ],
+      tabs: tabs,
     },
   };
-
-  if (sidebarTabs?.document) {
-    state.data.tabs.push({
-      id: DOCUMENT,
-      ...sidebarTabs.document,
-    });
-  }
-
-  if (sidebarTabs?.publishModal) {
-    state.data.modalSidebarTab = {
-      id: PUBLISH_MODAL_DOCUMENT,
-      ...sidebarTabs.publishModal,
-    };
-  }
 
   return <Context.Provider value={state}>{children}</Context.Provider>;
 }

--- a/packages/story-editor/src/components/tabview/index.js
+++ b/packages/story-editor/src/components/tabview/index.js
@@ -282,7 +282,7 @@ function TabView({
         <Tab
           key={id}
           ref={(node) => {
-            if (tabRefs) {
+            if (tabRefs?.[id]) {
               tabRefs[id].current = node;
             } else {
               internalTabRefs.current[id] = node;


### PR DESCRIPTION
## Context
Part of Perf work
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Noticed Sidebar had empty render on element selection:
<img width="548" alt="Screen Shot 2022-04-13 at 10 53 40 AM" src="https://user-images.githubusercontent.com/35983235/163220912-f72dc22d-c2b2-4106-930a-2f723b02a6f3.png">


This PR removes this empty re-render in the sidebar:
<img width="547" alt="Screen Shot 2022-04-13 at 10 56 15 AM" src="https://user-images.githubusercontent.com/35983235/163221319-30d2768d-bf64-44c2-b3d1-a0ddd4d56290.png">

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
Just updating context selector usage and making some things constants
<!-- Please describe your changes. -->

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
NA
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11260 
