### PR TITLE
Remove unneeded const in `useFullbleedMediaAsBackground`

### DIFF
--- a/packages/story-editor/src/components/canvas/utils/useFullbleedMediaAsBackground.js
+++ b/packages/story-editor/src/components/canvas/utils/useFullbleedMediaAsBackground.js
@@ -31,16 +31,13 @@ import { MEDIA_ELEMENT_TYPES } from '@googleforcreators/elements';
 import isTargetCoveringContainer from '../../../utils/isTargetCoveringContainer';
 import { useStory, useCanvas } from '../../../app';
 
-const DISMISS_BACKGROUND_AUTOSET_MESSAGE_STORAGE_KEY =
-  'BACKGROUND_IS_SET_DIALOG_DISMISSED';
-
 function useFullbleedMediaAsBackground({ selectedElement }) {
   const [
     isBackgroundSnackbarMessageDismissed,
     setIsBackgroundSnackbarMessageDismissed,
   ] = useState(
     localStore.getItemByKey(
-      LOCAL_STORAGE_PREFIX[DISMISS_BACKGROUND_AUTOSET_MESSAGE_STORAGE_KEY]
+      LOCAL_STORAGE_PREFIX.BACKGROUND_IS_SET_DIALOG_DISMISSED
     )
   );
   const { setBackgroundElement, isDefaultBackground } = useStory((state) => ({
@@ -72,7 +69,7 @@ function useFullbleedMediaAsBackground({ selectedElement }) {
           dismissible: true,
         });
         localStore.setItemByKey(
-          LOCAL_STORAGE_PREFIX[DISMISS_BACKGROUND_AUTOSET_MESSAGE_STORAGE_KEY],
+          LOCAL_STORAGE_PREFIX.BACKGROUND_IS_SET_DIALOG_DISMISSED,
           true
         );
         setIsBackgroundSnackbarMessageDismissed(true);

--- a/packages/story-editor/src/components/library/karma/libraryTabs.karma.js
+++ b/packages/story-editor/src/components/library/karma/libraryTabs.karma.js
@@ -60,7 +60,7 @@ describe('LibraryTabs integration', () => {
 
     it('Media 3p Panel should have no aXe violations', async () => {
       // Set local storage to have accepted third party media terms to avoid interruption with dialog
-      localStore.setItemByKey(`${LOCAL_STORAGE_PREFIX.TERMS_MEDIA3P}`, true);
+      localStore.setItemByKey(LOCAL_STORAGE_PREFIX.TERMS_MEDIA3P, true);
       const { media3pTab } = fixture.editor.library;
       expect(media3pTab).toBeDefined();
       // navigate to third party media panel
@@ -118,7 +118,7 @@ describe('LibraryTabs integration', () => {
 
   describe('keyboard navigation', () => {
     beforeEach(async () => {
-      localStore.setItemByKey(`${LOCAL_STORAGE_PREFIX.TERMS_MEDIA3P}`, true);
+      localStore.setItemByKey(LOCAL_STORAGE_PREFIX.TERMS_MEDIA3P, true);
       const textTab = fixture.container.querySelector('#library-tab-media');
       await fixture.events.focus(textTab);
     });

--- a/packages/story-editor/src/components/library/panes/media/media3p/karma/mediaFetching.karma.js
+++ b/packages/story-editor/src/components/library/panes/media/media3p/karma/mediaFetching.karma.js
@@ -201,7 +201,7 @@ describe('Media3pPane fetching', () => {
   let listCategoriesSpy;
 
   beforeEach(async () => {
-    localStore.setItemByKey(`${LOCAL_STORAGE_PREFIX.TERMS_MEDIA3P}`, true);
+    localStore.setItemByKey(LOCAL_STORAGE_PREFIX.TERMS_MEDIA3P, true);
 
     fixture = new Fixture();
 

--- a/packages/story-editor/src/components/library/panes/media/media3p/termsDialog.js
+++ b/packages/story-editor/src/components/library/panes/media/media3p/termsDialog.js
@@ -35,14 +35,14 @@ const TERMS_URL = 'https://wp.stories.google/docs/terms/';
 
 function TermsDialog() {
   const hasAcknowledgedTerms3p = localStore.getItemByKey(
-    `${LOCAL_STORAGE_PREFIX.TERMS_MEDIA3P}`
+    LOCAL_STORAGE_PREFIX.TERMS_MEDIA3P
   );
 
   const [dialogOpen, setDialogOpen] = useState(!hasAcknowledgedTerms3p);
 
   const acknowledgeTerms = useCallback(() => {
     setDialogOpen(false);
-    localStore.setItemByKey(`${LOCAL_STORAGE_PREFIX.TERMS_MEDIA3P}`, true);
+    localStore.setItemByKey(LOCAL_STORAGE_PREFIX.TERMS_MEDIA3P, true);
     trackEvent('media3p_terms_acknowledged');
   }, []);
 

--- a/packages/story-editor/src/components/library/panes/text/textSets/textSetsPane.js
+++ b/packages/story-editor/src/components/library/panes/text/textSets/textSetsPane.js
@@ -96,7 +96,7 @@ function TextSetsPane({ paneRef }) {
   const storyPages = useStory(({ state: { pages } }) => pages);
 
   const [selectedCat, setSelectedCat] = useState(
-    localStore.getItemByKey(`${LOCAL_STORAGE_PREFIX.TEXT_SET_SETTINGS}`)
+    localStore.getItemByKey(LOCAL_STORAGE_PREFIX.TEXT_SET_SETTINGS)
       ?.selectedCategory
   );
 
@@ -171,7 +171,7 @@ function TextSetsPane({ paneRef }) {
               CATEGORIES[selectedCategory]
             )
       );
-      localStore.setItemByKey(`${LOCAL_STORAGE_PREFIX.TEXT_SET_SETTINGS}`, {
+      localStore.setItemByKey(LOCAL_STORAGE_PREFIX.TEXT_SET_SETTINGS, {
         selectedCategory,
       });
       trackChange.current = true;


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

<!-- A brief description of what this PR does. -->

Just spotted this while looking at something else. Teeny tiny code quality improvement.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
