### PR TITLE
Fix story saving after removing background audio

### DIFF
--- a/packages/e2e-tests/src/specs/editor/backgroundAudio.js
+++ b/packages/e2e-tests/src/specs/editor/backgroundAudio.js
@@ -24,6 +24,8 @@ import {
   takeSnapshot,
   withExperimentalFeatures,
   withPlugin,
+  insertStoryTitle,
+  publishStory,
 } from '@web-stories-wp/e2e-test-utils';
 
 const VTT_URL = `${process.env.WP_BASE_URL}/wp-content/e2e-assets/test.vtt`;
@@ -215,6 +217,37 @@ describe('Background Audio', () => {
         await expect(page).not.toMatchElement('button', {
           text: 'Link to file',
         });
+      });
+    });
+
+    describe('Add and remove background audio', () => {
+      // see: https://github.com/GoogleForCreators/web-stories-wp/issues/11229
+      it('should allow saving after deleting audio', async () => {
+        await createNewStory();
+        await insertStoryTitle('Add and delete background audio');
+        await expect(page).toClick('li[role="tab"]', { text: 'Document' });
+
+        // Toggle the panel which is collapsed by default.
+        await expect(page).toClick('[aria-label="Background Audio"]');
+        await expect(page).toClick('button', { text: 'Upload an audio file' });
+
+        await page.waitForSelector('.media-modal', {
+          visible: true,
+        });
+
+        await expect(page).toClick('.media-modal #menu-item-upload', {
+          text: 'Upload files',
+          visible: true,
+        });
+
+        const fileName = await uploadFile('audio.mp3');
+        uploadedFiles.push(fileName);
+
+        await expect(page).toClick('button', { text: 'Select audio file' });
+        await page.waitForSelector('.media-modal', { visible: false });
+        await expect(page).toMatch(fileName);
+        await expect(page).toClick('[aria-label="Remove file"]');
+        await publishStory();
       });
     });
   });

--- a/packages/output/src/page.js
+++ b/packages/output/src/page.js
@@ -51,8 +51,8 @@ function OutputPage({
     animations,
     elements,
     backgroundColor,
-    backgroundAudio = {},
-    pageAttachment = {},
+    backgroundAudio,
+    pageAttachment,
   } = page;
 
   const [backgroundElement, ...otherElements] = elements;
@@ -104,10 +104,10 @@ function OutputPage({
     )
     .map(({ id: videoId }) => `el-${videoId}-captions`);
 
-  const backgroundAudioSrc = backgroundAudio.resource?.src;
-  const hasBackgroundAudioCaptions = backgroundAudio.tracks?.length > 0;
+  const backgroundAudioSrc = backgroundAudio?.resource?.src;
+  const hasBackgroundAudioCaptions = backgroundAudio?.tracks?.length > 0;
   const hasNonLoopingBackgroundAudio =
-    false === backgroundAudio.loop && backgroundAudio.resource?.length;
+    false === backgroundAudio?.loop && backgroundAudio?.resource?.length;
   const needsEnhancedBackgroundAudio =
     hasBackgroundAudioCaptions || hasNonLoopingBackgroundAudio;
 
@@ -189,7 +189,7 @@ function OutputPage({
       {/* <amp-story-page-outlink> needs to be the last child element */}
       {pageAttachment?.url && <Outlink {...pageAttachment} />}
       {products.length > 0 && flags?.shoppingIntegration && (
-        <ShoppingAttachment products={products} theme={pageAttachment.theme} />
+        <ShoppingAttachment products={products} theme={pageAttachment?.theme} />
       )}
     </amp-story-page>
   );

--- a/packages/output/src/test/page.js
+++ b/packages/output/src/test/page.js
@@ -1399,9 +1399,7 @@ describe('Page output', () => {
       const { container } = render(<PageOutput {...props} />);
       const page = container.querySelector('amp-story-page');
       await expect(page).toBeInTheDocument();
-      expect(page).not.toContain(
-        'background-audio="https://example.com/audio.mp3"'
-      );
+      expect(page).not.toContain('background-audio=');
     });
 
     it('should use amp-video for non-looping background audio', async () => {

--- a/packages/output/src/test/page.js
+++ b/packages/output/src/test/page.js
@@ -1384,6 +1384,26 @@ describe('Page output', () => {
       );
     });
 
+    it('should not contain background audio if null', async () => {
+      const props = {
+        id: '123',
+        page: {
+          backgroundAudio: null,
+          id: '123',
+          elements: [],
+        },
+        autoAdvance: false,
+        defaultPageDuration: 7,
+      };
+
+      const { container } = render(<PageOutput {...props} />);
+      const page = container.querySelector('amp-story-page');
+      await expect(page).toBeInTheDocument();
+      expect(page).not.toContain(
+        'background-audio="https://example.com/audio.mp3"'
+      );
+    });
+
     it('should use amp-video for non-looping background audio', async () => {
       const props = {
         id: '123',

--- a/packages/story-editor/src/components/canvas/mediaCaptions/mediaCaptionsLayer.js
+++ b/packages/story-editor/src/components/canvas/mediaCaptions/mediaCaptionsLayer.js
@@ -92,7 +92,7 @@ function MediaCaptionsLayer() {
 
     if (backgroundAudio) {
       setMediaElementId(`page-${currentPageId}-background-audio`);
-      setMediaTrackCount(backgroundAudio.tracks.length);
+      setMediaTrackCount(backgroundAudio?.tracks?.length);
       return;
     }
 


### PR DESCRIPTION
## Context

When removing background audio from a page, page.backgroundAudio becomes null and in turn the Story can't save.

<img width="642" alt="162777840-ee0884d5-5db7-495f-a3d7-275e70919b91" src="https://user-images.githubusercontent.com/62242/163491994-98e39aa8-c4bd-4d0b-ac33-24138bb8da40.png">

See: https://github.com/GoogleForCreators/web-stories-wp/issues/11229#issue-1200164316

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
- Adds optional chaining
- Removes default values `{}`
- Add e2e test to match the add / remove background audio use case


<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add background audio to page
2. Remove background audio again
3. Save story


## Reviews

### Does this PR have a security-related impact?

No

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

No

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

No

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11229
