### PR TITLE
Design Panel: Document update logic

### DIFF
--- a/docs/design-panel-push-update-flow.md
+++ b/docs/design-panel-push-update-flow.md
@@ -21,7 +21,7 @@ flowchart TB
                 subgraph SUBMIT [ ]
                     direction TB
                     E[onSubmit] --> F[[internalSubmit]]
-                    F --> G[[apply presubmit element mutations on elementUpdates]]
+                    F --> G[[apply presubmit element mutations on all staged elementUpdates]]
                     G --> H[[onSetProperties]]
                     H --> I[updateElementsById]
                 end
@@ -48,8 +48,5 @@ flowchart TB
        design_panels .-> story_reducer
 ```
 ## Current Usage
-Most of the time, we are passing `submit` as `true` for the `pushUpdate(update, submit)` or `pushUpdateForObject(...)` callback args. The current setup is mainly used so the presubmit hooks that can alter an update to element before sending the element updates to the story reducer. Most precommit hooks do things like clamp a value within a certain range, or resize the text element depending on updates to text properties.
-
-## Suggested Path Moving Forward
-If we were to do any architectural shifts here, I think we could eliminate a significant level of abstraction. Right now we have an abstract design panel, and we pass an the current selected elements to `getDesignPanelsForSelection(selection)` to get the panels, we then pass each panel `selectedElements, selectedElementAnimations, etc`. Basically every panel needs access to every piece of story state any other panel might necessitate with this setup. Even if the panel only needs to know a specific derived piece of data from the selection.
+Most of the time, we are passing `submit` as `true` for the `pushUpdate(update, submit)` or `pushUpdateForObject(...)` callback args. The current setup is mainly used so the presubmit hooks can alter an update to an element before sending the element updates to the story reducer. Most precommit hooks do things like clamp a value within a certain range, or resize the text element depending on updates to text properties.
 

--- a/docs/design-panel-push-update-flow.md
+++ b/docs/design-panel-push-update-flow.md
@@ -1,5 +1,7 @@
 # Design Panel Element Update Data Flow
+
 Below is a rough outline of the data flow following input change updates in the design panel to how they update the element in the top level story provider. Most of this code can be found in `packages/story-editor/src/components/style/designPanel.js` :
+
 ```mermaid
 flowchart TB
     subgraph story_reducer[story reducer]
@@ -47,6 +49,8 @@ flowchart TB
        submit_event .-> submit_handler
        design_panels .-> story_reducer
 ```
+
 ## Current Usage
+
 Most of the time, we are passing `submit` as `true` for the `pushUpdate(update, submit)` or `pushUpdateForObject(...)` callback args. The current setup is mainly used so the presubmit hooks can alter an update to an element before sending the element updates to the story reducer. Most precommit hooks do things like clamp a value within a certain range, or resize the text element depending on updates to text properties.
 

--- a/packages/story-editor/src/components/style/designPanel.js
+++ b/packages/story-editor/src/components/style/designPanel.js
@@ -43,12 +43,8 @@ const AutoSubmitButton = styled.input.attrs({ type: 'submit' })`
   display: none;
 `;
 
-/**
- * NOTE: data flow for updating elements with pushUpdate documented in `docs/design-panel-push-update-flow.md`
- *
- * @param {any} props Design Panel Props
- * @return {any} React Element
- */
+// NOTE: data flow for updating elements with pushUpdate documented in `docs/design-panel-push-update-flow.md`
+
 function DesignPanel({
   panelType,
   selectedElements,

--- a/packages/story-editor/src/components/style/designPanel.js
+++ b/packages/story-editor/src/components/style/designPanel.js
@@ -43,6 +43,12 @@ const AutoSubmitButton = styled.input.attrs({ type: 'submit' })`
   display: none;
 `;
 
+/**
+ * NOTE: data flow for updating elements with pushUpdate documented in `docs/design-panel-push-update-flow.md`
+ *
+ * @param {any} props Design Panel Props
+ * @return {any} React Element
+ */
 function DesignPanel({
   panelType,
   selectedElements,


### PR DESCRIPTION
## Context
Was doing some design panel performance exploration on #11390 and ran into some blockers with the current architecture. Didn't want to change any of the update logic architecture while moving off, so decided to document it. I know prometheus mentioned something similar here #6690 so hopefully this helps with that ticket.
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Added this chart to our docs. Hopefully helps others evaluate and assess the current system as we make changes here in the future:

```mermaid
flowchart TB
    subgraph story_reducer[story reducer]
        direction LR
        subgraph ACTION
            direction TB
            L[UPDATE_ELEMENTS] --> M[Story Updated]
        end
    end
    subgraph design_panels[StylePanels]
        subgraph design_panel_state[State]
            direction TB
            design_panel_state_el_updates((elementUpdates Array))
            design_panel_state_el_handlers((presubmitHandlers Array))
        end
        subgraph design_panel_callbacks[Callbacks]
            direction LR
            subgraph submit_handler[submit handler]
                subgraph SUBMIT [ ]
                    direction TB
                    E[onSubmit] --> F[[internalSubmit]]
                    F --> G[[apply presubmit element mutations on all staged elementUpdates]]
                    G --> H[[onSetProperties]]
                    H --> I[updateElementsById]
                end
            end
            subgraph submit_event[submit event]
                subgraph DOM EVENT FIRED [ ]
                    direction TB
                    K{Dispatch Event - 'submit'}
                end
            end
            subgraph push_update[pushUpdate called]
                subgraph INPUT ONCHANGE[ ]
                    direction TB
                    A[pushUpdate or pushUpdateForObject] --> |update, submit| B[[setElementUpdates - Add update to update queue]]
                    B -->|submit == false| C[elementUpdates - locally stored updates]
                    B --> |submit == true| D[submit]
                    D --> J[[setTimout to dispatch 'submit' event]]
                end
            end
        end
    end
       push_update .-> submit_event
       submit_event .-> submit_handler
       design_panels .-> story_reducer
```

## Relevant Technical Choices


## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
NA
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
NA
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Partially addresses #6690
Partially addresses #10072
