### PR TITLE
REST API: Prime user meta in controller

### DIFF
--- a/includes/REST_API/Stories_Users_Controller.php
+++ b/includes/REST_API/Stories_Users_Controller.php
@@ -131,6 +131,9 @@ class Stories_Users_Controller extends WP_REST_Users_Controller implements Servi
 			unset( $prepared_args['who'] );
 		}
 
+		// Fix core issue, where user meta is not primed in WP_User_Query. See https://core.trac.wordpress.org/ticket/55594.
+		$prepared_args['fields'] = 'all_with_meta';
+
 		return $prepared_args;
 	}
 

--- a/tests/phpunit/integration/tests/REST_API/Stories_Users_Controller.php
+++ b/tests/phpunit/integration/tests/REST_API/Stories_Users_Controller.php
@@ -82,7 +82,8 @@ class Stories_Users_Controller extends DependencyInjectedRestTestCase {
 		$actual = $this->controller->filter_user_query( [ 'who' => 'authors' ] );
 		$this->assertEqualSets(
 			[
-				'who' => 'authors',
+				'who'    => 'authors',
+				'fields' => 'all_with_meta',
 			],
 			$actual
 		);
@@ -100,6 +101,7 @@ class Stories_Users_Controller extends DependencyInjectedRestTestCase {
 		$this->assertEqualSets(
 			[
 				'capabilities' => [ 'edit_web-stories' ],
+				'fields'       => 'all_with_meta',
 			],
 			$actual
 		);
@@ -118,6 +120,7 @@ class Stories_Users_Controller extends DependencyInjectedRestTestCase {
 		$this->assertEqualSets(
 			[
 				'capabilities' => [ 'edit_web-stories' ],
+				'fields'       => 'all_with_meta',
 			],
 			$actual
 		);
@@ -151,6 +154,7 @@ class Stories_Users_Controller extends DependencyInjectedRestTestCase {
 		$this->assertEqualSets(
 			[
 				'capabilities' => [ 'edit_posts', 'edit_web-stories' ],
+				'fields'       => 'all_with_meta',
 			],
 			$actual
 		);
@@ -163,6 +167,7 @@ class Stories_Users_Controller extends DependencyInjectedRestTestCase {
 		$args    = [
 			'orderby' => 'registered',
 			'order'   => 'ASC',
+			'fields'  => 'all_with_meta',
 		];
 		$results = $this->controller->filter_user_query( $args );
 		$this->assertEqualSets( $args, $results );


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

While doing some more profiling of REST APIs, I found an core issue with the user rest api. See [#55594 ](https://core.trac.wordpress.org/ticket/55594). As we extend this endpoint, we can patch this issue. 

The issue, in a nutshell, when the `WP_User_Query` is run in User REST API, user meta cache is not primed. This means that when user meta is requested to render meta in the endpoint, it does a single query to get meta for that user. If you request 100 users, that would result in 100 queries to user meta table. By request, fields=>`all_with_meta`, all user meta caches are loaded in one query, using the `cache_users` function. 

### Before

<img width="955" alt="Screenshot 2022-04-21 at 00 36 51" src="https://user-images.githubusercontent.com/237508/164342627-177010be-be01-4740-8900-cae8a4a35809.png">


### After
 
<img width="976" alt="Screenshot 2022-04-21 at 00 38 31" src="https://user-images.githubusercontent.com/237508/164342644-cb4529a5-e8e0-4b18-8927-1bb3ce51dedc.png">


## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
