### PR TITLE
Decoupling: Use dashboard container ID from config

### DIFF
--- a/docs/third-party-integration/dashboard/integration-layer.md
+++ b/docs/third-party-integration/dashboard/integration-layer.md
@@ -193,6 +193,11 @@ To configure the dashboard to your needs you can pass various config options to 
             - required: No
             - description: It defines the top bar height, which is used in calculation for placement of components. 
 
+- `containerID`
+    - type: `string`
+    - required: No
+    - description: The id of the upper dashboard container which defines the available space for dashboard.
+
 - `siteKitStatus`
     - type: `Object`
     - required: No

--- a/docs/third-party-integration/dashboard/integration-layer.md
+++ b/docs/third-party-integration/dashboard/integration-layer.md
@@ -196,7 +196,7 @@ To configure the dashboard to your needs you can pass various config options to 
 - `containerID`
     - type: `string`
     - required: No
-    - description: The id of the upper dashboard container which defines the available space for dashboard.
+    - description: The id of the upper dashboard container which defines the available space for dashboard. If not defined `window.innerWidth` will be used for calculating the space.
 
 - `siteKitStatus`
     - type: `Object`

--- a/docs/third-party-integration/dashboard/integration-layer.md
+++ b/docs/third-party-integration/dashboard/integration-layer.md
@@ -193,7 +193,7 @@ To configure the dashboard to your needs you can pass various config options to 
             - required: No
             - description: It defines the top bar height, which is used in calculation for placement of components. 
 
-- `containerID`
+- `containerId`
     - type: `string`
     - required: No
     - description: The id of the upper dashboard container which defines the available space for dashboard. If not defined `window.innerWidth` will be used for calculating the space.

--- a/packages/dashboard/src/constants/pageStructure.js
+++ b/packages/dashboard/src/constants/pageStructure.js
@@ -16,8 +16,6 @@
 
 export { PAGE_RATIO, PAGE_WIDTH, PAGE_HEIGHT } from '@googleforcreators/units';
 
-export const WPBODY_ID = 'wpbody';
-
 export const DASHBOARD_LEFT_NAV_WIDTH = 288;
 
 export const MIN_DASHBOARD_WIDTH = 1098;

--- a/packages/dashboard/src/utils/usePagePreviewSize.js
+++ b/packages/dashboard/src/utils/usePagePreviewSize.js
@@ -105,8 +105,8 @@ const getContainerWidth = (windowWidth) => {
 
 export default function usePagePreviewSize(options = {}) {
   const { thumbnailMode = false, isGrid } = options;
-  const { containerID } = useConfig();
-  const dashboardContainerRef = useRef(document.getElementById(containerID));
+  const { containerId } = useConfig();
+  const dashboardContainerRef = useRef(document.getElementById(containerId));
 
   // BP is contingent on the actual window size
   const [viewportWidth, setViewportWidth] = useState(window.innerWidth);

--- a/packages/dashboard/src/utils/usePagePreviewSize.js
+++ b/packages/dashboard/src/utils/usePagePreviewSize.js
@@ -32,12 +32,12 @@ import { PAGE_RATIO } from '@googleforcreators/units';
 import {
   DASHBOARD_LEFT_NAV_WIDTH,
   MIN_DASHBOARD_WIDTH,
-  WPBODY_ID,
   VIEWPORT_BREAKPOINT,
   STORY_PREVIEW_WIDTH,
   GRID_SPACING,
   PAGE_WRAPPER,
 } from '../constants';
+import useConfig from '../app/config/useConfig';
 
 /**
  * Here we need to calculate height for every pagePreview in use.
@@ -105,9 +105,8 @@ const getContainerWidth = (windowWidth) => {
 
 export default function usePagePreviewSize(options = {}) {
   const { thumbnailMode = false, isGrid } = options;
-  // When the dashboard is pulled out of wordpress this id will need to be updated.
-  // For now, we need to grab wordpress instead because of how the app's rendered
-  const dashboardContainerRef = useRef(document.getElementById(WPBODY_ID));
+  const { containerID } = useConfig();
+  const dashboardContainerRef = useRef(document.getElementById(containerID));
 
   // BP is contingent on the actual window size
   const [viewportWidth, setViewportWidth] = useState(window.innerWidth);

--- a/packages/wp-dashboard/src/index.js
+++ b/packages/wp-dashboard/src/index.js
@@ -82,6 +82,7 @@ window.webStories.initializeStoryDashboard = (id, config) => {
     styleConstants: {
       topOffset: TOOLBAR_HEIGHT,
     },
+    containerID: 'wpbody',
   };
 
   render(

--- a/packages/wp-dashboard/src/index.js
+++ b/packages/wp-dashboard/src/index.js
@@ -82,7 +82,7 @@ window.webStories.initializeStoryDashboard = (id, config) => {
     styleConstants: {
       topOffset: TOOLBAR_HEIGHT,
     },
-    containerID: 'wpbody',
+    containerId: 'wpbody',
   };
 
   render(


### PR DESCRIPTION
## Context
`usePagePreviewSize` uses the WordPress id `wpbody` for calculating the container width for preview, which shouldn't live in the core dashboard, so we can pass it down via the config instead.


## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
