### PR TITLE
Restore Global Keyboard Workspace Focus Shortcut

### DIFF
--- a/packages/story-editor/src/components/canvas/framesLayer.js
+++ b/packages/story-editor/src/components/canvas/framesLayer.js
@@ -26,6 +26,7 @@ import { STORY_ANIMATION_STATE } from '@googleforcreators/animation';
 import {
   themeHelpers,
   useKeyDownEffect,
+  useGlobalKeyDownEffect,
   useLiveRegion,
 } from '@googleforcreators/design-system';
 
@@ -194,6 +195,16 @@ function FramesLayer() {
       enterFocusGroup,
       setFocusGroupCleanup,
     })
+  );
+
+  useGlobalKeyDownEffect(
+    { key: 'mod+option+2', editable: true },
+    () => {
+      enterFocusGroup({
+        groupId: FOCUS_GROUPS.ELEMENT_SELECTION,
+      });
+    },
+    [enterFocusGroup]
   );
 
   // TODO: https://github.com/google/web-stories-wp/issues/10266

--- a/packages/story-editor/src/components/canvas/karma/canvasKeyboardNavigation.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/canvasKeyboardNavigation.karma.js
@@ -88,6 +88,36 @@ describe('Canvas - keyboard navigation', () => {
     );
   }
 
+  it('should focus the canvas with global keyboard shortcut mod+alt+2 (mod+option+2)', async () => {
+    // add some elements
+    // add text to canvas
+    await fixture.editor.library.textTab.click();
+    await fixture.events.click(fixture.editor.library.text.preset('Paragraph'));
+    // add shape to canvas
+    await fixture.editor.library.shapesTab.click();
+    await fixture.events.click(fixture.editor.library.shapes.shape('Triangle'));
+    // add image to canvas
+    await fixture.editor.library.mediaTab.click();
+    await fixture.events.mouse.clickOn(
+      fixture.editor.library.media.item(0),
+      20,
+      20
+    );
+
+    await fixture.events.keyboard.shortcut('mod+alt+2');
+
+    const selectedElements = await fixture.renderHook(() =>
+      useStory(({ state }) => state.selectedElements)
+    );
+
+    expect(selectedElements.length).toBe(1);
+    expect(selectedElements[0].isBackground).toBe(true);
+    // see that background element is selected & focused
+    expect(document.activeElement.getAttribute('data-element-id')).toBe(
+      selectedElements[0].id
+    );
+  });
+
   it('should not focus the canvas while tabbing through the editor', async () => {
     await tabToCanvasFocusContainer();
 

--- a/packages/story-editor/src/components/canvas/useFocusCanvas.js
+++ b/packages/story-editor/src/components/canvas/useFocusCanvas.js
@@ -37,13 +37,6 @@ function useFocusCanvas() {
     });
   }, []);
 
-  // Globally listen for Cmd+Option+2 / Ctrl+Alt+2 for focus
-  useGlobalKeyDownEffect(
-    { key: 'mod+option+2', editable: true },
-    () => focusCanvas(true),
-    [focusCanvas]
-  );
-
   return focusCanvas;
 }
 

--- a/packages/story-editor/src/components/canvas/useFocusCanvas.js
+++ b/packages/story-editor/src/components/canvas/useFocusCanvas.js
@@ -18,7 +18,6 @@
  * External dependencies
  */
 import { useCallback } from '@googleforcreators/react';
-import { useGlobalKeyDownEffect } from '@googleforcreators/design-system';
 
 function useFocusCanvas() {
   /**


### PR DESCRIPTION
## Context

We have a global keyboard shortcut for `mod+option+2` that should focus the canvas. 

## Summary

Global keyboard shortcut to focus canvas/workspace broke, this fixes it. 

## Relevant Technical Choices

Move global keyboard shortcut into `canvas/frameLayers` from `canvas/useCanvasFocus` because frameLayers is where the canvas focus otherwise lives. 

Add a karma test to avoid future regressions of the same. 

## To-do

Noticed while working on this that the `mod+option-1` shortcut that should go to the `Element Library Selection` doesn't work every time. Probably something to do with the sidePanel updates. Will verify and make a new ticket if one doesn't already exist. 

## User-facing changes

Should restore `mod+option+1` shortcut to focus canvas

![Kapture 2022-04-22 at 12 01 49](https://user-images.githubusercontent.com/10720454/164777913-468a2e09-d5c0-4ec1-9bf0-f0652e17bb55.gif)


## Testing Instructions

Check that focusing workspace (canvas) from global keyboard shortcut is restored. 

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10793
