### PR TITLE
Editor: Contributor Flow Submit Feedback

### DIFF
--- a/packages/story-editor/src/app/story/actions/useSaveStory.js
+++ b/packages/story-editor/src/app/story/actions/useSaveStory.js
@@ -60,6 +60,7 @@ function useSaveStory({ storyId, pages, story, updateStory }) {
   const { showSnackbar } = useSnackbar();
   const [isSaving, setIsSaving] = useState(false);
   const [isFreshlyPublished, setIsFreshlyPublished] = useState(false);
+  const [isFreshlyPending, setIsFreshlyPending] = useState(false);
 
   const { editLink } = story;
   const refreshPostEditURL = useRefreshPostEditURL(storyId, editLink);
@@ -116,7 +117,9 @@ function useSaveStory({ storyId, pages, story, updateStory }) {
           const isStoryPublished = ['publish', 'future', 'private'].includes(
             data.status
           );
+          const isStoryPending = ['pending'].includes(data.status);
           setIsFreshlyPublished(!isStoryAlreadyPublished && isStoryPublished);
+          setIsFreshlyPending(!isStoryAlreadyPublished && isStoryPending);
         })
         .catch((err) => {
           const description = err.message ? stripHTML(err.message) : null;
@@ -181,7 +184,7 @@ function useSaveStory({ storyId, pages, story, updateStory }) {
     ]
   );
 
-  return { saveStory, isSaving, isFreshlyPublished };
+  return { saveStory, isSaving, isFreshlyPublished, isFreshlyPending };
 }
 
 export default useSaveStory;

--- a/packages/story-editor/src/app/story/storyProvider.js
+++ b/packages/story-editor/src/app/story/storyProvider.js
@@ -114,12 +114,13 @@ function StoryProvider({ storyId, initialEdits, children }) {
   // (and it will have side-effects because saving can update url and status,
   //  thus the need for `updateStory`)
   const { updateStory } = api;
-  const { saveStory, isSaving, isFreshlyPublished } = useSaveStory({
-    storyId,
-    pages,
-    story,
-    updateStory,
-  });
+  const { saveStory, isSaving, isFreshlyPublished, isFreshlyPending } =
+    useSaveStory({
+      storyId,
+      pages,
+      story,
+      updateStory,
+    });
 
   const { autoSave, isAutoSaving } = useAutoSave({
     storyId,
@@ -146,6 +147,7 @@ function StoryProvider({ storyId, initialEdits, children }) {
         isSavingStory: isSaving,
         isAutoSavingStory: isAutoSaving,
         isFreshlyPublished,
+        isFreshlyPending,
       },
       copiedElementState,
     }),
@@ -165,6 +167,7 @@ function StoryProvider({ storyId, initialEdits, children }) {
       isSaving,
       isAutoSaving,
       isFreshlyPublished,
+      isFreshlyPending,
       copiedElementState,
     ]
   );

--- a/packages/wp-story-editor/src/components/postReviewDialog/index.js
+++ b/packages/wp-story-editor/src/components/postReviewDialog/index.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useCallback, useEffect, useState } from '@googleforcreators/react';
+import { __ } from '@googleforcreators/i18n';
+import { Text, THEME_CONSTANTS } from '@googleforcreators/design-system';
+import { Dialog, useStory } from '@googleforcreators/story-editor';
+
+function PostReviewDialog() {
+  const { isFreshlyPending } = useStory(
+    ({
+      state: {
+        capabilities: { hasPublishAction },
+        meta: { isFreshlyPending },
+      },
+    }) => ({
+      hasPublishAction,
+      isFreshlyPending,
+    })
+  );
+
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => setIsOpen(Boolean(isFreshlyPending)), [isFreshlyPending]);
+
+  const onClose = useCallback(() => setIsOpen(false), []);
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      title={__('Submitted for Review.', 'web-stories')}
+      primaryText={__('Dismiss', 'web-stories')}
+      onPrimary={onClose}
+    >
+      <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}>
+        {__(
+          'Your Story has been successfully submitted for review.',
+          'web-stories'
+        )}
+      </Text>
+    </Dialog>
+  );
+}
+
+export default PostReviewDialog;

--- a/packages/wp-story-editor/src/components/postReviewDialog/stories/postReviewDialog.js
+++ b/packages/wp-story-editor/src/components/postReviewDialog/stories/postReviewDialog.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,12 +13,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { default as PostPublishDialog } from './postPublishDialog';
-export { default as PostReviewDialog } from './postReviewDialog';
-export { default as Layout } from './layout';
-export { default as MediaUpload } from './mediaUpload';
-export { default as PostLock } from './postLock';
-export { default as StatusCheck } from './statusCheck';
-export { default as CorsCheck } from './corsCheck';
-export { default as FontCheck } from './fontCheck';
-export * from './metaBoxes';
+
+/**
+ * External dependencies
+ */
+import { StoryContext } from '@googleforcreators/story-editor';
+
+/**
+ * Internal dependencies
+ */
+import PostReviewDialog from '..';
+
+export default {
+  title: 'Stories Editor/Components/Dialog/Post-Review',
+  component: PostReviewDialog,
+};
+
+const storyContext = {
+  state: {
+    meta: {
+      isFreshlyPublished: true,
+    },
+  },
+};
+
+export const _default = () => {
+  return (
+    <StoryContext.Provider value={storyContext}>
+      <PostReviewDialog />
+    </StoryContext.Provider>
+  );
+};

--- a/packages/wp-story-editor/src/components/postReviewDialog/test/postReviewDialog.js
+++ b/packages/wp-story-editor/src/components/postReviewDialog/test/postReviewDialog.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import {
+  fireEvent,
+  screen,
+  waitForElementToBeRemoved,
+} from '@testing-library/react';
+import { setAppElement } from '@googleforcreators/design-system';
+import { StoryContext } from '@googleforcreators/story-editor';
+import { renderWithTheme } from '@googleforcreators/test-utils';
+
+/**
+ * Internal dependencies
+ */
+import PostReviewDialog from '..';
+
+function setupButtons({ meta: extraMetaProps } = {}) {
+  const storyContextValue = {
+    state: {
+      capabilities: {
+        hasPublishAction: false,
+      },
+      meta: { isSaving: false, isFreshlyPending: false, ...extraMetaProps },
+      story: {
+        status: 'draft',
+        storyId: 123,
+        date: null,
+        editLink: 'http://localhost/wp-admin/post.php?post=123&action=edit',
+      },
+    },
+    actions: { saveStory: jest.fn(), autoSave: jest.fn() },
+  };
+
+  renderWithTheme(
+    <StoryContext.Provider value={storyContextValue}>
+      <PostReviewDialog />
+    </StoryContext.Provider>
+  );
+}
+
+describe('buttons', () => {
+  let modalWrapper;
+
+  beforeAll(() => {
+    modalWrapper = document.createElement('aside');
+    document.documentElement.appendChild(modalWrapper);
+    setAppElement(modalWrapper);
+  });
+
+  afterAll(() => {
+    document.documentElement.removeChild(modalWrapper);
+  });
+
+  it('should display post-review dialog if recently published and in review', async () => {
+    setupButtons({ meta: { isFreshlyPending: true } });
+
+    const dismissButton = screen.getByRole('button', { name: 'Dismiss' });
+    expect(dismissButton).toBeInTheDocument();
+    fireEvent.click(dismissButton);
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByRole('button', { name: 'Dismiss' })
+    );
+  });
+});

--- a/packages/wp-story-editor/src/index.js
+++ b/packages/wp-story-editor/src/index.js
@@ -50,6 +50,7 @@ import '@wordpress/dom-ready'; // Just imported here so it's part of the bundle.
 import {
   Layout,
   PostPublishDialog,
+  PostReviewDialog,
   StatusCheck,
   CorsCheck,
   FontCheck,
@@ -103,6 +104,7 @@ window.webStories.initializeStoryEditor = (id, config, initialEdits) => {
         <GlobalStyle />
         <Layout />
         <PostPublishDialog />
+        <PostReviewDialog />
         <StatusCheck />
         <CorsCheck />
         <FontCheck />


### PR DESCRIPTION
## Context

The purpose of this PR is to ensure that Contributors who do not have access to Publish new Stories can get affirmative feedback when their Story has been submitted for review (known as Pending in WP status).

## Summary

This PR does the following:

- Adds `isFreshlyPending` as a hook for future use within the Editor repo package
- Adds a confirmation modal specific to contributor workflow that confirms a Story has been submitted for review.

## Relevant Technical Choices

There was a hook that helped surface whether a story was freshly published, but in this case, we needed something that included the `pending` status that a Story goes into when submitted for review.

## To-do

No additional follow up needed.

## User-facing changes

Before: No visible feedback after submitting a story for review.
After:
![Screen Shot 2022-04-27 at 1 52 23 PM](https://user-images.githubusercontent.com/7110244/165588983-98618b9f-d057-4e18-b0c9-f33f2eab51fe.png)


## Testing Instructions

This PR can be tested by following these steps:

1. Log into WordPress in a Contributor role
2. Create a new or edit an existing Story
3. Make a change and/or save the draft by hitting Submit for Review
4. You should see the modal above the first time you attempt to submit for review.

## Reviews

### Does this PR have a security-related impact?

No.

### Does this PR change what data or activity we track or use?

No.

### Does this PR have a legal-related impact?

No.

## Checklist

<!-- Check these after PR creation -->

- [X] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [X] I have tested this code to the best of my abilities
- [X] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [X] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [X] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [X] I have added documentation where necessary
- [X] I have added a matching `Type: XYZ` label to the PR

---

Fixes #10851
