### PR TITLE
Editor: Tooltip & PopUp Menu Positioning Fix

### DIFF
--- a/packages/design-system/src/components/popup/index.js
+++ b/packages/design-system/src/components/popup/index.js
@@ -90,7 +90,7 @@ function Popup({
       const updatedXOffset = () => {
         // When in RTL the popup could render off the left side of the screen. If so, let's update the
         // offset to keep it inbounds.
-        if (x < leftOffset) {
+        if (x <= leftOffset) {
           switch (placement) {
             case PLACEMENT.BOTTOM_END:
             case PLACEMENT.TOP_END:
@@ -115,7 +115,7 @@ function Popup({
           }
         }
 
-        if (isRTL && right > offset.bodyRight - leftOffset) {
+        if (isRTL && right >= offset.bodyRight - leftOffset) {
           // maxOffset should keep us inbounds, except in the case of RTL due to the admin-sidebar nav we could use another
           // switch case here to make offset more precise, however the math below will always return the popup fully in screen.
           return { ...offset, x: offset.bodyRight - width - leftOffset };

--- a/packages/design-system/src/components/tooltip/index.js
+++ b/packages/design-system/src/components/tooltip/index.js
@@ -188,10 +188,11 @@ function BaseTooltip({
         neededVerticalSpace >= window.innerHeight;
       // We can sometimes render a tooltip too far to the left, ie. in RTL mode, or with the wp-admin sidenav.
       // When that is the case, let's update the offset.
-      const isOverFlowingLeft = left < (isRTL ? 0 : leftOffset);
+      const isOverFlowingLeft = Math.trunc(left) < (isRTL ? 0 : leftOffset);
       // The getOffset util has a maxOffset that prevents the tooltip from being render too far to the right. However, when
       // in RTL we can sometimes run into the wp-admin sidenav.
-      const isOverFlowingRight = isRTL && right > offset.bodyRight - leftOffset;
+      const isOverFlowingRight =
+        isRTL && Math.trunc(right) > offset.bodyRight - leftOffset;
 
       if (shouldMoveToTop) {
         if (dynamicPlacement.endsWith('-start')) {


### PR DESCRIPTION
## Context

This PR adds an equality sign for two types of logic around positioning for the tooltip, and should fix two reported issues in both RTL and LTR views of the Editor.

## Summary

Before: 
See: #11346 and #11375

After:

![Screen Shot 2022-05-06 at 3 34 37 PM](https://user-images.githubusercontent.com/7110244/167205742-4e2503ac-9fe6-4758-b44b-59487ebd0416.png)


## Relevant Technical Choices


## To-do

No changes.

## User-facing changes

This should improve positioning of the tooltip / tooltip menu.

## Testing Instructions

This PR can be tested by following these steps:

1. Open a Story
2. Add an element
3. Add a link to the element
4. Add an optional badge icon
5. Hover over the menu to edit the optional badge icon
6. Click on it multiple times: previously, it would change in Chrome if you clicked on it more than once.
7. Switch to RTL or to LTR, you should see the tooltip menu in the correct position in both views.

Additionally, you should be able to follow the reproduction steps in the linked reported issues and see them resolved.


## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #11346 
Fixes #11375
