### PR TITLE
Design System: Popup clean up

### DIFF
--- a/packages/dashboard/src/components/tooltip/tooltip.js
+++ b/packages/dashboard/src/components/tooltip/tooltip.js
@@ -33,14 +33,12 @@ export default function Tooltip({
   placement = TOOLTIP_PLACEMENT.BOTTOM,
   ...props
 }) {
-  const { isRTL, styleConstants: { leftOffset } = {} } = useConfig();
+  const { isRTL } = useConfig();
   const derivedPlacement = isRTL ? TOOLTIP_RTL_PLACEMENT[placement] : placement;
 
   return (
     <BaseTooltip
       placement={derivedPlacement}
-      isRTL={isRTL}
-      leftOffset={leftOffset}
       //TODO: https://github.com/GoogleForCreators/web-stories-wp/issues/11200
       ignoreMaxOffsetY
       {...props}

--- a/packages/dashboard/src/dashboard.js
+++ b/packages/dashboard/src/dashboard.js
@@ -20,6 +20,7 @@ import {
   lightMode,
   ModalGlobalStyle,
   SnackbarProvider,
+  PopupProvider,
   theme as externalDesignSystemTheme,
   ThemeGlobals,
   deepMerge,
@@ -43,12 +44,15 @@ import getDefaultConfig from './getDefaultConfig';
 
 function Dashboard({ config, children }) {
   const _config = deepMerge(getDefaultConfig(), config);
-  const { isRTL, flags } = _config;
   const activeTheme = {
     ...externalDesignSystemTheme,
     colors: lightMode,
   };
-
+  const {
+    isRTL,
+    flags,
+    styleConstants: { leftOffset, topOffset } = {},
+  } = _config;
   return (
     <FlagsProvider features={flags}>
       <StyleSheetManager stylisPlugins={isRTL ? [stylisRTLPlugin] : []}>
@@ -60,9 +64,17 @@ function Dashboard({ config, children }) {
               <NavProvider>
                 <RouterProvider>
                   <SnackbarProvider>
-                    <GlobalStyle />
-                    <KeyboardOnlyOutline />
-                    {children}
+                    <PopupProvider
+                      value={{
+                        isRTL,
+                        leftOffset,
+                        topOffset,
+                      }}
+                    >
+                      <GlobalStyle />
+                      <KeyboardOnlyOutline />
+                      {children}
+                    </PopupProvider>
                   </SnackbarProvider>
                 </RouterProvider>
               </NavProvider>

--- a/packages/design-system/src/components/datalist/datalist.js
+++ b/packages/design-system/src/components/datalist/datalist.js
@@ -98,6 +98,8 @@ const Datalist = forwardRef(function Datalist(
     containerStyleOverrides,
     title,
     dropdownButtonLabel,
+    isRTL,
+    leftOffset,
     ...rest
   },
   ref
@@ -219,6 +221,8 @@ const Datalist = forwardRef(function Datalist(
           isOpen={isOpen}
           fillWidth={DEFAULT_WIDTH}
           zIndex={zIndex}
+          isRTL={isRTL}
+          leftOffset={leftOffset}
         >
           {list}
         </Popup>
@@ -251,6 +255,8 @@ Datalist.propTypes = {
   listStyleOverrides: PropTypes.array,
   title: PropTypes.string,
   dropdownButtonLabel: PropTypes.string,
+  isRTL: PropTypes.bool,
+  leftOffset: PropTypes.number,
 };
 
 export default Datalist;

--- a/packages/design-system/src/components/datalist/datalist.js
+++ b/packages/design-system/src/components/datalist/datalist.js
@@ -98,8 +98,6 @@ const Datalist = forwardRef(function Datalist(
     containerStyleOverrides,
     title,
     dropdownButtonLabel,
-    isRTL,
-    leftOffset,
     ...rest
   },
   ref
@@ -221,8 +219,6 @@ const Datalist = forwardRef(function Datalist(
           isOpen={isOpen}
           fillWidth={DEFAULT_WIDTH}
           zIndex={zIndex}
-          isRTL={isRTL}
-          leftOffset={leftOffset}
         >
           {list}
         </Popup>
@@ -255,8 +251,6 @@ Datalist.propTypes = {
   listStyleOverrides: PropTypes.array,
   title: PropTypes.string,
   dropdownButtonLabel: PropTypes.string,
-  isRTL: PropTypes.bool,
-  leftOffset: PropTypes.number,
 };
 
 export default Datalist;

--- a/packages/design-system/src/components/dropDown/index.js
+++ b/packages/design-system/src/components/dropDown/index.js
@@ -80,8 +80,6 @@ export const DropDown = forwardRef(
       isInline = false,
       selectedValue = '',
       className,
-      isRTL,
-      leftOffset,
       ...rest
     },
     ref
@@ -197,8 +195,6 @@ export const DropDown = forwardRef(
             fillWidth={popupFillWidth}
             zIndex={popupZIndex}
             ignoreMaxOffsetY
-            isRTL={isRTL}
-            leftOffset={leftOffset}
           >
             {menu}
           </Popup>
@@ -217,7 +213,6 @@ DropDown.propTypes = {
   hasError: PropTypes.bool,
   hint: PropTypes.string,
   isKeepMenuOpenOnSelection: PropTypes.bool,
-  isRTL: PropTypes.bool,
   menuStylesOverride: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   options: MENU_OPTIONS,
   onMenuItemClick: PropTypes.func,
@@ -232,5 +227,4 @@ DropDown.propTypes = {
     PropTypes.bool,
     PropTypes.number,
   ]),
-  leftOffset: PropTypes.number,
 };

--- a/packages/design-system/src/components/dropDown/index.js
+++ b/packages/design-system/src/components/dropDown/index.js
@@ -80,6 +80,8 @@ export const DropDown = forwardRef(
       isInline = false,
       selectedValue = '',
       className,
+      isRTL,
+      leftOffset,
       ...rest
     },
     ref
@@ -195,6 +197,8 @@ export const DropDown = forwardRef(
             fillWidth={popupFillWidth}
             zIndex={popupZIndex}
             ignoreMaxOffsetY
+            isRTL={isRTL}
+            leftOffset={leftOffset}
           >
             {menu}
           </Popup>
@@ -228,4 +232,5 @@ DropDown.propTypes = {
     PropTypes.bool,
     PropTypes.number,
   ]),
+  leftOffset: PropTypes.number,
 };

--- a/packages/design-system/src/components/mediaInput/index.js
+++ b/packages/design-system/src/components/mediaInput/index.js
@@ -183,8 +183,6 @@ export const MediaInput = forwardRef(function Media(
     canUpload = true,
     menuProps = {},
     imgProps = {},
-    isRTL = false,
-    leftOffset = 0,
     ...rest
   },
   ref
@@ -225,8 +223,6 @@ export const MediaInput = forwardRef(function Media(
       {canUpload && (
         <BaseTooltip
           title={hasMenu ? null : __('Open media picker', 'web-stories')}
-          isRTL={isRTL}
-          leftOffset={leftOffset}
         >
           <Button
             ref={(node) => {
@@ -258,8 +254,6 @@ export const MediaInput = forwardRef(function Media(
         placement={PLACEMENT.BOTTOM_END}
         anchor={internalRef}
         isOpen={isMenuOpen}
-        isRTL={isRTL}
-        leftOffset={leftOffset}
       >
         <Menu
           parentId={buttonId}

--- a/packages/design-system/src/components/mediaInput/index.js
+++ b/packages/design-system/src/components/mediaInput/index.js
@@ -259,6 +259,7 @@ export const MediaInput = forwardRef(function Media(
         anchor={internalRef}
         isOpen={isMenuOpen}
         isRTL={isRTL}
+        leftOffset={leftOffset}
       >
         <Menu
           parentId={buttonId}

--- a/packages/design-system/src/components/popup/index.js
+++ b/packages/design-system/src/components/popup/index.js
@@ -32,6 +32,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { noop } from '../../utils';
+import { usePopup } from '../../contexts';
 import { getTransforms, getOffset } from './utils';
 import { PLACEMENT, PopupContainer } from './constants';
 const DEFAULT_TOP_OFFSET = 0;
@@ -39,7 +40,6 @@ const DEFAULT_POPUP_Z_INDEX = 2;
 const DEFAULT_LEFT_OFFSET = 0;
 
 function Popup({
-  isRTL = false,
   anchor,
   dock,
   children,
@@ -49,11 +49,15 @@ function Popup({
   isOpen,
   fillWidth = false,
   refCallback = noop,
-  topOffset = DEFAULT_TOP_OFFSET,
-  leftOffset = DEFAULT_LEFT_OFFSET,
   zIndex = DEFAULT_POPUP_Z_INDEX,
   ignoreMaxOffsetY,
 }) {
+  const {
+    topOffset = DEFAULT_TOP_OFFSET,
+    leftOffset = DEFAULT_LEFT_OFFSET,
+    isRTL = false,
+  } = usePopup();
+
   const [popupState, setPopupState] = useState(null);
   const isMounted = useRef(false);
   const popup = useRef(null);
@@ -196,7 +200,6 @@ function Popup({
 }
 
 Popup.propTypes = {
-  isRTL: PropTypes.bool,
   anchor: PropTypes.shape({ current: PropTypes.instanceOf(Element) })
     .isRequired,
   dock: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
@@ -207,8 +210,6 @@ Popup.propTypes = {
   isOpen: PropTypes.bool,
   fillWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
   refCallback: PropTypes.func,
-  topOffset: PropTypes.number,
-  leftOffset: PropTypes.number,
   zIndex: PropTypes.number,
   ignoreMaxOffsetY: PropTypes.bool,
 };

--- a/packages/design-system/src/components/popup/index.js
+++ b/packages/design-system/src/components/popup/index.js
@@ -86,7 +86,7 @@ function Popup({
       const updatedXOffset = () => {
         // When in RTL the popup could render off the left side of the screen. If so, let's update the
         // offset to keep it inbounds.
-        if (x <= leftOffset) {
+        if (x < leftOffset) {
           switch (placement) {
             case PLACEMENT.BOTTOM_END:
             case PLACEMENT.TOP_END:
@@ -111,7 +111,7 @@ function Popup({
           }
         }
 
-        if (isRTL && right >= offset.bodyRight - leftOffset) {
+        if (isRTL && right > offset.bodyRight - leftOffset) {
           // maxOffset should keep us inbounds, expect in the case of RTL due to the admin-sidebar nav we could use another
           // switch case here to make offset more precise, however the math below will always return the popup fully in screen.
           return { ...offset, x: offset.bodyRight - width - leftOffset };
@@ -208,6 +208,7 @@ Popup.propTypes = {
   fillWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
   refCallback: PropTypes.func,
   topOffset: PropTypes.number,
+  leftOffset: PropTypes.number,
   zIndex: PropTypes.number,
   ignoreMaxOffsetY: PropTypes.bool,
 };

--- a/packages/design-system/src/components/popup/index.js
+++ b/packages/design-system/src/components/popup/index.js
@@ -34,8 +34,9 @@ import PropTypes from 'prop-types';
 import { noop } from '../../utils';
 import { getTransforms, getOffset } from './utils';
 import { PLACEMENT, PopupContainer } from './constants';
-const DEFAULT_TOPOFFSET = 0;
+const DEFAULT_TOP_OFFSET = 0;
 const DEFAULT_POPUP_Z_INDEX = 2;
+const DEFAULT_LEFT_OFFSET = 0;
 
 function Popup({
   isRTL = false,
@@ -48,10 +49,10 @@ function Popup({
   isOpen,
   fillWidth = false,
   refCallback = noop,
-  topOffset = DEFAULT_TOPOFFSET,
+  topOffset = DEFAULT_TOP_OFFSET,
+  leftOffset = DEFAULT_LEFT_OFFSET,
   zIndex = DEFAULT_POPUP_Z_INDEX,
   ignoreMaxOffsetY,
-  resetXOffset = false,
 }) {
   const [popupState, setPopupState] = useState(null);
   const isMounted = useRef(false);
@@ -66,21 +67,61 @@ function Popup({
       if (evt?.target?.nodeType && popup.current?.contains(evt.target)) {
         return;
       }
+      const offset = anchor.current
+        ? getOffset({
+            placement,
+            spacing,
+            anchor,
+            dock,
+            popup,
+            isRTL,
+            topOffset,
+            ignoreMaxOffsetY,
+          })
+        : {};
+      const { height, x, width, right } = popup.current
+        ? popup.current.getBoundingClientRect()
+        : {};
+
+      const updatedXOffset = () => {
+        // When in RTL the popup could render off the left side of the screen. If so, let's update the
+        // offset to keep it inbounds.
+        if (x <= leftOffset) {
+          switch (placement) {
+            case PLACEMENT.BOTTOM_END:
+            case PLACEMENT.TOP_END:
+              return { ...offset, x: isRTL ? offset.x : width + leftOffset };
+            case PLACEMENT.LEFT_END:
+            case PLACEMENT.LEFT:
+            case PLACEMENT.LEFT_START:
+              // Left placement shouldn't be used if it renders off the left of the screen in LTR
+              return {
+                ...offset,
+                x: isRTL ? offset.x : width + -x - leftOffset,
+              };
+            case PLACEMENT.BOTTOM_START:
+            case PLACEMENT.TOP_START:
+            case PLACEMENT.RIGHT_END:
+            case PLACEMENT.RIGHT_START:
+            case PLACEMENT.RIGHT:
+              // These should only matter in the case of isRTL so we'll need the entire width of the popup as the offset
+              return { ...offset, x: width };
+            default:
+              return { ...offset, x: width / 2 + (isRTL ? 0 : leftOffset) };
+          }
+        }
+
+        if (isRTL && right >= offset.bodyRight - leftOffset) {
+          // maxOffset should keep us inbounds, expect in the case of RTL due to the admin-sidebar nav we could use another
+          // switch case here to make offset more precise, however the math below will always return the popup fully in screen.
+          return { ...offset, x: offset.bodyRight - width - leftOffset };
+        }
+
+        return null;
+      };
       setPopupState({
-        offset: anchor.current
-          ? getOffset({
-              placement,
-              spacing,
-              anchor,
-              dock,
-              popup,
-              isRTL,
-              topOffset,
-              ignoreMaxOffsetY,
-              resetXOffset,
-            })
-          : {},
-        height: popup.current?.getBoundingClientRect()?.height,
+        offset: updatedXOffset() || offset,
+        height,
       });
     },
     [
@@ -90,8 +131,8 @@ function Popup({
       dock,
       isRTL,
       topOffset,
+      leftOffset,
       ignoreMaxOffsetY,
-      resetXOffset,
     ]
   );
 
@@ -169,7 +210,6 @@ Popup.propTypes = {
   topOffset: PropTypes.number,
   zIndex: PropTypes.number,
   ignoreMaxOffsetY: PropTypes.bool,
-  resetXOffset: PropTypes.bool,
 };
 
 export { Popup, PLACEMENT };

--- a/packages/design-system/src/components/popup/index.js
+++ b/packages/design-system/src/components/popup/index.js
@@ -112,7 +112,7 @@ function Popup({
         }
 
         if (isRTL && right > offset.bodyRight - leftOffset) {
-          // maxOffset should keep us inbounds, expect in the case of RTL due to the admin-sidebar nav we could use another
+          // maxOffset should keep us inbounds, except in the case of RTL due to the admin-sidebar nav we could use another
           // switch case here to make offset more precise, however the math below will always return the popup fully in screen.
           return { ...offset, x: offset.bodyRight - width - leftOffset };
         }

--- a/packages/design-system/src/components/popup/utils/getOffset.js
+++ b/packages/design-system/src/components/popup/utils/getOffset.js
@@ -102,10 +102,6 @@ export function getYOffset(placement, spacing = 0, anchorRect) {
  * as perceived by the page because of scroll. This is really only true of dropDowns that
  * exist beyond the initial page scroll. Because the editor is a fixed view this only
  * comes up in peripheral pages (dashboard, settings).
- * @param {boolean} args.resetXOffset tooltips (which use Popup) can dynamically adjust `placement` when rendered
- * off screen, eg. when in RTL. However, when using Popup directly, we can run into it being rendered off screen
- * when in RTL. Flag is sent via `Popup` which will determine whether or not we should force the X offset to zero
- * or width of popup.
  * @return {Offset} Popup offset.
  */
 export function getOffset({
@@ -116,7 +112,6 @@ export function getOffset({
   popup,
   isRTL,
   ignoreMaxOffsetY,
-  resetXOffset,
   topOffset = 0,
 }) {
   const anchorRect = anchor.current.getBoundingClientRect();
@@ -134,12 +129,7 @@ export function getOffset({
   const { x: spacingH = 0, y: spacingV = 0 } = spacing || {};
 
   // Horizontal
-  const offsetX = () => {
-    if (resetXOffset && popupRect?.left <= 0) {
-      return isRTL ? width : 0;
-    }
-    return getXOffset(placement, spacingH, anchorRect, dockRect, isRTL);
-  };
+  const offsetX = getXOffset(placement, spacingH, anchorRect, dockRect, isRTL);
 
   const maxOffsetX = !isRTL
     ? bodyRect.width - width - getXTransforms(placement) * width
@@ -152,7 +142,7 @@ export function getOffset({
 
   // Clamp values
   return {
-    x: Math.max(0, Math.min(offsetX(), maxOffsetX)),
+    x: Math.max(0, Math.min(offsetX, maxOffsetX)),
     y: ignoreMaxOffsetY
       ? offsetY
       : Math.max(topOffset, Math.min(offsetY, maxOffsetY)),

--- a/packages/design-system/src/components/search/search.js
+++ b/packages/design-system/src/components/search/search.js
@@ -87,8 +87,6 @@ export const Search = ({
   popupFillWidth = DEFAULT_POPUP_FILL_WIDTH,
   popupZIndex,
   selectedValue = {},
-  isRTL,
-  leftOffset,
   ...rest
 }) => {
   const listId = useMemo(() => `list-${uuidv4()}`, []);
@@ -279,8 +277,6 @@ export const Search = ({
           placement={placement}
           fillWidth={popupFillWidth}
           zIndex={popupZIndex}
-          isRTL={isRTL}
-          leftOffset={leftOffset}
         >
           <Menu
             activeValue={activeOption?.value}
@@ -321,7 +317,6 @@ Search.propTypes = {
   handleSearchValueChange: PropTypes.func,
   hasError: PropTypes.bool,
   hint: PropTypes.string,
-  isRTL: PropTypes.bool,
   label: PropTypes.string,
   menuStylesOverride: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   onMenuItemClick: PropTypes.func,
@@ -340,5 +335,4 @@ Search.propTypes = {
       PropTypes.number,
     ]),
   }),
-  leftOffset: PropTypes.number,
 };

--- a/packages/design-system/src/components/search/search.js
+++ b/packages/design-system/src/components/search/search.js
@@ -87,6 +87,8 @@ export const Search = ({
   popupFillWidth = DEFAULT_POPUP_FILL_WIDTH,
   popupZIndex,
   selectedValue = {},
+  isRTL,
+  leftOffset,
   ...rest
 }) => {
   const listId = useMemo(() => `list-${uuidv4()}`, []);
@@ -277,6 +279,8 @@ export const Search = ({
           placement={placement}
           fillWidth={popupFillWidth}
           zIndex={popupZIndex}
+          isRTL={isRTL}
+          leftOffset={leftOffset}
         >
           <Menu
             activeValue={activeOption?.value}
@@ -336,4 +340,5 @@ Search.propTypes = {
       PropTypes.number,
     ]),
   }),
+  leftOffset: PropTypes.number,
 };

--- a/packages/design-system/src/components/slider/index.js
+++ b/packages/design-system/src/components/slider/index.js
@@ -202,8 +202,6 @@ const FakeThumb = styled.div`
  * @param {number} props.max Maximum value
  * @param {number} props.thumbSize Thumb diameter in pixels if different from standard
  * @param {string} props.suffix Optional value suffix to be displayed in tooltip
- * @param {boolean} props.isRTL Needed for tooltip placement
- * @param {number} props.leftOffset Needed for tooltip placement
  * @param {number} props.popupZIndexOverride Needed for z index of tooltip
  * @return {Node} Range input component
  */
@@ -216,8 +214,6 @@ function Slider({
   max = 500,
   thumbSize = DEFAULT_SIZE,
   suffix = '',
-  isRTL,
-  leftOffset,
   popupZIndexOverride,
   ...rest
 }) {
@@ -260,8 +256,6 @@ function Slider({
       placement={PLACEMENT.TOP}
       popupZIndexOverride={popupZIndexOverride}
       forceAnchorRef={fakeThumbRef}
-      isRTL={isRTL}
-      leftOffset={leftOffset}
       styleOverride={{
         style: {
           transform: `translate(${
@@ -305,8 +299,6 @@ Slider.propTypes = {
   max: PropTypes.number,
   thumbSize: PropTypes.number,
   suffix: PropTypes.string,
-  isRTL: PropTypes.bool,
-  leftOffset: PropTypes.number,
   popupZIndexOverride: PropTypes.number,
 };
 

--- a/packages/design-system/src/components/tooltip/index.js
+++ b/packages/design-system/src/components/tooltip/index.js
@@ -41,6 +41,7 @@ import { Text } from '../typography';
 import { RTL_PLACEMENT, PopupContainer } from '../popup/constants';
 import { getOffset, getTransforms } from '../popup/utils';
 import { noop } from '../../utils';
+import { usePopup } from '../../contexts';
 import { SvgForTail, Tail, SVG_TOOLTIP_TAIL_ID, TAIL_HEIGHT } from './tail';
 
 const SPACE_BETWEEN_TOOLTIP_AND_ELEMENT = TAIL_HEIGHT;
@@ -103,8 +104,6 @@ let lastVisibleDelayedTooltip = null;
  * as perceived by the page because of scroll. This is really only true of dropDowns that
  * exist beyond the initial page scroll. Because the editor is a fixed view this only
  * comes up in peripheral pages (dashboard, settings).
- * @param props.isRTL RTL flag from config
- * @param props.leftOffset wp-admin bar width from config, prevents overlap with side bar.
  * @return {import('react').Component} BaseTooltip element
  */
 
@@ -122,11 +121,10 @@ function BaseTooltip({
   className = null,
   popupZIndexOverride,
   ignoreMaxOffsetY = false,
-  isRTL,
-  leftOffset = DEFAULT_LEFT_OFFSET,
   styleOverride,
   ...props
 }) {
+  const { leftOffset = DEFAULT_LEFT_OFFSET, isRTL } = usePopup();
   const [shown, setShown] = useState(false);
   const [arrowDelta, setArrowDelta] = useState(null);
   const anchorRef = useRef(null);
@@ -399,8 +397,6 @@ const BaseTooltipPropTypes = {
   isDelayed: PropTypes.bool,
   popupZIndexOverride: PropTypes.number,
   ignoreMaxOffsetY: PropTypes.bool,
-  isRTL: PropTypes.bool,
-  leftOffset: PropTypes.number,
 };
 BaseTooltip.propTypes = BaseTooltipPropTypes;
 

--- a/packages/design-system/src/contexts/popup/context.js
+++ b/packages/design-system/src/contexts/popup/context.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-export { default as SnackbarContext } from './snackbar/context';
-export { default as SnackbarProvider } from './snackbar/snackbarProvider';
-export { useSnackbar } from './snackbar/useSnackbar';
-export { default as PopupContext } from './popup/context';
-export { default as PopupProvider } from './popup/popupProvider';
-export { usePopup } from './popup/usePopup';
+/**
+ * External dependencies
+ */
+import { createContext } from '@googleforcreators/react';
+
+export default createContext({});

--- a/packages/design-system/src/contexts/popup/popupProvider.js
+++ b/packages/design-system/src/contexts/popup/popupProvider.js
@@ -23,16 +23,4 @@ import PropTypes from 'prop-types';
  */
 import Context from './context';
 
-function PopupProvider({ children, value }) {
-  return <Context.Provider value={value}>{children}</Context.Provider>;
-}
-
-PopupProvider.propTypes = {
-  children: PropTypes.node,
-  value: PropTypes.shape({
-    isRTL: PropTypes.bool,
-    leftOffset: PropTypes.number,
-  }),
-};
-
-export default PopupProvider;
+export default Context.Provider;

--- a/packages/design-system/src/contexts/popup/popupProvider.js
+++ b/packages/design-system/src/contexts/popup/popupProvider.js
@@ -15,10 +15,6 @@
  */
 
 /**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-/**
  * Internal dependencies
  */
 import Context from './context';

--- a/packages/design-system/src/contexts/popup/popupProvider.js
+++ b/packages/design-system/src/contexts/popup/popupProvider.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,25 @@
  * limitations under the License.
  */
 
-export { default as SnackbarContext } from './snackbar/context';
-export { default as SnackbarProvider } from './snackbar/snackbarProvider';
-export { useSnackbar } from './snackbar/useSnackbar';
-export { default as PopupContext } from './popup/context';
-export { default as PopupProvider } from './popup/popupProvider';
-export { usePopup } from './popup/usePopup';
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+/**
+ * Internal dependencies
+ */
+import Context from './context';
+
+function PopupProvider({ children, value }) {
+  return <Context.Provider value={value}>{children}</Context.Provider>;
+}
+
+PopupProvider.propTypes = {
+  children: PropTypes.node,
+  value: PropTypes.shape({
+    isRTL: PropTypes.bool,
+    leftOffset: PropTypes.number,
+  }),
+};
+
+export default PopupProvider;

--- a/packages/design-system/src/contexts/popup/usePopup.js
+++ b/packages/design-system/src/contexts/popup/usePopup.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,16 @@
  * limitations under the License.
  */
 
-export { default as SnackbarContext } from './snackbar/context';
-export { default as SnackbarProvider } from './snackbar/snackbarProvider';
-export { useSnackbar } from './snackbar/useSnackbar';
-export { default as PopupContext } from './popup/context';
-export { default as PopupProvider } from './popup/popupProvider';
-export { usePopup } from './popup/usePopup';
+/**
+ * External dependencies
+ */
+import { identity, useContextSelector } from '@googleforcreators/react';
+
+/**
+ * Internal dependencies
+ */
+import Context from './context';
+
+export function usePopup(selector) {
+  return useContextSelector(Context, selector ?? identity);
+}

--- a/packages/element-library/src/video/playPauseButton.js
+++ b/packages/element-library/src/video/playPauseButton.js
@@ -119,8 +119,6 @@ function PlayPauseButton({
   element,
   videoRef = null,
   isRTL,
-  topOffset = 0,
-  leftOffset,
 }) {
   const hasVideoSrc = Boolean(element.resource.src);
   const isPlayAbove =
@@ -246,13 +244,10 @@ function PlayPauseButton({
   const TransitionWrapper = isPlayAbove
     ? ({ children }) => (
         <Popup
-          isRTL={isRTL}
           anchor={elementRef}
           isOpen
           placement="top"
           spacing={playAboveSpacing}
-          topOffset={topOffset}
-          leftOffset={leftOffset}
         >
           {children}
         </Popup>
@@ -295,8 +290,6 @@ PlayPauseButton.propTypes = {
   element: StoryPropTypes.element.isRequired,
   videoRef: PropTypes.object,
   isRTL: PropTypes.bool,
-  topOffset: PropTypes.number,
-  leftOffset: PropTypes.number,
 };
 
 export default PlayPauseButton;

--- a/packages/element-library/src/video/playPauseButton.js
+++ b/packages/element-library/src/video/playPauseButton.js
@@ -120,6 +120,7 @@ function PlayPauseButton({
   videoRef = null,
   isRTL,
   topOffset = 0,
+  leftOffset,
 }) {
   const hasVideoSrc = Boolean(element.resource.src);
   const isPlayAbove =
@@ -251,6 +252,7 @@ function PlayPauseButton({
           placement="top"
           spacing={playAboveSpacing}
           topOffset={topOffset}
+          leftOffset={leftOffset}
         >
           {children}
         </Popup>
@@ -294,6 +296,7 @@ PlayPauseButton.propTypes = {
   videoRef: PropTypes.object,
   isRTL: PropTypes.bool,
   topOffset: PropTypes.number,
+  leftOffset: PropTypes.number,
 };
 
 export default PlayPauseButton;

--- a/packages/story-editor/src/components/canvas/pageAttachment/index.js
+++ b/packages/story-editor/src/components/canvas/pageAttachment/index.js
@@ -25,7 +25,7 @@ import { __ } from '@googleforcreators/i18n';
 /**
  * Internal dependencies
  */
-import { useCanvas, useConfig } from '../../../app';
+import { useCanvas } from '../../../app';
 import useElementsWithLinks from '../../../utils/useElementsWithLinks';
 import { OUTLINK_THEME } from '../../../constants';
 import DefaultIcon from './icons/defaultIcon.svg';
@@ -144,7 +144,6 @@ function PageAttachment({ pageAttachment = {} }) {
     icon,
     theme,
   } = pageAttachment;
-  const { isRTL, styleConstants: { leftOffset, topOffset } = {} } = useConfig();
   const bgColor = theme === OUTLINK_THEME.DARK ? DARK_COLOR : LIGHT_COLOR;
   const fgColor = theme === OUTLINK_THEME.DARK ? LIGHT_COLOR : DARK_COLOR;
   return (
@@ -164,13 +163,10 @@ function PageAttachment({ pageAttachment = {} }) {
             </OutlinkChip>
             {pageAttachmentContainer && hasInvalidLinkSelected && (
               <Popup
-                isRTL={isRTL}
                 anchor={{ current: pageAttachmentContainer }}
                 isOpen
                 placement={PLACEMENT.LEFT}
                 spacing={spacing}
-                topOffset={topOffset}
-                leftOffset={leftOffset}
               >
                 <Tooltip>
                   {__(

--- a/packages/story-editor/src/components/canvas/pageAttachment/index.js
+++ b/packages/story-editor/src/components/canvas/pageAttachment/index.js
@@ -144,7 +144,7 @@ function PageAttachment({ pageAttachment = {} }) {
     icon,
     theme,
   } = pageAttachment;
-  const { isRTL, styleConstants: { topOffset } = {} } = useConfig();
+  const { isRTL, styleConstants: { leftOffset, topOffset } = {} } = useConfig();
   const bgColor = theme === OUTLINK_THEME.DARK ? DARK_COLOR : LIGHT_COLOR;
   const fgColor = theme === OUTLINK_THEME.DARK ? LIGHT_COLOR : DARK_COLOR;
   return (
@@ -170,6 +170,7 @@ function PageAttachment({ pageAttachment = {} }) {
                 placement={PLACEMENT.LEFT}
                 spacing={spacing}
                 topOffset={topOffset}
+                leftOffset={leftOffset}
               >
                 <Tooltip>
                   {__(

--- a/packages/story-editor/src/components/footer/gridview/gridView.js
+++ b/packages/story-editor/src/components/footer/gridview/gridView.js
@@ -160,7 +160,7 @@ function GridView({ onClose }) {
     })
   );
 
-  const { isRTL, styleConstants: { leftOffset } = {} } = useConfig();
+  const { isRTL } = useConfig();
   const [pagesPerRow, setPagesPerRow] = useState(4);
   const [availableWidth, setAvailableWidth] = useState(null);
   const wrapperRef = useRef();
@@ -224,8 +224,6 @@ function GridView({ onClose }) {
           value={pagesPerRow}
           handleChange={(newValue) => setPagesPerRow(newValue)}
           aria-label={__('Pages per row', 'web-stories')}
-          isRTL={isRTL}
-          leftOffset={leftOffset}
           popupZIndexOverride={Z_INDEX_GRID_VIEW_SLIDER}
         />
         <NoButton />

--- a/packages/story-editor/src/components/form/color/colorInput.js
+++ b/packages/story-editor/src/components/form/color/colorInput.js
@@ -41,7 +41,6 @@ import {
   Popup,
   PLACEMENT,
   CONTEXT_MENU_SKIP_ELEMENT,
-  usePopup,
 } from '@googleforcreators/design-system';
 import { v4 as uuidv4 } from 'uuid';
 /**
@@ -59,7 +58,7 @@ import {
   focusStyle,
   inputContainerStyleOverride,
 } from '../../panels/shared/styles';
-import { useCanvas } from '../../../app';
+import { useCanvas, useConfig } from '../../../app';
 
 const Preview = styled.div`
   height: 36px;
@@ -212,7 +211,7 @@ const ColorInput = forwardRef(function ColorInput(
     refs: { sidebar },
   } = useSidebar();
 
-  const { topOffset } = usePopup();
+  const { styleConstants: { topOffset } = {} } = useConfig();
 
   const positionPlacement = useCallback(
     (popupRef) => {

--- a/packages/story-editor/src/components/form/color/colorInput.js
+++ b/packages/story-editor/src/components/form/color/colorInput.js
@@ -205,7 +205,7 @@ const ColorInput = forwardRef(function ColorInput(
       isEyedropperActive,
     })
   );
-  const { isRTL, styleConstants: { topOffset } = {} } = useConfig();
+  const { isRTL, styleConstants: { topOffset, leftOffset } = {} } = useConfig();
   const [dynamicPlacement, setDynamicPlacement] = useState(pickerPlacement);
 
   const {
@@ -343,6 +343,7 @@ const ColorInput = forwardRef(function ColorInput(
       )}
       <Popup
         isRTL={isRTL}
+        leftOffset={leftOffset}
         anchor={previewRef}
         dock={isInDesignMenu ? null : sidebar}
         isOpen={pickerOpen && !isEyedropperActive}
@@ -350,7 +351,6 @@ const ColorInput = forwardRef(function ColorInput(
         spacing={spacing}
         topOffset={topOffset}
         refCallback={positionPlacement}
-        resetXOffset
         renderContents={({ propagateDimensionChange }) => (
           <ColorPicker
             color={isMixed ? null : value}

--- a/packages/story-editor/src/components/form/color/colorInput.js
+++ b/packages/story-editor/src/components/form/color/colorInput.js
@@ -41,6 +41,7 @@ import {
   Popup,
   PLACEMENT,
   CONTEXT_MENU_SKIP_ELEMENT,
+  usePopup,
 } from '@googleforcreators/design-system';
 import { v4 as uuidv4 } from 'uuid';
 /**
@@ -58,7 +59,7 @@ import {
   focusStyle,
   inputContainerStyleOverride,
 } from '../../panels/shared/styles';
-import { useCanvas, useConfig } from '../../../app';
+import { useCanvas } from '../../../app';
 
 const Preview = styled.div`
   height: 36px;
@@ -205,12 +206,13 @@ const ColorInput = forwardRef(function ColorInput(
       isEyedropperActive,
     })
   );
-  const { isRTL, styleConstants: { topOffset, leftOffset } = {} } = useConfig();
   const [dynamicPlacement, setDynamicPlacement] = useState(pickerPlacement);
 
   const {
     refs: { sidebar },
   } = useSidebar();
+
+  const { topOffset } = usePopup();
 
   const positionPlacement = useCallback(
     (popupRef) => {
@@ -342,14 +344,11 @@ const ColorInput = forwardRef(function ColorInput(
         </Tooltip>
       )}
       <Popup
-        isRTL={isRTL}
-        leftOffset={leftOffset}
         anchor={previewRef}
         dock={isInDesignMenu ? null : sidebar}
         isOpen={pickerOpen && !isEyedropperActive}
         placement={dynamicPlacement}
         spacing={spacing}
-        topOffset={topOffset}
         refCallback={positionPlacement}
         renderContents={({ propagateDimensionChange }) => (
           <ColorPicker

--- a/packages/story-editor/src/components/form/media.js
+++ b/packages/story-editor/src/components/form/media.js
@@ -48,8 +48,6 @@ const MediaInputField = ({
   onChange,
   forwardedRef,
   value,
-  isRTL,
-  leftOffset,
   ...rest
 }) => {
   const onMenuOption = useCallback(
@@ -76,8 +74,6 @@ const MediaInputField = ({
       openMediaPicker={open}
       ref={forwardedRef}
       value={value === MULTIPLE_VALUE ? null : value}
-      isRTL={isRTL}
-      leftOffset={leftOffset}
       {...rest}
     />
   );
@@ -100,11 +96,7 @@ function MediaInput(
   },
   forwardedRef
 ) {
-  const {
-    MediaUpload,
-    isRTL,
-    styleConstants: { leftOffset } = {},
-  } = useConfig();
+  const { MediaUpload } = useConfig();
 
   const renderMediaIcon = useCallback(
     (open) => {
@@ -131,13 +123,11 @@ function MediaInput(
           dropdownOptions={dropdownOptions}
           forwardedRef={forwardedRef}
           value={value}
-          isRTL={isRTL}
-          leftOffset={leftOffset}
           {...rest}
         />
       );
     },
-    [value, onChange, forwardedRef, isRTL, leftOffset, rest, menuOptions]
+    [value, onChange, forwardedRef, rest, menuOptions]
   );
 
   return (
@@ -164,8 +154,6 @@ MediaInputField.propTypes = {
     PropTypes.shape({ current: PropTypes.elementType }),
   ]),
   value: PropTypes.string,
-  isRTL: PropTypes.bool,
-  leftOffset: PropTypes.number,
 };
 
 MediaInput.propTypes = {

--- a/packages/story-editor/src/components/library/panes/media/common/insertionMenu.js
+++ b/packages/story-editor/src/components/library/panes/media/common/insertionMenu.js
@@ -48,6 +48,7 @@ import useStory from '../../../../../app/story/useStory';
 import { ActionButton } from '../../shared';
 import useRovingTabIndex from '../../../../../utils/useRovingTabIndex';
 import useFocusCanvas from '../../../../canvas/useFocusCanvas';
+import { useConfig } from '../../../../../app';
 
 const DropDownContainer = styled.div`
   margin-top: 10px;
@@ -97,6 +98,8 @@ function InsertionMenu({
   setParentActive = noop,
   setParentInactive = noop,
 }) {
+  const { isRTL, styleConstants: { leftOffset } = {} } = useConfig();
+
   const insertButtonRef = useRef();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const onMenuOpen = useCallback((e) => {
@@ -187,6 +190,8 @@ function InsertionMenu({
           anchor={insertButtonRef}
           placement={PLACEMENT.BOTTOM_START}
           isOpen={isMenuOpen}
+          isRTL={isRTL}
+          leftOffset={leftOffset}
         >
           <DropDownContainer>
             <Menu

--- a/packages/story-editor/src/components/library/panes/media/common/insertionMenu.js
+++ b/packages/story-editor/src/components/library/panes/media/common/insertionMenu.js
@@ -48,7 +48,6 @@ import useStory from '../../../../../app/story/useStory';
 import { ActionButton } from '../../shared';
 import useRovingTabIndex from '../../../../../utils/useRovingTabIndex';
 import useFocusCanvas from '../../../../canvas/useFocusCanvas';
-import { useConfig } from '../../../../../app';
 
 const DropDownContainer = styled.div`
   margin-top: 10px;
@@ -98,8 +97,6 @@ function InsertionMenu({
   setParentActive = noop,
   setParentInactive = noop,
 }) {
-  const { isRTL, styleConstants: { leftOffset } = {} } = useConfig();
-
   const insertButtonRef = useRef();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const onMenuOpen = useCallback((e) => {
@@ -190,8 +187,6 @@ function InsertionMenu({
           anchor={insertButtonRef}
           placement={PLACEMENT.BOTTOM_START}
           isOpen={isMenuOpen}
-          isRTL={isRTL}
-          leftOffset={leftOffset}
         >
           <DropDownContainer>
             <Menu

--- a/packages/story-editor/src/components/library/panes/media/local/dropDownMenu.js
+++ b/packages/story-editor/src/components/library/panes/media/local/dropDownMenu.js
@@ -39,7 +39,7 @@ import {
 /**
  * Internal dependencies
  */
-import { useLocalMedia } from '../../../../../app';
+import { useLocalMedia, useConfig } from '../../../../../app';
 import { ActionButton } from '../../shared';
 import useFocusCanvas from '../../../../canvas/useFocusCanvas';
 import useRovingTabIndex from '../../../../../utils/useRovingTabIndex';
@@ -114,6 +114,7 @@ function DropDownMenu({
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [showEditDialog, setShowEditDialog] = useState(false);
   const moreButtonRef = useRef();
+  const { isRTL, styleConstants: { leftOffset } = {} } = useConfig();
 
   const onClose = useCallback(() => {
     onMenuCancelled();
@@ -191,6 +192,8 @@ function DropDownMenu({
             anchor={moreButtonRef}
             placement={PLACEMENT.BOTTOM_START}
             isOpen={isMenuOpen}
+            isRTL={isRTL}
+            leftOffset={leftOffset}
           >
             <DropDownContainer>
               <Menu

--- a/packages/story-editor/src/components/library/panes/media/local/dropDownMenu.js
+++ b/packages/story-editor/src/components/library/panes/media/local/dropDownMenu.js
@@ -39,7 +39,7 @@ import {
 /**
  * Internal dependencies
  */
-import { useLocalMedia, useConfig } from '../../../../../app';
+import { useLocalMedia } from '../../../../../app';
 import { ActionButton } from '../../shared';
 import useFocusCanvas from '../../../../canvas/useFocusCanvas';
 import useRovingTabIndex from '../../../../../utils/useRovingTabIndex';
@@ -114,7 +114,6 @@ function DropDownMenu({
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [showEditDialog, setShowEditDialog] = useState(false);
   const moreButtonRef = useRef();
-  const { isRTL, styleConstants: { leftOffset } = {} } = useConfig();
 
   const onClose = useCallback(() => {
     onMenuCancelled();
@@ -192,8 +191,6 @@ function DropDownMenu({
             anchor={moreButtonRef}
             placement={PLACEMENT.BOTTOM_START}
             isOpen={isMenuOpen}
-            isRTL={isRTL}
-            leftOffset={leftOffset}
           >
             <DropDownContainer>
               <Menu

--- a/packages/story-editor/src/components/library/panes/text/stylePresets/stylePresets.js
+++ b/packages/story-editor/src/components/library/panes/text/stylePresets/stylePresets.js
@@ -37,7 +37,7 @@ import { getHTMLFormatters } from '@googleforcreators/rich-text';
 /**
  * Internal dependencies
  */
-import { useStory, useConfig } from '../../../../../app';
+import { useStory } from '../../../../../app';
 import { PRESET_TYPES } from '../../../../../constants';
 import useAddPreset from '../../../../../utils/useAddPreset';
 import { DEFAULT_PRESET } from '../textPresets';
@@ -108,7 +108,6 @@ function PresetPanel() {
   const buttonRef = useRef(null);
   const stylesRef = useRef(null);
   const [isPopupOpen, setIsPopupOpen] = useState(false);
-  const { isRTL, styleConstants: { leftOffset, topOffset } = {} } = useConfig();
   const hasPresets = textStyles.length > 0;
 
   const pushUpdate = useCallback(
@@ -208,9 +207,6 @@ function PresetPanel() {
             <Icons.ChevronDownSmall />
           </MoreButton>
           <Popup
-            topOffset={topOffset}
-            isRTL={isRTL}
-            leftOffset={leftOffset}
             anchor={buttonRef}
             isOpen={isPopupOpen}
             placement={PLACEMENT.RIGHT_START}

--- a/packages/story-editor/src/components/library/panes/text/stylePresets/stylePresets.js
+++ b/packages/story-editor/src/components/library/panes/text/stylePresets/stylePresets.js
@@ -108,7 +108,7 @@ function PresetPanel() {
   const buttonRef = useRef(null);
   const stylesRef = useRef(null);
   const [isPopupOpen, setIsPopupOpen] = useState(false);
-  const { isRTL, styleConstants: { topOffset } = {} } = useConfig();
+  const { isRTL, styleConstants: { leftOffset, topOffset } = {} } = useConfig();
   const hasPresets = textStyles.length > 0;
 
   const pushUpdate = useCallback(
@@ -210,6 +210,7 @@ function PresetPanel() {
           <Popup
             topOffset={topOffset}
             isRTL={isRTL}
+            leftOffset={leftOffset}
             anchor={buttonRef}
             isOpen={isPopupOpen}
             placement={PLACEMENT.RIGHT_START}

--- a/packages/story-editor/src/components/panels/design/textStyle/stylePresets.js
+++ b/packages/story-editor/src/components/panels/design/textStyle/stylePresets.js
@@ -36,7 +36,7 @@ import { useRef, useState } from '@googleforcreators/react';
 /**
  * Internal dependencies
  */
-import { useStory, useConfig } from '../../../../app';
+import { useStory } from '../../../../app';
 import { PRESET_TYPES } from '../../../../constants';
 import useAddPreset from '../../../../utils/useAddPreset';
 import useSidebar from '../../../sidebar/useSidebar';
@@ -81,7 +81,6 @@ function PresetPanel({ pushUpdate }) {
   } = useSidebar();
   const buttonRef = useRef(null);
   const [isPopupOpen, setIsPopupOpen] = useState(false);
-  const { isRTL, styleConstants: { leftOffset, topOffset } = {} } = useConfig();
   const hasPresets = textStyles.length > 0;
 
   const handleApplyStyle = useApplyStyle({ pushUpdate });
@@ -125,9 +124,6 @@ function PresetPanel({ pushUpdate }) {
             <Icons.ChevronDownSmall />
           </MoreButton>
           <Popup
-            topOffset={topOffset}
-            isRTL={isRTL}
-            leftOffset={leftOffset}
             anchor={buttonRef}
             dock={sidebar}
             isOpen={isPopupOpen}

--- a/packages/story-editor/src/components/panels/design/textStyle/stylePresets.js
+++ b/packages/story-editor/src/components/panels/design/textStyle/stylePresets.js
@@ -81,7 +81,7 @@ function PresetPanel({ pushUpdate }) {
   } = useSidebar();
   const buttonRef = useRef(null);
   const [isPopupOpen, setIsPopupOpen] = useState(false);
-  const { isRTL, styleConstants: { topOffset } = {} } = useConfig();
+  const { isRTL, styleConstants: { leftOffset, topOffset } = {} } = useConfig();
   const hasPresets = textStyles.length > 0;
 
   const handleApplyStyle = useApplyStyle({ pushUpdate });
@@ -127,6 +127,7 @@ function PresetPanel({ pushUpdate }) {
           <Popup
             topOffset={topOffset}
             isRTL={isRTL}
+            leftOffset={leftOffset}
             anchor={buttonRef}
             dock={sidebar}
             isOpen={isPopupOpen}

--- a/packages/story-editor/src/components/tooltip/tooltip.js
+++ b/packages/story-editor/src/components/tooltip/tooltip.js
@@ -33,16 +33,9 @@ export default function Tooltip({
   placement = TOOLTIP_PLACEMENT.BOTTOM,
   ...props
 }) {
-  const { isRTL, styleConstants: { leftOffset } = {} } = useConfig();
+  const { isRTL } = useConfig();
   const derivedPlacement = isRTL ? TOOLTIP_RTL_PLACEMENT[placement] : placement;
 
-  return (
-    <BaseTooltip
-      placement={derivedPlacement}
-      isRTL={isRTL}
-      leftOffset={leftOffset}
-      {...props}
-    />
-  );
+  return <BaseTooltip placement={derivedPlacement} {...props} />;
 }
 Tooltip.propTypes = TooltipPropTypes;

--- a/packages/story-editor/src/storyEditor.js
+++ b/packages/story-editor/src/storyEditor.js
@@ -24,6 +24,7 @@ import PropTypes from 'prop-types';
 import {
   SnackbarProvider,
   ModalGlobalStyle,
+  PopupProvider,
   deepMerge,
 } from '@googleforcreators/design-system';
 import { FlagsProvider } from 'flagged';
@@ -59,7 +60,12 @@ import getDefaultConfig from './getDefaultConfig';
 
 function StoryEditor({ config, initialEdits, children }) {
   const _config = deepMerge(getDefaultConfig(), config);
-  const { storyId, isRTL, flags } = _config;
+  const {
+    storyId,
+    isRTL,
+    flags,
+    styleConstants: { leftOffset, topOffset } = {},
+  } = _config;
 
   return (
     <FlagsProvider features={flags}>
@@ -85,14 +91,22 @@ function StoryEditor({ config, initialEdits, children }) {
                                     <HelpCenterProvider>
                                       <PageCanvasProvider>
                                         <PageDataUrlProvider>
-                                          <GlobalStyle />
-                                          <DevTools />
-                                          <DefaultMoveableGlobalStyle />
-                                          <CropMoveableGlobalStyle />
-                                          <ModalGlobalStyle />
-                                          <CalendarStyle />
-                                          <KeyboardOnlyOutlines />
-                                          {children}
+                                          <PopupProvider
+                                            value={{
+                                              isRTL,
+                                              leftOffset,
+                                              topOffset,
+                                            }}
+                                          >
+                                            <GlobalStyle />
+                                            <DevTools />
+                                            <DefaultMoveableGlobalStyle />
+                                            <CropMoveableGlobalStyle />
+                                            <ModalGlobalStyle />
+                                            <CalendarStyle />
+                                            <KeyboardOnlyOutlines />
+                                            {children}
+                                          </PopupProvider>
                                         </PageDataUrlProvider>
                                       </PageCanvasProvider>
                                     </HelpCenterProvider>

--- a/packages/wp-story-editor/src/components/documentPane/publish/publishTime.js
+++ b/packages/wp-story-editor/src/components/documentPane/publish/publishTime.js
@@ -35,13 +35,8 @@ import {
   Row,
   useStory,
   focusStyle,
-  useConfig,
 } from '@googleforcreators/story-editor';
 
-/**
- * Internal dependencies
- */
-import { TOOLBAR_HEIGHT } from '../../../constants';
 // date-fns format without timezone.
 const TIMEZONELESS_FORMAT = 'Y-m-d\\TH:i:s';
 
@@ -63,7 +58,6 @@ function PublishTime() {
     })
   );
   const use12HourFormat = is12Hour();
-  const { isRTL, styleConstants: { leftOffset } = {} } = useConfig();
 
   /* translators: Date format, see https://www.php.net/manual/en/datetime.format.php */
   const shortDateFormat = __('d/m/Y', 'web-stories');
@@ -133,11 +127,8 @@ function PublishTime() {
         />
       </Row>
       <Popup
-        topOffset={TOOLBAR_HEIGHT}
-        leftOffset={leftOffset}
         anchor={dateFieldRef}
         isOpen={showDatePicker}
-        isRTL={isRTL}
         zIndex={10}
         renderContents={({ propagateDimensionChange }) => (
           <DateTime

--- a/packages/wp-story-editor/src/components/documentPane/publish/publishTime.js
+++ b/packages/wp-story-editor/src/components/documentPane/publish/publishTime.js
@@ -63,7 +63,8 @@ function PublishTime() {
     })
   );
   const use12HourFormat = is12Hour();
-  const { isRTL } = useConfig();
+  const { isRTL, styleConstants: { leftOffset } = {} } = useConfig();
+
   /* translators: Date format, see https://www.php.net/manual/en/datetime.format.php */
   const shortDateFormat = __('d/m/Y', 'web-stories');
 
@@ -133,6 +134,7 @@ function PublishTime() {
       </Row>
       <Popup
         topOffset={TOOLBAR_HEIGHT}
+        leftOffset={leftOffset}
         anchor={dateFieldRef}
         isOpen={showDatePicker}
         isRTL={isRTL}


### PR DESCRIPTION
## Context
This is some follow up work related to the Layers Panel `Tooltip` getting negative valued x-offsets. Since the Layers Panel has some very nested absolute positioning the `getOffset` util thinks the `Tooltip` should be based off somewhere that the panel isn't. `Tooltip` offset updates, edge cases, etc where fixed in #11280. However, we still needed to address the `getOffset` to account for edge cases in `Popups` that were a work-around for those Tooltips.    

We had a special prop flag `resetXOffset`, to know when to look for the edge cases where this was an issue. Now that `Tooltip` is separate we can remove the `resetXOffset` flag and better handle any off screen issues directly in the `Popup` component. 
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

<!-- A brief description of what this PR does. -->
`Popup` now updates the x-offset in cases where it would either collide with admin side nav, or otherwise get cutoff screen in x. 

## Relevant Technical Choices
Removed `resetXOffset` from the shared util `getOffset`. Both `Tooltip` and `Popup` use this function to grab offset values for portals. I wanted to keep this portion straightforward.  Since `Tooltip` and `Popup` have varied `placement` considerations I wanted to keep any special offset updates or edge case logic specific to each component. The `getOffset` will still give us `maxOffsetX` to prevent us from cutoff on the right edge, however,  `Popup` now takes `leftOffset` into consideration for RTL mode. `leftOffset` is also being utilized for LTR sidenav bar consideration. 

~~The bulk of these files was just adding `isRTL` and `leftOffset` to all uses of `Popup`.~~

New `usePopup` hook and `PopupProvider`. This provider now gives us access to `leftOffset`, `topOffset` and `isRTL` so we no longer need to pass these as props to `Tooltip` or `Popup` 🎉
 
<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->
Now that `Insertion Menu` is receiving `isRTL` the popup placement is correct in the RTL view as seen below. 
|Before|After|
|--|--|
|<img width="404" alt="Screen Shot 2022-04-21 at 8 31 11 AM" src="https://user-images.githubusercontent.com/1820266/164481024-6c88945a-3ad9-4aac-9c82-a29532139ae3.png">|<img width="403" alt="Screen Shot 2022-04-21 at 8 29 54 AM" src="https://user-images.githubusercontent.com/1820266/164480930-90a957e6-ad47-4db4-a757-693d81da93f2.png">|


## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. In RTL, open the Insert panel and hover over an image. 
2. Click the `+` icon  to open the `Insertion Menu`
3. The Popup should no longer be cutoff by the wp-admin bar
4. While we are here, let/s check for Popup regressions. 
5. Select / add text on the canvas and open the `Style` Panel
6. Open the color picker, (any version of it),  save styles, Font dropdown
7. We can also check the dropdowns in Document tab and the Publish Time Popup. 
8. Double check Dropdowns in the Dashboard and Dashboard settings as well.  


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11201 
Fixes #11303 
