### PR TITLE
Update list of WP constants in PHP-Scoper config

### DIFF
--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -185,30 +185,13 @@ return [
 	'exclude-classes'   => $wp_classes,
 
 	'exclude-functions' => $wp_functions,
-	
-	// Currently exclude-wordpress-constants.json is empty [].
-	// Issue https://github.com/sniccowp/php-scoper-wordpress-excludes/issues/2 .
-	// If fixed we can remove the hardcoded WP constants.
-	
+
 	'exclude-constants' => array_merge(
 		$wp_constants,
 		[
-			'WP_CONTENT_DIR',
-			'WP_CONTENT_URL',
-			'ABSPATH',
-			'WPINC',
-			'WP_DEBUG_DISPLAY',
-			'WPMU_PLUGIN_DIR',
-			'WP_PLUGIN_DIR',
-			'WP_PLUGIN_URL',
-			'WPMU_PLUGIN_URL',
 			'AMP__FILE__',
 			'AMP__DIR__',
 			'AMP__VERSION',
-			'MINUTE_IN_SECONDS',
-			'HOUR_IN_SECONDS',
-			'DAY_IN_SECONDS',
-			'MONTH_IN_SECONDS',
 		]
 	),
 ];

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -10,9 +10,9 @@
 
 use Isolated\Symfony\Component\Finder\Finder;
 
-$wp_classes   = json_decode( file_get_contents( 'vendor/sniccowp/php-scoper-wordpress-excludes/generated/exclude-wordpress-classes.json' ) );
-$wp_functions = json_decode( file_get_contents( 'vendor/sniccowp/php-scoper-wordpress-excludes/generated/exclude-wordpress-functions.json' ) );
-$wp_constants = json_decode( file_get_contents( 'vendor/sniccowp/php-scoper-wordpress-excludes/generated/exclude-wordpress-constants.json' ) );
+$wp_classes   = json_decode( file_get_contents( 'vendor/sniccowp/php-scoper-wordpress-excludes/generated/exclude-wordpress-classes.json' ), true );
+$wp_functions = json_decode( file_get_contents( 'vendor/sniccowp/php-scoper-wordpress-excludes/generated/exclude-wordpress-functions.json' ), true );
+$wp_constants = json_decode( file_get_contents( 'vendor/sniccowp/php-scoper-wordpress-excludes/generated/exclude-wordpress-constants.json' ), true );
 
 return [
 	'prefix'            => 'Google\\Web_Stories_Dependencies',


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

This is a follow-up to #10511

## Summary

<!-- A brief description of what this PR does. -->

The list of constants in `vendor/sniccowp/php-scoper-wordpress-excludes/generated/exclude-wordpress-constants.json` is no longer empty, which means we can simplify our PHP-Scoper config a bit.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #