### PR TITLE
Dashboard: Set total pages to 1 if falsy/zero

### DIFF
--- a/packages/dashboard/src/app/reducer/stories.js
+++ b/packages/dashboard/src/app/reducer/stories.js
@@ -149,7 +149,7 @@ function storyReducer(state, action) {
           ...stories,
           ...payloadStories,
         },
-        totalPages: totalPages,
+        totalPages: totalPages || 1,
         totalStoriesByStatus: totalStoriesByStatus,
         allPagesFetched: page >= totalPages,
       };

--- a/packages/dashboard/src/app/reducer/test/stories.js
+++ b/packages/dashboard/src/app/reducer/test/stories.js
@@ -254,6 +254,47 @@ describe('storyReducer', () => {
     });
   });
 
+  it(`should update stories state when ${ACTION_TYPES.FETCH_STORIES_SUCCESS} is called and set totalPages to at least one`, () => {
+    const result = storyReducer(
+      { ...initialState },
+      {
+        type: ACTION_TYPES.FETCH_STORIES_SUCCESS,
+        payload: {
+          page: 1,
+          stories: {},
+          totalStoriesByStatus: {
+            all: 0,
+            [STORY_STATUS.DRAFT]: 0,
+            [STORY_STATUS.PUBLISH]: 0,
+            [STORY_STATUS.FUTURE]: 0,
+            [STORY_STATUS.PENDING]: 0,
+            [STORY_STATUS.PRIVATE]: 0,
+            [STORY_STATUS.PUBLISH]: 0,
+          },
+          totalPages: 0,
+          fetchedStoryIds: [],
+        },
+      }
+    );
+
+    expect(result).toMatchObject({
+      ...initialState,
+      storiesOrderById: [],
+      stories: {},
+      totalStoriesByStatus: {
+        all: 0,
+        [STORY_STATUS.DRAFT]: 0,
+        [STORY_STATUS.PUBLISH]: 0,
+        [STORY_STATUS.FUTURE]: 0,
+        [STORY_STATUS.PENDING]: 0,
+        [STORY_STATUS.PRIVATE]: 0,
+        [STORY_STATUS.PUBLISH]: 0,
+      },
+      totalPages: 1,
+      allPagesFetched: true,
+    });
+  });
+
   it(`should update isLoading when ${ACTION_TYPES.LOADING_STORIES} is called`, () => {
     const result = storyReducer(
       { ...initialState },

--- a/packages/dashboard/src/utils/useStoryView.js
+++ b/packages/dashboard/src/utils/useStoryView.js
@@ -60,7 +60,7 @@ export default function useStoryView({
 
   const setPageClamped = useCallback(
     (newPage) => {
-      const pageRange = { MIN: 1, MAX: totalPages || 1 };
+      const pageRange = { MIN: 1, MAX: totalPages };
       setPage(clamp(newPage, pageRange));
     },
     [totalPages]

--- a/packages/dashboard/src/utils/useStoryView.js
+++ b/packages/dashboard/src/utils/useStoryView.js
@@ -60,7 +60,7 @@ export default function useStoryView({
 
   const setPageClamped = useCallback(
     (newPage) => {
-      const pageRange = { MIN: 1, MAX: totalPages };
+      const pageRange = { MIN: 1, MAX: totalPages || 1 };
       setPage(clamp(newPage, pageRange));
     },
     [totalPages]


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
Ensure that the stories page is never set below 1.
## Summary

<!-- A brief description of what this PR does. -->
Sets the total pages of the dashboard stories to be at least 1 to avoid `rest_invalid_param` error

## Relevant Technical Choices

<!-- Please describe your changes. -->
The dashboard view uses `Stories_Controller.php` when fetching the relevant stories to display on search.  This call can result in `X-WP-TotalPages` being set to zero and intern causing issues on the next fetch because the dashboard assumes it should be at least one.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->
Before:
https://user-images.githubusercontent.com/14057928/165390910-5e79f8d1-f30d-4e39-81b4-da484db16878.mp4

After:
https://user-images.githubusercontent.com/14057928/165390965-e067fe79-7100-4b60-9f45-b9b739e41bbe.mp4

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Go to Stories Plugin > Dashboard
2. Search for a template that doesn't exist (e.g. 'zzz')

On Staging:
- Notice an error in the console and the stories are not loaded correctly

On branch:
- Notice the templates are fetched, and no error in console

## Reviews

### Does this PR have a security-related impact?
No
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
No
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
No
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.




NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11259 