### PR TITLE
Publish: do not set visibility in story state

### DIFF
--- a/packages/wp-story-editor/src/components/documentPane/status/status.js
+++ b/packages/wp-story-editor/src/components/documentPane/status/status.js
@@ -18,7 +18,12 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useCallback, useEffect, forwardRef } from '@googleforcreators/react';
+import {
+  useCallback,
+  useEffect,
+  forwardRef,
+  useState,
+} from '@googleforcreators/react';
 import { __ } from '@googleforcreators/i18n';
 import styled from 'styled-components';
 import {
@@ -92,11 +97,10 @@ function StatusPanel({
     editLink,
     title,
     storyId,
-    visibility,
   } = useStory(
     ({
       state: {
-        story: { status, password, editLink, title, storyId, visibility },
+        story: { status, password, editLink, title, storyId },
         capabilities,
       },
       actions: { updateStory, saveStory },
@@ -109,30 +113,23 @@ function StatusPanel({
       editLink,
       title,
       storyId,
-      visibility,
     })
   );
+
+  const [visibility, setVisibility] = useState(VISIBILITY.PUBLIC);
 
   const isUploading = useIsUploadingToStory();
 
   useEffect(() => {
     if (password) {
-      updateStory({
-        properties: { visibility: VISIBILITY.PASSWORD_PROTECTED },
-      });
+      setVisibility(VISIBILITY.PASSWORD_PROTECTED);
       return;
     }
 
     if (status === STATUS.PRIVATE) {
+      setVisibility(VISIBILITY.PRIVATE);
       updateStory({
         properties: { visibility: VISIBILITY.PRIVATE },
-      });
-      return;
-    }
-
-    if (!visibility) {
-      updateStory({
-        properties: { visibility: VISIBILITY.PUBLIC },
       });
       return;
     }
@@ -175,7 +172,6 @@ function StatusPanel({
     const properties = {
       status: STATUS.PRIVATE,
       password: '',
-      visibility: VISIBILITY.PRIVATE,
     };
 
     trackEvent('publish_story', {
@@ -184,6 +180,7 @@ function StatusPanel({
     });
     refreshPostEditURL();
 
+    setVisibility(VISIBILITY.PRIVATE);
     saveStory(properties);
   }, [title.length, refreshPostEditURL, saveStory]);
 
@@ -217,7 +214,7 @@ function StatusPanel({
           properties.status =
             visibility === VISIBILITY.PRIVATE ? STATUS.DRAFT : status;
           properties.password = '';
-          properties.visibility = VISIBILITY.PUBLIC;
+          setVisibility(VISIBILITY.PUBLIC);
           break;
 
         case VISIBILITY.PRIVATE:
@@ -228,7 +225,7 @@ function StatusPanel({
           properties.status =
             visibility === VISIBILITY.PRIVATE ? STATUS.DRAFT : status;
           properties.password = password || '';
-          properties.visibility = VISIBILITY.PASSWORD_PROTECTED;
+          setVisibility(VISIBILITY.PASSWORD_PROTECTED);
           break;
 
         default:

--- a/packages/wp-story-editor/src/components/documentPane/status/test/status.js
+++ b/packages/wp-story-editor/src/components/documentPane/status/test/status.js
@@ -160,7 +160,6 @@ describe('statusPanel', () => {
     expect(saveStory).toHaveBeenCalledWith({
       status: STATUS.PRIVATE,
       password: '',
-      visibility: VISIBILITY.PRIVATE,
     });
   });
 
@@ -200,7 +199,6 @@ describe('statusPanel', () => {
       properties: {
         status: 'draft',
         password: '',
-        visibility: VISIBILITY.PUBLIC,
       },
     });
   });


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

`visibility` is only a field that we use internally, it's not something that exists in WP.

Storing this in the story provider is not needed. This can be in local state.

## Summary

<!-- A brief description of what this PR does. -->

Use `useState()` instead of the story provider context for keeping track of visibility.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
