### PR TITLE
Quick Actions: Reset Element Broken w/ Border Width & Radius

### DIFF
--- a/packages/story-editor/src/components/floatingMenu/elements/borderWidthAndColor.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/borderWidthAndColor.js
@@ -78,13 +78,13 @@ function BorderWidthAndColor() {
   );
   // We only allow editing the current border width, if all borders are identical
   const hasUniformBorder =
-    border.left === border.right &&
-    border.left === border.top &&
-    border.left === border.bottom;
+    border?.left === border?.right &&
+    border?.left === border?.top &&
+    border?.left === border?.bottom;
 
   // Border width and color inputs should only be rendered if all sides of the border are the same.
   // Both checks are needed since not all shaped have lockedWidth eg. circles.
-  if (!border.lockedWidth && !hasUniformBorder) {
+  if (!border?.lockedWidth && !hasUniformBorder) {
     return null;
   }
 
@@ -104,7 +104,7 @@ function BorderWidthAndColor() {
       properties: ({ border: oldBorder }) => ({
         border: {
           locked: true,
-          color: border.color,
+          color: border?.color,
           ...oldBorder,
           left: value,
           right: value,
@@ -142,7 +142,7 @@ function BorderWidthAndColor() {
           tabIndex={-1}
           ref={inputRef}
           suffix={<Icons.BorderBox />}
-          value={border.left || 0}
+          value={border?.left || 0}
           aria-label={WIDTH_LABEL}
           onChange={(_, value) => handleWidthChange(value)}
           onKeyDown={(e) => {
@@ -156,7 +156,7 @@ function BorderWidthAndColor() {
           <Color
             tabIndex={-1}
             label={COLOR_LABEL}
-            value={border.color || BLACK}
+            value={border?.color || BLACK}
             onChange={handleColorChange}
             hasInputs={false}
             hasEyedropper={false}


### PR DESCRIPTION
## Context

See: https://github.com/googleforcreators/web-stories-wp/issues/11379 for reported bug.

Video of issue:
(thank you @BrookeGraham for report and video shown below!)
![reset elements.gif](https://images.zenhubusercontent.com/61252a26f86e89526edc42b7/b789a584-be4b-42d3-b9c1-3c0e7be3ebf2)

Video of fix:
https://user-images.githubusercontent.com/7110244/166057948-f52b7829-6345-413f-b9de-fbfbdccd1e45.mov

## Summary

This fixes a bug that happens when one attempts to reset an element in the editor that has a border and/or border radius.

## Relevant Technical Choices

This PR adds optional chaining for the `border` object, as resetting the element results in `border` being null and implodes the application with an error.

## To-do

None.

## User-facing changes

No user-facing changes, only removing a bug that existed.

## Testing Instructions

This PR can be tested by following these steps:

1. Go to any element in the editor
2. Add a border
3. Click on the Reset Element button
4. You should expect the element to be reset and not result in an error.


## Reviews

### Does this PR have a security-related impact?

No.

### Does this PR change what data or activity we track or use?

No.

### Does this PR have a legal-related impact?

No.

## Checklist

- [X] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [X] I have tested this code to the best of my abilities
- [X] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [X] I have added a matching `Type: XYZ` label to the PR

---

Fixes #11379 
