### PR TITLE
Performance: Saved template image generation integrate with page canvas provider

### DIFF
--- a/packages/story-editor/src/components/library/panes/pageTemplates/savedPageTemplate.js
+++ b/packages/story-editor/src/components/library/panes/pageTemplates/savedPageTemplate.js
@@ -111,9 +111,9 @@ function SavedPageTemplate(
   const queuePageImageGeneration = usePageDataUrls(
     ({ actions }) => actions.queuePageImageGeneration
   );
-  const pageDataUrl = usePageDataUrls(
-    ({ state: { dataUrls } }) => dataUrls[page.id]
-  );
+  const pageDataUrl =
+    usePageDataUrls(({ state: { dataUrls } }) => dataUrls[page.id]) ||
+    page.pregeneratedPageDataUrl;
   const [isActive, setIsActive] = useState(false);
 
   useFocusOut(ref, () => setIsActive(false), []);

--- a/packages/story-editor/src/components/library/panes/pageTemplates/savedPageTemplate.js
+++ b/packages/story-editor/src/components/library/panes/pageTemplates/savedPageTemplate.js
@@ -36,6 +36,7 @@ import styled from 'styled-components';
 import { generatePatternStyles } from '@googleforcreators/patterns';
 import { fetchRemoteBlob, blobToFile } from '@googleforcreators/media';
 import { trackError } from '@googleforcreators/tracking';
+import { UnitsProvider } from '@googleforcreators/units';
 
 /**
  * Internal dependencies
@@ -216,9 +217,16 @@ function SavedPageTemplate(
             draggable={false}
           />
         ) : (
-          page.elements.map((element) => (
-            <DisplayElement key={element.id} previewMode element={element} />
-          ))
+          <UnitsProvider
+            pageSize={{
+              height: pageSize.height,
+              width: pageSize.width,
+            }}
+          >
+            {page.elements.map((element) => (
+              <DisplayElement key={element.id} previewMode element={element} />
+            ))}
+          </UnitsProvider>
         )}
         {isActive && <InsertionOverlay showIcon={false} />}
         <ActionButton

--- a/packages/story-editor/src/utils/createThumbnailCanvasFromFullbleedCanvas.js
+++ b/packages/story-editor/src/utils/createThumbnailCanvasFromFullbleedCanvas.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { PAGE_RATIO } from '@googleforcreators/units';
+
+/**
+ * Creates a thumbnail aspect ratio canvas when given a fullbleed aspect
+ * ratio canvas.
+ *
+ * @param {HTMLCanvasElement} fullbleedCanvas fullbleed aspect ratio canvas element
+ * @return {HTMLCanvasElement} a new thumbnail aspect ratio canvas element
+ */
+function createThumbnailCanvasFromFullbleedCanvas(fullbleedCanvas) {
+  const thumbnailCanvas = document.createElement('canvas');
+  const thumbnailContext = thumbnailCanvas.getContext('2d');
+
+  const fullbleedHeight = Number(fullbleedCanvas.height);
+  const thumbnailHeight = Number(fullbleedCanvas.width) / PAGE_RATIO;
+  const dy = (fullbleedHeight - thumbnailHeight) / 2;
+  thumbnailCanvas.width = fullbleedCanvas.width;
+  thumbnailCanvas.height = thumbnailHeight;
+  thumbnailContext.drawImage(fullbleedCanvas, 0, -dy);
+
+  return thumbnailCanvas;
+}
+
+export default createThumbnailCanvasFromFullbleedCanvas;


### PR DESCRIPTION
## Context
Allows saved page templates to access the page canvas cache when clicking `save page as template`.
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
`save page as template` button will now use the existing page canvas if it exists instead of generating a new canvas from the page. If there's no up to date page canvas in the cache, then the saved template will generate the canvas itself and create the image off of that.

**TLDR**
Save page as templates now takes advantage of the shared canvas cache.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
we're only accessing the canvas cache for generating the dataURL so the `save page as template` button checks to see if there's a valid canvas for this page, and if there is, converts it to a dataURL so the new saved template thumb has access to the image on first render.

The saved template thumb is responsible for taking that dataURL, converting it to a .png file, and uploading it to WP. The reason I went with making the saved template thumb responsible for uploading the image to WP was to reduce latency when clicking the button (with this approach, we don't have to wait for more requests to come back before adding the template to the saved templates panel)
<!-- Please describe your changes. -->

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
NA
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
You could always `console.log` to see when functions are firing, otherwise it can be a little hard to identify whats an image and what's a fully rendered story. regardless, here's how the cache behaves.

**Populating page canvas cache before creation**
- If you're on a story page, then switch to another page, the canvas thumb should now generate an image for the non-active page and store it in the cache.
- Travel back to the original page once the canvas thumb has generated the image for it
- Go to templates and click `add page as template`
- You should see no calls to `html-to-canvas` cus the canvas already exists in the cache
- The saved template should just pull a dataURL off the canvas and use that as the image instead of generating a canvas
- the saved template should generate a .jpg file off of that dataURL, and post to WP to store that .jpg with the saved template post
- the saved template should receive a `src` back that points to the image now on the server and use that to render the image
- the saved template should always render the image from the server on all subsequent loads.

**Note**
It's possible to populate the canvas cache with the current page via smart colors right now to. One way to test this is to go to the header presets and turn on smart colors, then hover over a preset, this should generate a canvas for the cache so that we can read color accessibility info off the page. If you don't actually add one of the presets & just hover over it, the cache for the current page should not be broken and can be used for the saved template image.

**No canvas in cache**
If there's no cache hits for the current version of the page you're creating, the saved template thumbnails will behave as they did before and generate a canvas from the fully rendered story themselves.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10821 
