### PR TITLE
Performance: Design Panel Perf Exploration

### DIFF
--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -28,6 +28,7 @@ export { default as usePrevious } from './usePrevious';
 export { default as useReduction } from './useReduction';
 export { default as useResizeEffect } from './useResizeEffect';
 export { default as renderToStaticMarkup } from './renderToStaticMarkup';
+export { default as useStableCallback } from './useStableCallback';
 export { default as useUnmount } from './useUnmount';
 export { default as useWhyDidYouUpdate } from './useWhyDidYouUpdate';
 export { default as useInitializedValue } from './useInitializedValue';

--- a/packages/react/src/useStableCallback.js
+++ b/packages/react/src/useStableCallback.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { useCallback, useRef } from 'react';
+
+/**
+ * Takes a callback and returns an up to date version of the supplied
+ * callback, but maintains a stable reference.
+ *
+ * i.e.
+ * ```js
+ * const stableCallback = useStableCallback(callback);
+ * ```
+ *
+ * @param {Function} callback a callback composed in your components scope
+ * @return {Function} callback with a stable reference
+ */
+function useStableCallback(callback) {
+  const ref = useRef();
+  ref.current = callback;
+  return useCallback((...args) => ref.current(...args), []);
+}
+
+export default useStableCallback;

--- a/packages/story-editor/src/components/panels/design/alignment/alignment.js
+++ b/packages/story-editor/src/components/panels/design/alignment/alignment.js
@@ -17,7 +17,13 @@
 /**
  * External dependencies
  */
-import { useRef, useCallback, useState } from '@googleforcreators/react';
+import {
+  useRef,
+  useCallback,
+  useState,
+  memo,
+  forwardRef,
+} from '@googleforcreators/react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { __ } from '@googleforcreators/i18n';
@@ -126,96 +132,19 @@ function ElementAlignmentPanel({ selectedElements, pushUpdate }) {
   ]);
 
   return (
-    <StyledPanel
-      name="alignment"
-      canCollapse={false}
-      ariaLabel={__('Alignment', 'web-stories')}
-    >
-      <ElementRow ref={ref}>
-        <Tooltip title={__('Distribute horizontally', 'web-stories')}>
-          <AlignmentButton
-            disabled={!isDistributionEnabled}
-            onClick={handleHorizontalDistribution}
-            aria-label={__('Distribute horizontally', 'web-stories')}
-            id={alignmentButtonIds[0]}
-            onFocus={() => setCurrentButton(alignmentButtonIds[0])}
-          >
-            <Icons.DistributeHorizontal />
-          </AlignmentButton>
-        </Tooltip>
-        <Tooltip title={__('Distribute vertically', 'web-stories')}>
-          <AlignmentButton
-            disabled={!isDistributionEnabled}
-            onClick={handleVerticalDistribution}
-            aria-label={__('Distribute vertically', 'web-stories')}
-            id={alignmentButtonIds[1]}
-            onFocus={() => setCurrentButton(alignmentButtonIds[1])}
-          >
-            <Icons.DistributeVertical />
-          </AlignmentButton>
-        </Tooltip>
-        <Tooltip title={__('Align left', 'web-stories')}>
-          <AlignmentButton
-            onClick={handleAlignLeft}
-            aria-label={__('Align left', 'web-stories')}
-            id={alignmentButtonIds[2]}
-            onFocus={() => setCurrentButton(alignmentButtonIds[2])}
-          >
-            <Icons.AlignLeft />
-          </AlignmentButton>
-        </Tooltip>
-        <Tooltip title={__('Align center', 'web-stories')}>
-          <AlignmentButton
-            onClick={handleAlignCenter}
-            aria-label={__('Align center', 'web-stories')}
-            id={alignmentButtonIds[3]}
-            onFocus={() => setCurrentButton(alignmentButtonIds[3])}
-          >
-            <Icons.AlignCenter />
-          </AlignmentButton>
-        </Tooltip>
-        <Tooltip title={__('Align right', 'web-stories')}>
-          <AlignmentButton
-            onClick={handleAlignRight}
-            aria-label={__('Align right', 'web-stories')}
-            id={alignmentButtonIds[4]}
-            onFocus={() => setCurrentButton(alignmentButtonIds[4])}
-          >
-            <Icons.AlignRight />
-          </AlignmentButton>
-        </Tooltip>
-        <Tooltip title={__('Align top', 'web-stories')}>
-          <AlignmentButton
-            onClick={handleAlignTop}
-            aria-label={__('Align top', 'web-stories')}
-            id={alignmentButtonIds[5]}
-            onFocus={() => setCurrentButton(alignmentButtonIds[5])}
-          >
-            <Icons.AlignTop />
-          </AlignmentButton>
-        </Tooltip>
-        <Tooltip title={__('Align vertical center', 'web-stories')}>
-          <AlignmentButton
-            onClick={handleAlignMiddle}
-            aria-label={__('Align vertical center', 'web-stories')}
-            id={alignmentButtonIds[6]}
-            onFocus={() => setCurrentButton(alignmentButtonIds[6])}
-          >
-            <Icons.AlignMiddle />
-          </AlignmentButton>
-        </Tooltip>
-        <Tooltip title={__('Align bottom', 'web-stories')}>
-          <AlignmentButton
-            onClick={handleAlignBottom}
-            aria-label={__('Align bottom', 'web-stories')}
-            id={alignmentButtonIds[7]}
-            onFocus={() => setCurrentButton(alignmentButtonIds[7])}
-          >
-            <Icons.AlignBottom />
-          </AlignmentButton>
-        </Tooltip>
-      </ElementRow>
-    </StyledPanel>
+    <Controls
+      ref={ref}
+      handleAlignBottom={handleAlignBottom}
+      setCurrentButton={setCurrentButton}
+      handleHorizontalDistribution={handleHorizontalDistribution}
+      isDistributionEnabled={isDistributionEnabled}
+      handleVerticalDistribution={handleVerticalDistribution}
+      handleAlignLeft={handleAlignLeft}
+      handleAlignCenter={handleAlignCenter}
+      handleAlignRight={handleAlignRight}
+      handleAlignTop={handleAlignTop}
+      handleAlignMiddle={handleAlignMiddle}
+    />
   );
 }
 
@@ -225,3 +154,114 @@ ElementAlignmentPanel.propTypes = {
 };
 
 export default ElementAlignmentPanel;
+
+const Controls = memo(
+  forwardRef(function Controls(
+    {
+      handleAlignBottom,
+      setCurrentButton,
+      isDistributionEnabled,
+      handleHorizontalDistribution,
+      handleVerticalDistribution,
+      handleAlignLeft,
+      handleAlignCenter,
+      handleAlignRight,
+      handleAlignTop,
+      handleAlignMiddle,
+    },
+    ref
+  ) {
+    return (
+      <StyledPanel
+        name="alignment"
+        canCollapse={false}
+        ariaLabel={__('Alignment', 'web-stories')}
+      >
+        <ElementRow ref={ref}>
+          <Tooltip title={__('Distribute horizontally', 'web-stories')}>
+            <AlignmentButton
+              disabled={!isDistributionEnabled}
+              onClick={handleHorizontalDistribution}
+              aria-label={__('Distribute horizontally', 'web-stories')}
+              id={alignmentButtonIds[0]}
+              onFocus={() => setCurrentButton(alignmentButtonIds[0])}
+            >
+              <Icons.DistributeHorizontal />
+            </AlignmentButton>
+          </Tooltip>
+          <Tooltip title={__('Distribute vertically', 'web-stories')}>
+            <AlignmentButton
+              disabled={!isDistributionEnabled}
+              onClick={handleVerticalDistribution}
+              aria-label={__('Distribute vertically', 'web-stories')}
+              id={alignmentButtonIds[1]}
+              onFocus={() => setCurrentButton(alignmentButtonIds[1])}
+            >
+              <Icons.DistributeVertical />
+            </AlignmentButton>
+          </Tooltip>
+          <Tooltip title={__('Align left', 'web-stories')}>
+            <AlignmentButton
+              onClick={handleAlignLeft}
+              aria-label={__('Align left', 'web-stories')}
+              id={alignmentButtonIds[2]}
+              onFocus={() => setCurrentButton(alignmentButtonIds[2])}
+            >
+              <Icons.AlignLeft />
+            </AlignmentButton>
+          </Tooltip>
+          <Tooltip title={__('Align center', 'web-stories')}>
+            <AlignmentButton
+              onClick={handleAlignCenter}
+              aria-label={__('Align center', 'web-stories')}
+              id={alignmentButtonIds[3]}
+              onFocus={() => setCurrentButton(alignmentButtonIds[3])}
+            >
+              <Icons.AlignCenter />
+            </AlignmentButton>
+          </Tooltip>
+          <Tooltip title={__('Align right', 'web-stories')}>
+            <AlignmentButton
+              onClick={handleAlignRight}
+              aria-label={__('Align right', 'web-stories')}
+              id={alignmentButtonIds[4]}
+              onFocus={() => setCurrentButton(alignmentButtonIds[4])}
+            >
+              <Icons.AlignRight />
+            </AlignmentButton>
+          </Tooltip>
+          <Tooltip title={__('Align top', 'web-stories')}>
+            <AlignmentButton
+              onClick={handleAlignTop}
+              aria-label={__('Align top', 'web-stories')}
+              id={alignmentButtonIds[5]}
+              onFocus={() => setCurrentButton(alignmentButtonIds[5])}
+            >
+              <Icons.AlignTop />
+            </AlignmentButton>
+          </Tooltip>
+          <Tooltip title={__('Align vertical center', 'web-stories')}>
+            <AlignmentButton
+              onClick={handleAlignMiddle}
+              aria-label={__('Align vertical center', 'web-stories')}
+              id={alignmentButtonIds[6]}
+              onFocus={() => setCurrentButton(alignmentButtonIds[6])}
+            >
+              <Icons.AlignMiddle />
+            </AlignmentButton>
+          </Tooltip>
+          <Tooltip title={__('Align bottom', 'web-stories')}>
+            <AlignmentButton
+              onClick={handleAlignBottom}
+              aria-label={__('Align bottom', 'web-stories')}
+              id={alignmentButtonIds[7]}
+              onFocus={() => setCurrentButton(alignmentButtonIds[7])}
+            >
+              <Icons.AlignBottom />
+            </AlignmentButton>
+          </Tooltip>
+        </ElementRow>
+      </StyledPanel>
+    );
+  })
+);

--- a/packages/story-editor/src/components/panels/design/alignment/useAlignment.js
+++ b/packages/story-editor/src/components/panels/design/alignment/useAlignment.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { useMemo } from '@googleforcreators/react';
+import { useMemo, useStableCallback } from '@googleforcreators/react';
 import {
   PAGE_WIDTH,
   PAGE_HEIGHT,
@@ -84,14 +84,14 @@ function useAlignment({ selectedElements, updateElements, isFloatingMenu }) {
   const boundRect =
     selectedElements.length === 1 ? PAGE_RECT : getBoundRect(selectedElements);
 
-  const handleTrackEvent = (direction) => {
+  const handleTrackEvent = useStableCallback((direction) => {
     trackEvent(isFloatingMenu ? 'floating_menu' : 'design_panel', {
       name: `set_alignment_${direction}`,
       element: 'multiple',
     });
-  };
+  });
 
-  const handleAlign = (direction) => {
+  const handleAlign = useStableCallback((direction) => {
     handleTrackEvent(direction);
     updateElements((properties) => {
       const { id } = properties;
@@ -123,9 +123,9 @@ function useAlignment({ selectedElements, updateElements, isFloatingMenu }) {
             : boundRect.endY - height - offset,
       };
     });
-  };
+  });
 
-  const handleAlignCenter = () => {
+  const handleAlignCenter = useStableCallback(() => {
     handleTrackEvent('center');
     const centerX = (boundRect.endX + boundRect.startX) / 2;
     updateElements((properties) => {
@@ -134,9 +134,9 @@ function useAlignment({ selectedElements, updateElements, isFloatingMenu }) {
         x: centerX - width / 2,
       };
     });
-  };
+  });
 
-  const handleAlignMiddle = () => {
+  const handleAlignMiddle = useStableCallback(() => {
     handleTrackEvent('middle');
     const centerY = (boundRect.endY + boundRect.startY) / 2;
     updateElements((properties) => {
@@ -145,9 +145,9 @@ function useAlignment({ selectedElements, updateElements, isFloatingMenu }) {
         y: centerY - height / 2,
       };
     });
-  };
+  });
 
-  const handleHorizontalDistribution = () => {
+  const handleHorizontalDistribution = useStableCallback(() => {
     handleTrackEvent('horizontal_distribution');
     const sortedElementsWithFrame = [...selectedElementsWithFrame];
     sortedElementsWithFrame.sort(
@@ -176,9 +176,9 @@ function useAlignment({ selectedElements, updateElements, isFloatingMenu }) {
       offsetX += frameWidth + commonSpaceWidthPerElement;
     });
     updateElements(({ id }) => updatedX[id]);
-  };
+  });
 
-  const handleVerticalDistribution = () => {
+  const handleVerticalDistribution = useStableCallback(() => {
     handleTrackEvent('vertical_distribution');
     const sortedElementsWithFrame = [...selectedElementsWithFrame];
     sortedElementsWithFrame.sort(
@@ -207,16 +207,16 @@ function useAlignment({ selectedElements, updateElements, isFloatingMenu }) {
       offsetY += frameHeight + commonSpaceHeightPerElement;
     });
     updateElements(({ id }) => updatedY[id]);
-  };
+  });
 
   return {
     isDistributionEnabled,
-    handleAlignLeft: () => handleAlign(ALIGNMENT.LEFT),
+    handleAlignLeft: useStableCallback(() => handleAlign(ALIGNMENT.LEFT)),
     handleAlignCenter,
-    handleAlignRight: () => handleAlign(ALIGNMENT.RIGHT),
-    handleAlignTop: () => handleAlign(ALIGNMENT.TOP),
+    handleAlignRight: useStableCallback(() => handleAlign(ALIGNMENT.RIGHT)),
+    handleAlignTop: useStableCallback(() => handleAlign(ALIGNMENT.TOP)),
     handleAlignMiddle,
-    handleAlignBottom: () => handleAlign(ALIGNMENT.BOTTOM),
+    handleAlignBottom: useStableCallback(() => handleAlign(ALIGNMENT.BOTTOM)),
     handleHorizontalDistribution,
     handleVerticalDistribution,
   };

--- a/packages/story-editor/src/components/panels/design/sizePosition/opacity.js
+++ b/packages/story-editor/src/components/panels/design/sizePosition/opacity.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { useCallback } from '@googleforcreators/react';
+import { useCallback, memo } from '@googleforcreators/react';
 import PropTypes from 'prop-types';
 import { __, _x } from '@googleforcreators/i18n';
 import { Icons, NumericInput } from '@googleforcreators/design-system';
@@ -40,9 +40,11 @@ function defaultOpacity({ opacity }) {
   return typeof opacity !== 'undefined' ? opacity : MIN_MAX.OPACITY.MAX;
 }
 
-function OpacityControls({ selectedElements, pushUpdate }) {
-  const opacity = getCommonValue(selectedElements, defaultOpacity);
+export function getOpacityFromSelectedElements(selectedElements) {
+  return getCommonValue(selectedElements, defaultOpacity);
+}
 
+function OpacityControls({ opacity, pushUpdate }) {
   const handleChange = useCallback(
     (evt, value) => pushUpdate({ opacity: value ?? 100 }, true),
     [pushUpdate]
@@ -65,8 +67,8 @@ function OpacityControls({ selectedElements, pushUpdate }) {
 }
 
 OpacityControls.propTypes = {
-  selectedElements: PropTypes.array.isRequired,
+  opacity: PropTypes.any,
   pushUpdate: PropTypes.func.isRequired,
 };
 
-export default OpacityControls;
+export default memo(OpacityControls);

--- a/packages/story-editor/src/components/panels/design/sizePosition/radius.js
+++ b/packages/story-editor/src/components/panels/design/sizePosition/radius.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useCallback } from '@googleforcreators/react';
+import { useCallback, memo } from '@googleforcreators/react';
 import styled from 'styled-components';
 import { __ } from '@googleforcreators/i18n';
 import { LockToggle, Icons } from '@googleforcreators/design-system';
@@ -28,7 +28,6 @@ import { canSupportMultiBorder } from '@googleforcreators/masks';
  * Internal dependencies
  */
 import { StackableGroup, StackableInput } from '../../../form/stackable';
-import useCommonObjectValue from '../../shared/useCommonObjectValue';
 import { focusStyle } from '../../shared/styles';
 import Tooltip from '../../../tooltip';
 import { MULTIPLE_VALUE, MULTIPLE_DISPLAY_VALUE } from '../../../../constants';
@@ -41,45 +40,11 @@ export const DEFAULT_BORDER_RADIUS = {
   locked: true,
 };
 
-const FlexContainer = styled.div`
-  display: flex;
-`;
+export function getIsBorderSupported(selectedElements) {
+  return selectedElements.every((el) => canSupportMultiBorder(el));
+}
 
-const LockContainer = styled.div`
-  position: relative;
-  display: flex;
-  align-items: center;
-  width: 32px;
-  margin-left: 8px;
-`;
-
-const StyledLockToggle = styled(LockToggle)`
-  ${focusStyle};
-`;
-
-const TopLeft = styled(Icons.Corner)`
-  transform: rotate(90deg);
-`;
-
-const TopRight = styled(Icons.Corner)`
-  transform: rotate(180deg);
-`;
-
-const BottomRight = styled(Icons.Corner)`
-  transform: rotate(270deg);
-`;
-
-function RadiusControls({ selectedElements, pushUpdateForObject }) {
-  const borderRadius = useCommonObjectValue(
-    selectedElements,
-    'borderRadius',
-    DEFAULT_BORDER_RADIUS
-  );
-
-  const allSupportBorder = selectedElements.every((el) =>
-    canSupportMultiBorder(el)
-  );
-
+function RadiusControls({ borderRadius, pushUpdateForObject }) {
   const lockRadius = borderRadius.locked === true;
 
   const handleChange = useCallback(
@@ -126,10 +91,6 @@ function RadiusControls({ selectedElements, pushUpdateForObject }) {
     },
     [pushUpdateForObject, borderRadius]
   );
-
-  if (!allSupportBorder) {
-    return null;
-  }
 
   const firstInputLabel = lockRadius
     ? __('Corner Radius', 'web-stories')
@@ -226,8 +187,36 @@ function RadiusControls({ selectedElements, pushUpdateForObject }) {
 }
 
 RadiusControls.propTypes = {
-  selectedElements: PropTypes.array.isRequired,
+  borderRadius: PropTypes.any,
   pushUpdateForObject: PropTypes.func.isRequired,
 };
 
-export default RadiusControls;
+export default memo(RadiusControls);
+
+const FlexContainer = styled.div`
+  display: flex;
+`;
+
+const LockContainer = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 32px;
+  margin-left: 8px;
+`;
+
+const StyledLockToggle = styled(LockToggle)`
+  ${focusStyle};
+`;
+
+const TopLeft = styled(Icons.Corner)`
+  transform: rotate(90deg);
+`;
+
+const TopRight = styled(Icons.Corner)`
+  transform: rotate(180deg);
+`;
+
+const BottomRight = styled(Icons.Corner)`
+  transform: rotate(270deg);
+`;

--- a/packages/story-editor/src/components/panels/shared/flipControls.js
+++ b/packages/story-editor/src/components/panels/shared/flipControls.js
@@ -20,7 +20,7 @@
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { __ } from '@googleforcreators/i18n';
-import { useCallback } from '@googleforcreators/react';
+import { useCallback, memo } from '@googleforcreators/react';
 import {
   BUTTON_SIZES,
   BUTTON_VARIANTS,
@@ -109,4 +109,4 @@ FlipControls.propTypes = {
   onChange: PropTypes.func.isRequired,
 };
 
-export default FlipControls;
+export default memo(FlipControls);

--- a/packages/story-editor/src/components/style/designPanel.js
+++ b/packages/story-editor/src/components/style/designPanel.js
@@ -24,6 +24,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useStableCallback,
 } from '@googleforcreators/react';
 
 /**
@@ -128,23 +129,20 @@ function DesignPanel({
     });
   }, []);
 
-  const pushUpdate = useCallback(
-    (update, submitArg = false) => {
-      setElementUpdates((prevUpdates) => {
-        const newUpdates = {};
-        selectedElements.forEach((element) => {
-          const prevUpdatedElement = { ...element, ...prevUpdates[element.id] };
-          const newUpdate = updateProperties(prevUpdatedElement, update, false);
-          newUpdates[element.id] = { ...prevUpdates[element.id], ...newUpdate };
-        });
-        return newUpdates;
+  const pushUpdate = useStableCallback((update, submitArg = false) => {
+    setElementUpdates((prevUpdates) => {
+      const newUpdates = {};
+      selectedElements.forEach((element) => {
+        const prevUpdatedElement = { ...element, ...prevUpdates[element.id] };
+        const newUpdate = updateProperties(prevUpdatedElement, update, false);
+        newUpdates[element.id] = { ...prevUpdates[element.id], ...newUpdate };
       });
-      if (submitArg) {
-        submit();
-      }
-    },
-    [selectedElements, submit]
-  );
+      return newUpdates;
+    });
+    if (submitArg) {
+      submit();
+    }
+  });
 
   const pushUpdateForObject = useCallback(
     (propertyName, update, defaultObject, submitArg = false) => {

--- a/packages/story-editor/src/components/style/styleLayout.js
+++ b/packages/story-editor/src/components/style/styleLayout.js
@@ -81,9 +81,9 @@ function StyleLayout() {
     data: { tabs },
   } = useStyle();
 
-  const { selectedElementIds } = useStory(({ state }) => ({
-    selectedElementIds: state.selectedElementIds,
-  }));
+  const hasSelection = useStory(
+    ({ state }) => state.selectedElementIds?.length > 0
+  );
 
   const { highlight, resetHighlight } = useHighlights((state) => ({
     highlight: {
@@ -105,7 +105,7 @@ function StyleLayout() {
     [setTab, resetHighlight]
   );
 
-  if (selectedElementIds.length === 0) {
+  if (!hasSelection) {
     return (
       <NoSelection>
         <Note size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.MEDIUM}>

--- a/packages/story-editor/src/components/style/stylePanes.js
+++ b/packages/story-editor/src/components/style/stylePanes.js
@@ -17,8 +17,8 @@
 /**
  * External dependencies
  */
-import { useCallback } from '@googleforcreators/react';
-import { PanelSections } from '@googleforcreators/design-system';
+import { useCallback, useMemo } from '@googleforcreators/react';
+import { PanelSections, PanelTypes } from '@googleforcreators/design-system';
 import styled from 'styled-components';
 
 /**
@@ -44,6 +44,15 @@ function StylePanes() {
   const { panels, createSubmitHandlerForPanel, panelProperties } =
     useDesignPanels();
 
+  const submitHandlerForPanel = useMemo(
+    () =>
+      Object.values(PanelTypes).reduce((handlers, type) => {
+        handlers[type] = createSubmitHandlerForPanel(type);
+        return handlers;
+      }, {}),
+    [createSubmitHandlerForPanel]
+  );
+
   const getPanelsByType = useCallback(
     (types, paneProps) => {
       const panelsList = panels
@@ -52,7 +61,7 @@ function StylePanes() {
           <DesignPanel
             key={type}
             panelType={Panel}
-            registerSubmitHandler={createSubmitHandlerForPanel(type)}
+            registerSubmitHandler={submitHandlerForPanel[type]}
             {...panelProperties}
           />
         ));
@@ -62,7 +71,7 @@ function StylePanes() {
         </StyledPane>
       );
     },
-    [panels, createSubmitHandlerForPanel, panelProperties]
+    [panels, submitHandlerForPanel, panelProperties]
   );
 
   return tabs.map(({ id }) => {


### PR DESCRIPTION
## Context
This code looked into the design panel performance.
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
This PR contains the second of two separate failed approaches to increase perf in the design panel. Documenting both approaches here to help guide future approaches.

### Culling Unnecessary Re-renders From the Top Down (Original Approach)
This was the first approach I tried, and the code isn't documented in this PR. My goal here was to pass around and interact with the story data a little more wisely to avoid unnecessary re-renders. The main blocker I ran into here was the current architecture inhibiting this.

The main issues stem from 2 architectural choices that make the entire style pane deeply intertwined with selected element state:
1. Holding & staging element updates in local state before dispatching the updates to the top level story reducer. This is used primarily to leverage presubmit handlers, but might be subject to change with #6690 . I modeled out the update logic here in #11389
2. Having an abstract concept of a Design Panel. Since every input panel is abstracted on to be handled as a "design panel", we don't know how the design panel is going to consume the data. Because of this, we end up passing every design panel far more data than is essential for its function (ie `selectedElements` & `selectedElementAnimations`) even tho we rarely need all that info for the all inputs (ie color input only cares about color of current selection).

Altering the current architecture seemed out of scope for this ticket, and without doing that, I was unable to find any solutions that fixed performance issues by just improving how we pass around data.

### Culling Unnecessary Re-renders from the Bottom Up (Second Approach)
This is the approach outlined in the code changes in this PR. The basic idea is to reduce unnecessary re-renders internally in each panel by making each panel more or a wrapper component, inferring the data needed for the input in the wrapper, then making the panel's markup memoized and passing the inferred input data to the memoized input markup.

I tried out this approach on the alignment & sizePosition panels as a POC. The approach was successful in eliminating re-renders, but the eliminated re-renders didn't outweigh cost of the memoization. The memoization also added complexity to the code. Here are my findings:

#### Updating selection between copies of the same element (only position value changes)
**React Timing**
We saw an improvement here, but this doesn't provide the full picture. This isn't accounting for the cost of the memoization which in some cases actually made this slower, while in others it was faster, however basically averaged out to be about the same as before.

| main | this PR |
| ----- | ----- |
| ~11.5ms | ~6.5ms |
| <img width="691" alt="Screen Shot 2022-04-28 at 12 35 43 PM" src="https://user-images.githubusercontent.com/35983235/165813726-96b43a2f-a451-460e-92ca-967cee16ef8b.png"> | <img width="693" alt="Screen Shot 2022-04-28 at 12 39 36 PM" src="https://user-images.githubusercontent.com/35983235/165814315-4be736c7-7b4f-40d9-b535-fb32c011c174.png"> |

**Main Thread Timing**
Basically averages out to be about the same here and doesn't warrant the added technical complexity of making panels follow a wrapper & memoized controls model:

| main | this PR |
| ----- | ----- |
| ~44ms | ~44ms |
| <img width="692" alt="Screen Shot 2022-04-28 at 12 46 44 PM" src="https://user-images.githubusercontent.com/35983235/165815550-959464e0-2842-42d4-b94e-cc9ee377f7e8.png"> |  <img width="693" alt="Screen Shot 2022-04-28 at 12 43 58 PM" src="https://user-images.githubusercontent.com/35983235/165815578-22eeab49-789d-42d9-b8d0-69351daf77ea.png"> |

### Summary
I think if we really want to see more substantial performance improvements here, it would be in altering the design panels more substantially in #6690 , and there are no quicker wins here.

That being said, this interaction is already under our 100ms budget [outlined here](https://github.com/GoogleForCreators/web-stories-wp/blob/782fd71d2f74752a62ea69fe1173f530b8f85664/docs/architecture.md?plain=1#L22-L23), so it may not be worth investing more time in until we add new features/regressions that push us over our allotted 100ms of response time (main is currently ~44ms in react development build and ~22ms in react prod build on my macbook pro rn).

I think this ticket, #10072 ,  was more of a discovery ticket than anything if you read the description, so I think this is enough to close it out. Will close the PR too, but just wanted to have the code up here to reference in case anybody wanted to see the technical implementation of some of the tactics used.


## Relevant Technical Choices
Described above
<!-- Please describe your changes. -->

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
NA
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
NA
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10072
