### PR TITLE
Layer grouping

### DIFF
--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -356,6 +356,17 @@ class Experiments extends Service_Base implements HasRequirements {
 				'group'       => 'editor',
 				'default'     => true,
 			],
+			/**
+			 * Author: @merapi
+			 * Issue: #9244
+			 * Creation date: 2022-05-04
+			 */
+			[
+				'name'        => 'layerGrouping',
+				'label'       => __( 'Layer grouping', 'web-stories' ),
+				'description' => __( 'Enable layer grouping', 'web-stories' ),
+				'group'       => 'editor',
+			],
 		];
 	}
 

--- a/packages/elements/src/types.js
+++ b/packages/elements/src/types.js
@@ -82,6 +82,7 @@ StoryPropTypes.flip = PropTypes.shape({
 
 const StoryElementPropTypes = {
   id: PropTypes.string.isRequired,
+  groupId: PropTypes.string,
   type: PropTypes.string.isRequired,
   x: PropTypes.number.isRequired,
   y: PropTypes.number.isRequired,

--- a/packages/story-editor/src/app/canvas/canvasProvider.js
+++ b/packages/story-editor/src/app/canvas/canvasProvider.js
@@ -129,9 +129,12 @@ function CanvasProvider({ children }) {
       }
       lastSelectedElementId.current = elId;
       if (evt.shiftKey) {
-        toggleElementInSelection({ elementId: elId });
+        toggleElementInSelection({ elementId: elId, withLinked: !evt.altKey });
       } else {
-        setSelectedElementsById({ elementIds: [elId] });
+        setSelectedElementsById({
+          elementIds: [elId],
+          withLinked: !evt.altKey,
+        });
       }
       evt.currentTarget.focus({ preventScroll: true });
       if (backgroundElementId !== elId) {

--- a/packages/story-editor/src/app/rightClickMenu/constants.js
+++ b/packages/story-editor/src/app/rightClickMenu/constants.js
@@ -59,6 +59,9 @@ export const RIGHT_CLICK_MENU_LABELS = {
   DUPLICATE_PAGE: __('Duplicate Page', 'web-stories'),
   DUPLICATE_ELEMENTS: (numElements = 1) =>
     _n('Duplicate Element', 'Duplicate Elements', numElements, 'web-stories'),
+  GROUP_LAYERS: __('Group Layers', 'web-stories'),
+  UNGROUP_LAYERS: __('Ungroup Layers', 'web-stories'),
+  UNGROUP_LAYER: __('Remove from Group', 'web-stories'),
   LOCK_UNLOCK: __('Lock/Unlock', 'web-stories'),
   PASTE_IMAGE_STYLES: __('Paste Image Styles', 'web-stories'),
   PASTE_SHAPE_STYLES: __('Paste Shape Styles', 'web-stories'),

--- a/packages/story-editor/src/app/rightClickMenu/hooks/useElementActions.js
+++ b/packages/story-editor/src/app/rightClickMenu/hooks/useElementActions.js
@@ -20,6 +20,8 @@ import { useSnackbar } from '@googleforcreators/design-system';
 import { __ } from '@googleforcreators/i18n';
 import { useCallback, useRef } from '@googleforcreators/react';
 import { trackEvent } from '@googleforcreators/tracking';
+import { v4 as uuidv4 } from 'uuid';
+
 /**
  * Internal dependencies
  */
@@ -90,6 +92,43 @@ const useElementActions = () => {
       elements: selectedElements.map((element) => element.type),
     });
   }, [duplicateElementsById, selectedElements, showSnackbar]);
+
+  const handleGroupSelectedElements = useCallback(() => {
+    if (!selectedElements.length) {
+      return;
+    }
+
+    const groupId = uuidv4();
+    updateElementsById({
+      elementIds: selectedElements.map(({ id }) => id),
+      properties: (currentProperties) =>
+        updateProperties(
+          currentProperties,
+          {
+            groupId,
+          },
+          /* commitValues */ true
+        ),
+    });
+  }, [selectedElements, updateElementsById]);
+
+  const handleUngroupSelectedElements = useCallback(() => {
+    if (!selectedElements.length) {
+      return;
+    }
+
+    updateElementsById({
+      elementIds: selectedElements.map(({ id }) => id),
+      properties: (currentProperties) =>
+        updateProperties(
+          currentProperties,
+          {
+            groupId: null,
+          },
+          /* commitValues */ true
+        ),
+    });
+  }, [selectedElements, updateElementsById]);
 
   /**
    * Set element as the element being 'edited'.
@@ -204,6 +243,8 @@ const useElementActions = () => {
 
   return {
     handleDuplicateSelectedElements,
+    handleGroupSelectedElements,
+    handleUngroupSelectedElements,
     handleOpenScaleAndCrop,
     handleSetPageBackground,
     handleRemovePageBackground,

--- a/packages/story-editor/src/app/rightClickMenu/items/index.js
+++ b/packages/story-editor/src/app/rightClickMenu/items/index.js
@@ -15,3 +15,4 @@
  */
 
 export { default as LayerLock } from './layerLock';
+export { default as LayerUngroup } from './layerUngroup';

--- a/packages/story-editor/src/app/rightClickMenu/items/layerUngroup.js
+++ b/packages/story-editor/src/app/rightClickMenu/items/layerUngroup.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { ContextMenuComponents } from '@googleforcreators/design-system';
+import { useCallback } from '@googleforcreators/react';
+import { useFeature } from 'flagged';
+
+/**
+ * Internal dependencies
+ */
+import { RIGHT_CLICK_MENU_LABELS } from '../constants';
+import { useStory } from '../..';
+
+function LayerUngroup() {
+  const { updateSelectedElements, selectedElements } = useStory(
+    ({ state, actions }) => ({
+      updateSelectedElements: actions.updateSelectedElements,
+      selectedElements: state.selectedElements,
+    })
+  );
+  const handleLayerUngroup = useCallback(
+    () =>
+      updateSelectedElements({
+        properties: (oldElement) => ({
+          ...oldElement,
+          groupId: null,
+        }),
+      }),
+    [updateSelectedElements]
+  );
+
+  const isLayerGroupingEnabled = useFeature('layerGrouping');
+  const isLayerInGroup = selectedElements.some((el) => el.groupId);
+
+  if (!isLayerGroupingEnabled || !isLayerInGroup) {
+    return null;
+  }
+
+  return (
+    <ContextMenuComponents.MenuButton onClick={handleLayerUngroup}>
+      {RIGHT_CLICK_MENU_LABELS.UNGROUP_LAYER}
+    </ContextMenuComponents.MenuButton>
+  );
+}
+
+export default LayerUngroup;

--- a/packages/story-editor/src/app/rightClickMenu/menus/foregroundMediaMenu.js
+++ b/packages/story-editor/src/app/rightClickMenu/menus/foregroundMediaMenu.js
@@ -39,7 +39,7 @@ import { useStory, useLocalMedia } from '../..';
 import useVideoTrim from '../../../components/videoTrim/useVideoTrim';
 import useRightClickMenu from '../useRightClickMenu';
 import useLayerSelect from '../useLayerSelect';
-import { LayerLock } from '../items';
+import { LayerLock, LayerUngroup } from '../items';
 import {
   DEFAULT_DISPLACEMENT,
   MenuPropType,
@@ -183,6 +183,7 @@ function ForegroundMediaMenu({ parentMenuRef }) {
       </ContextMenuComponents.MenuButton>
 
       <LayerLock />
+      <LayerUngroup />
 
       <ContextMenuComponents.MenuSeparator />
 

--- a/packages/story-editor/src/app/rightClickMenu/menus/multipleElementsMenu.js
+++ b/packages/story-editor/src/app/rightClickMenu/menus/multipleElementsMenu.js
@@ -18,19 +18,50 @@
  * External dependencies
  */
 import { ContextMenuComponents } from '@googleforcreators/design-system';
+import { useFeature } from 'flagged';
+
 /**
  * Internal dependencies
  */
 import { RIGHT_CLICK_MENU_LABELS } from '../constants';
 import { useElementActions } from '../hooks';
+import { useStory } from '../..';
 
 function MultipleElementsMenu() {
-  const { handleDuplicateSelectedElements } = useElementActions();
+  const {
+    handleDuplicateSelectedElements,
+    handleGroupSelectedElements,
+    handleUngroupSelectedElements,
+  } = useElementActions();
+  const isLayerGroupingEnabled = useFeature('layerGrouping');
+  const { selectedElements } = useStory(({ state }) => ({
+    selectedElements: state.selectedElements,
+  }));
+  const isGroupSelected = selectedElements.some((el) => el.groupId);
+  const isOnlyGroupSelected = selectedElements.every(
+    (el) => el.groupId && el.groupId === selectedElements[0].groupId
+  );
 
   return (
-    <ContextMenuComponents.MenuButton onClick={handleDuplicateSelectedElements}>
-      {RIGHT_CLICK_MENU_LABELS.DUPLICATE_ELEMENTS(2)}
-    </ContextMenuComponents.MenuButton>
+    <>
+      <ContextMenuComponents.MenuButton
+        onClick={handleDuplicateSelectedElements}
+      >
+        {RIGHT_CLICK_MENU_LABELS.DUPLICATE_ELEMENTS(2)}
+      </ContextMenuComponents.MenuButton>
+      {isLayerGroupingEnabled && !isOnlyGroupSelected && (
+        <ContextMenuComponents.MenuButton onClick={handleGroupSelectedElements}>
+          {RIGHT_CLICK_MENU_LABELS.GROUP_LAYERS}
+        </ContextMenuComponents.MenuButton>
+      )}
+      {isLayerGroupingEnabled && isGroupSelected && (
+        <ContextMenuComponents.MenuButton
+          onClick={handleUngroupSelectedElements}
+        >
+          {RIGHT_CLICK_MENU_LABELS.UNGROUP_LAYERS}
+        </ContextMenuComponents.MenuButton>
+      )}
+    </>
   );
 }
 

--- a/packages/story-editor/src/app/rightClickMenu/menus/shapeMenu.js
+++ b/packages/story-editor/src/app/rightClickMenu/menus/shapeMenu.js
@@ -37,7 +37,7 @@ import {
   usePresetActions,
 } from '../hooks';
 import useLayerSelect from '../useLayerSelect';
-import { LayerLock } from '../items';
+import { LayerLock, LayerUngroup } from '../items';
 import { useStory } from '../..';
 import useRightClickMenu from '../useRightClickMenu';
 import {
@@ -157,6 +157,7 @@ function ShapeMenu({ parentMenuRef }) {
       </ContextMenuComponents.MenuButton>
 
       <LayerLock />
+      <LayerUngroup />
 
       <ContextMenuComponents.MenuSeparator />
 

--- a/packages/story-editor/src/app/rightClickMenu/menus/stickerMenu.js
+++ b/packages/story-editor/src/app/rightClickMenu/menus/stickerMenu.js
@@ -32,7 +32,7 @@ import {
 } from '../constants';
 import { useElementActions, useLayerActions } from '../hooks';
 import useLayerSelect from '../useLayerSelect';
-import { LayerLock } from '../items';
+import { LayerLock, LayerUngroup } from '../items';
 import useRightClickMenu from '../useRightClickMenu';
 import {
   DEFAULT_DISPLACEMENT,
@@ -145,6 +145,7 @@ function StickerMenu({ parentMenuRef }) {
       </ContextMenuComponents.MenuButton>
 
       <LayerLock />
+      <LayerUngroup />
     </>
   );
 }

--- a/packages/story-editor/src/app/rightClickMenu/menus/textMenu.js
+++ b/packages/story-editor/src/app/rightClickMenu/menus/textMenu.js
@@ -37,7 +37,7 @@ import {
   usePresetActions,
 } from '../hooks';
 import useLayerSelect from '../useLayerSelect';
-import { LayerLock } from '../items';
+import { LayerLock, LayerUngroup } from '../items';
 import { useStory } from '../..';
 import useRightClickMenu from '../useRightClickMenu';
 import {
@@ -157,6 +157,7 @@ function TextMenu({ parentMenuRef }) {
       </ContextMenuComponents.MenuButton>
 
       <LayerLock />
+      <LayerUngroup />
 
       <ContextMenuComponents.MenuSeparator />
 

--- a/packages/story-editor/src/app/story/useStoryReducer/actions.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/actions.js
@@ -169,8 +169,11 @@ const arrangeSelection =
 
 const setSelectedElementsById =
   (dispatch) =>
-  ({ elementIds }) =>
-    dispatch({ type: types.SET_SELECTED_ELEMENTS, payload: { elementIds } });
+  ({ elementIds, withLinked }) =>
+    dispatch({
+      type: types.SET_SELECTED_ELEMENTS,
+      payload: { elementIds, withLinked },
+    });
 
 const clearSelection = (dispatch) => () =>
   dispatch({ type: types.SET_SELECTED_ELEMENTS, payload: { elementIds: [] } });
@@ -187,10 +190,10 @@ const removeElementFromSelection =
 
 const toggleElementInSelection =
   (dispatch) =>
-  ({ elementId }) =>
+  ({ elementId, withLinked }) =>
     dispatch({
       type: types.TOGGLE_ELEMENT_IN_SELECTION,
-      payload: { elementId },
+      payload: { elementId, withLinked },
     });
 
 const updateStory =

--- a/packages/story-editor/src/app/story/useStoryReducer/reducers/setSelectedElements.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/reducers/setSelectedElements.js
@@ -40,9 +40,10 @@ import { intersect } from './utils';
  * @param {Object} state Current state
  * @param {Object} payload Action payload
  * @param {Array.<string>} payload.elementIds Object with properties of new page
+ * @param payload.withLinked
  * @return {Object} New state
  */
-function setSelectedElements(state, { elementIds }) {
+function setSelectedElements(state, { elementIds, withLinked = false }) {
   const newElementIds =
     typeof elementIds === 'function' ? elementIds(state.selection) : elementIds;
 
@@ -50,7 +51,22 @@ function setSelectedElements(state, { elementIds }) {
     return state;
   }
 
-  const uniqueElementIds = [...new Set(newElementIds)];
+  const currentPage = state.pages.find(({ id }) => id === state.current);
+  let allIds = newElementIds;
+
+  if (withLinked) {
+    const elements = currentPage.elements.filter(({ id }) =>
+      newElementIds.includes(id)
+    );
+    const groupIds = elements.map(({ groupId }) => groupId).filter(Boolean);
+    const elementsFromGroups = currentPage.elements.filter(({ groupId }) =>
+      groupIds.includes(groupId)
+    );
+    const elementsIdsFromGroups = elementsFromGroups.map(({ id }) => id);
+    allIds = allIds.concat(elementsIdsFromGroups);
+  }
+
+  const uniqueElementIds = [...new Set(allIds)];
 
   // They can only be similar if they have the same length
   if (state.selection.length === uniqueElementIds.length) {
@@ -65,7 +81,6 @@ function setSelectedElements(state, { elementIds }) {
 
   // If it's a multi-selection, filter out the background element, locked elements,
   // and video placeholders.
-  const currentPage = state.pages.find(({ id }) => id === state.current);
   const byId = (id) => currentPage.elements.find(({ id: i }) => i === id);
   const isNotBackgroundElement = (id) => currentPage.elements[0].id !== id;
   const isNotLockedElement = (id) => !byId(id).isLocked;

--- a/packages/story-editor/src/app/story/useStoryReducer/reducers/toggleLayer.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/reducers/toggleLayer.js
@@ -19,16 +19,20 @@
 import toggleElement from './toggleElement';
 import setSelectedElements from './setSelectedElements';
 
-function toggleLayer(state, { elementId, metaKey, shiftKey }) {
+function toggleLayer(
+  state,
+  { elementId, metaKey, shiftKey, withLinked = false }
+) {
   // Meta pressed. Toggle this layer in the selection.
   if (metaKey) {
-    return toggleElement(state, { elementId });
+    return toggleElement(state, { elementId, withLinked });
   }
 
   // No special key pressed - just selected this layer and nothing else.
   if (state.selection.length <= 0 || !shiftKey) {
     return setSelectedElements(state, {
       elementIds: [elementId],
+      withLinked,
     });
   }
 
@@ -49,6 +53,7 @@ function toggleLayer(state, { elementId, metaKey, shiftKey }) {
 
   return setSelectedElements(state, {
     elementIds,
+    withLinked,
   });
 }
 

--- a/packages/story-editor/src/components/canvas/test/frameElement.js
+++ b/packages/story-editor/src/components/canvas/test/frameElement.js
@@ -72,7 +72,10 @@ describe('FrameElement selection', () => {
     // Fire a mousedown event.
     const wrapper = container.querySelector('[data-element-id="1"]');
     fireEvent.mouseDown(wrapper);
-    expect(setSelectedElementsById).toHaveBeenCalledWith({ elementIds: ['1'] });
+    expect(setSelectedElementsById).toHaveBeenCalledWith({
+      elementIds: ['1'],
+      withLinked: true,
+    });
   });
 
   it('should select unselected element on focus', () => {
@@ -98,7 +101,10 @@ describe('FrameElement selection', () => {
     // Fire a mousedown event.
     const wrapper = container.querySelector('[data-element-id="1"]');
     fireEvent.focus(wrapper);
-    expect(setSelectedElementsById).toHaveBeenCalledWith({ elementIds: ['1'] });
+    expect(setSelectedElementsById).toHaveBeenCalledWith({
+      elementIds: ['1'],
+      withLinked: true,
+    });
   });
 
   it('should not select on mousedown if already selected', () => {
@@ -156,7 +162,10 @@ describe('FrameElement selection', () => {
     // Fire a mousedown event with shift.
     const wrapper = container.querySelector('[data-element-id="1"]');
     fireEvent.mouseDown(wrapper, { shiftKey: true });
-    expect(toggleElementInSelection).toHaveBeenCalledWith({ elementId: '1' });
+    expect(toggleElementInSelection).toHaveBeenCalledWith({
+      elementId: '1',
+      withLinked: true,
+    });
   });
 });
 

--- a/packages/story-editor/src/components/panels/design/layer/layer.js
+++ b/packages/story-editor/src/components/panels/design/layer/layer.js
@@ -318,7 +318,9 @@ function Layer({ element }) {
   const LockIcon = element.isLocked ? Icons.LockClosed : Icons.LockOpen;
 
   const layerName = getLayerName(element);
-
+  const layerGroupName = element.groupId
+    ? `${__('Group', 'web-stories')} ${element.groupId.substr(-3)}: `
+    : null;
   return (
     <LayerContainer>
       <LayerButton
@@ -336,6 +338,7 @@ function Layer({ element }) {
         </LayerIconWrapper>
         <LayerDescription>
           <LayerContentContainer>
+            <LayerText>{layerGroupName}</LayerText>
             <LayerText>{layerName}</LayerText>
           </LayerContentContainer>
           {element.isBackground && (

--- a/packages/story-editor/src/components/panels/design/layer/useLayerSelection.js
+++ b/packages/story-editor/src/components/panels/design/layer/useLayerSelection.js
@@ -42,6 +42,7 @@ function useLayerSelection(layer) {
         elementId,
         metaKey: evt.metaKey,
         shiftKey: evt.shiftKey,
+        withLinked: true,
       });
 
       // In any case, revert focus to selected element(s)


### PR DESCRIPTION
## Summary

This PR gives you the option to group layers which enables you to (main goals of layer grouping):
- select and move multiple elements at once
- align a group of elements as one element (instead of aligning each of them individually)

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

- [ ] Tests (will change in the future so there is little point to do them now?)
- [ ] In V2:
- [ ] Agree on/implement default group naming: "Group 1 Copy" style or "Group 2" (best effort to increment the number)

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9244
