### PR TITLE
Editor: Hide design menu if not enabled for element type

### DIFF
--- a/packages/element-library/src/gif/constants.js
+++ b/packages/element-library/src/gif/constants.js
@@ -29,6 +29,7 @@ export {
   isMaskable,
   isMedia,
   hasEditMode,
+  hasDesignMenu,
   editModeGrayout,
 } from '../media/constants';
 

--- a/packages/element-library/src/image/constants.js
+++ b/packages/element-library/src/image/constants.js
@@ -29,6 +29,7 @@ export {
   isMaskable,
   isMedia,
   hasEditMode,
+  hasDesignMenu,
   editModeGrayout,
   resizeRules,
 } from '../media/constants';

--- a/packages/element-library/src/media/constants.js
+++ b/packages/element-library/src/media/constants.js
@@ -34,6 +34,8 @@ export const MEDIA_MASK_OPACITY = 0.4;
 
 export const hasEditMode = true;
 
+export const hasDesignMenu = true;
+
 export const isMedia = true;
 
 export const canFlip = true;

--- a/packages/element-library/src/product/constants.js
+++ b/packages/element-library/src/product/constants.js
@@ -35,6 +35,8 @@ export const defaultAttributes = {
 
 export const hasEditMode = false;
 
+export const hasDesignMenu = false;
+
 export const isMedia = false;
 
 export const canFlip = true;

--- a/packages/element-library/src/shape/constants.js
+++ b/packages/element-library/src/shape/constants.js
@@ -33,6 +33,8 @@ export const defaultAttributes = {
 
 export const hasEditMode = false;
 
+export const hasDesignMenu = true;
+
 export const isMedia = false;
 
 export const canFlip = true;

--- a/packages/element-library/src/sticker/constants.js
+++ b/packages/element-library/src/sticker/constants.js
@@ -25,6 +25,8 @@ import { SHARED_DEFAULT_ATTRIBUTES } from '../shared';
 
 export const hasEditMode = false;
 
+export const hasDesignMenu = true;
+
 export const isMedia = false;
 
 export const canFlip = true;

--- a/packages/element-library/src/text/constants.js
+++ b/packages/element-library/src/text/constants.js
@@ -46,6 +46,8 @@ export const defaultAttributes = {
 
 export const hasEditMode = true;
 
+export const hasDesignMenu = true;
+
 export const hasEditModeMoveable = true;
 
 export const isMedia = false;

--- a/packages/element-library/src/video/constants.js
+++ b/packages/element-library/src/video/constants.js
@@ -33,6 +33,7 @@ export {
   isMaskable,
   isMedia,
   hasEditMode,
+  hasDesignMenu,
   editModeGrayout,
 } from '../media/constants';
 

--- a/packages/story-editor/src/components/floatingMenu/constants.js
+++ b/packages/story-editor/src/components/floatingMenu/constants.js
@@ -17,10 +17,24 @@
 /**
  * External dependencies
  */
-import { ELEMENT_TYPES } from '@googleforcreators/elements';
+import {
+  ELEMENT_TYPES,
+  getDefinitionForType,
+} from '@googleforcreators/elements';
 
 export const SELECTED_ELEMENT_TYPES = {
   ...ELEMENT_TYPES,
   MULTIPLE: 'multiple',
   NONE: 'none',
 };
+
+export function hasDesignMenu(type) {
+  switch (type) {
+    case SELECTED_ELEMENT_TYPES.MULTIPLE:
+      return true;
+    case SELECTED_ELEMENT_TYPES.NONE:
+      return false;
+    default:
+      return getDefinitionForType(type)?.hasDesignMenu;
+  }
+}

--- a/packages/story-editor/src/components/floatingMenu/layer.js
+++ b/packages/story-editor/src/components/floatingMenu/layer.js
@@ -29,7 +29,7 @@ import {
  */
 import { useCanvas, useLayout, useStory, useTransform } from '../../app';
 import { FLOATING_MENU_DISTANCE } from '../../constants';
-import { SELECTED_ELEMENT_TYPES } from './constants';
+import { SELECTED_ELEMENT_TYPES, hasDesignMenu } from './constants';
 import FloatingMenu from './menu';
 
 function FloatingMenuLayer() {
@@ -97,10 +97,8 @@ function FloatingMenuLayer() {
     // frame will already be updating because of the resize, so a DOM mutation is incoming.
   }, [workspaceWidth, workspaceHeight]);
 
-  const hasMenu =
-    selectedElementType !== SELECTED_ELEMENT_TYPES.NONE &&
-    !isDismissed &&
-    moveable;
+  const selectedElementHasDesignMenu = hasDesignMenu(selectedElementType);
+  const hasMenu = selectedElementHasDesignMenu && !isDismissed && moveable;
 
   // Whenever moveable is set (because selection count changed between none, single, or multiple)
   useEffect(() => {


### PR DESCRIPTION
## Context

This adds a new config option to element types, that hides the design menu if not enabled for a particular element type. Note that this setting only applies to single selection of said element type. If the user multi-selects either solely or partially elements with this setting off, the multi-select menu will still appear.

## User-facing changes

| Before | After |
|-|-|
| ![Screen Shot 2022-04-18 at 11 56 01](https://user-images.githubusercontent.com/637548/163835739-ba923b28-9c91-4225-bf12-ad3c35d98024.png) | ![Screen Shot 2022-04-18 at 11 55 39](https://user-images.githubusercontent.com/637548/163835746-efdad5c0-dce0-4901-b4ad-ada4990c3d79.png) |

## Testing Instructions

This PR can be tested by following these steps:

1. Enable shopping experiment and set the proper settings
2. Add a product to the page
3. Observe that no design menu is displayed just below the menu

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #11116
