### PR TITLE
Checklist: Allow removing First Page Animations

### DIFF
--- a/packages/story-editor/src/components/checklist/checks/firstPageAnimation.js
+++ b/packages/story-editor/src/components/checklist/checks/firstPageAnimation.js
@@ -86,6 +86,7 @@ const FirstPageAnimation = () => {
           <DefaultFooterText as="span">
             <Link
               target="_blank"
+              rel="noreferrer"
               onClick={onClick}
               href="https://wp.stories.google/docs/how-to/animations/"
               size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}

--- a/packages/story-editor/src/components/checklist/checks/firstPageAnimation.js
+++ b/packages/story-editor/src/components/checklist/checks/firstPageAnimation.js
@@ -40,13 +40,27 @@ export function firstPageAnimation(animations) {
 
 const FirstPageAnimation = () => {
   const isChecklistMounted = useIsChecklistMounted();
-  const { updatePageProperties, firstPage } = useStory(
-    ({ actions: { updatePageProperties }, state: { pages } }) => ({
-      updatePageProperties,
-      firstPage: pages?.at(0),
-    })
+
+  const { updatePageProperties, page, id, animations } = useStory(
+    ({ actions: { updatePageProperties }, state: { pages } }) => {
+      const page = pages?.at(0);
+      return {
+        updatePageProperties,
+        page,
+        id: page?.id,
+        animations: page?.animations,
+      };
+    }
   );
-  const isRendered = firstPageAnimation(firstPage?.animations);
+
+  const removeAnimations = useCallback(() => {
+    updatePageProperties({
+      pageId: id,
+      properties: { animations: [] },
+    });
+  }, [id]);
+
+  const isRendered = firstPageAnimation(animations);
 
   const onClick = useCallback((evt) => {
     trackClick(evt, 'click_checklist_cover_animations');
@@ -61,12 +75,7 @@ const FirstPageAnimation = () => {
       cta={
         <DefaultCtaButton
           aria-label={'Remove Animations'}
-          onClick={() =>
-            updatePageProperties({
-              pageId: firstPage?.id,
-              properties: { animations: [] },
-            })
-          }
+          onClick={removeAnimations}
         >
           {'Remove Animations'}
         </DefaultCtaButton>

--- a/packages/story-editor/src/components/checklist/checks/firstPageAnimation.js
+++ b/packages/story-editor/src/components/checklist/checks/firstPageAnimation.js
@@ -57,7 +57,7 @@ const FirstPageAnimation = () => {
       pageId,
       properties: { animations: [] },
     });
-  }, [id]);
+  }, [pageId]);
 
   const isRendered = firstPageAnimation(pageAnimations);
 

--- a/packages/story-editor/src/components/checklist/checks/firstPageAnimation.js
+++ b/packages/story-editor/src/components/checklist/checks/firstPageAnimation.js
@@ -57,7 +57,7 @@ const FirstPageAnimation = () => {
       pageId,
       properties: { animations: [] },
     });
-  }, [pageId]);
+  }, [updatePageProperties, pageId]);
 
   const isRendered = firstPageAnimation(pageAnimations);
 

--- a/packages/story-editor/src/components/checklist/checks/firstPageAnimation.js
+++ b/packages/story-editor/src/components/checklist/checks/firstPageAnimation.js
@@ -41,26 +41,25 @@ export function firstPageAnimation(animations) {
 const FirstPageAnimation = () => {
   const isChecklistMounted = useIsChecklistMounted();
 
-  const { updatePageProperties, page, id, animations } = useStory(
+  const { updatePageProperties, pageId, pageAnimations } = useStory(
     ({ actions: { updatePageProperties }, state: { pages } }) => {
       const page = pages?.at(0);
       return {
         updatePageProperties,
-        page,
-        id: page?.id,
-        animations: page?.animations,
+        pageId: page?.id,
+        pageAnimations: page?.animations,
       };
     }
   );
 
   const removeAnimations = useCallback(() => {
     updatePageProperties({
-      pageId: id,
+      pageId,
       properties: { animations: [] },
     });
   }, [id]);
 
-  const isRendered = firstPageAnimation(animations);
+  const isRendered = firstPageAnimation(pageAnimations);
 
   const onClick = useCallback((evt) => {
     trackClick(evt, 'click_checklist_cover_animations');

--- a/packages/story-editor/src/components/checklist/checks/firstPageAnimation.js
+++ b/packages/story-editor/src/components/checklist/checks/firstPageAnimation.js
@@ -17,6 +17,7 @@
 /**
  * External dependencies
  */
+import { __ } from '@googleforcreators/i18n';
 import { useCallback } from '@googleforcreators/react';
 import { Link, THEME_CONSTANTS } from '@googleforcreators/design-system';
 import { trackClick } from '@googleforcreators/tracking';
@@ -73,10 +74,10 @@ const FirstPageAnimation = () => {
       title={title}
       cta={
         <DefaultCtaButton
-          aria-label={'Remove Animations'}
+          aria-label={__('Remove Animations', 'web-stories')}
           onClick={removeAnimations}
         >
-          {'Remove Animations'}
+          {__('Remove Animations', 'web-stories')}
         </DefaultCtaButton>
       }
       footer={
@@ -84,11 +85,12 @@ const FirstPageAnimation = () => {
           <DefaultFooterText>{footer}</DefaultFooterText>
           <DefaultFooterText as="span">
             <Link
+              target="_blank"
               onClick={onClick}
               href="https://wp.stories.google/docs/how-to/animations/"
               size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
             >
-              {'Learn more'}
+              {__('Learn more', 'web-stories')}
             </Link>
           </DefaultFooterText>
         </>

--- a/packages/story-editor/src/components/checklist/checks/firstPageAnimation.js
+++ b/packages/story-editor/src/components/checklist/checks/firstPageAnimation.js
@@ -25,7 +25,11 @@ import { trackClick } from '@googleforcreators/tracking';
  * Internal dependencies
  */
 import { useStory } from '../../../app';
-import { ChecklistCard, DefaultFooterText } from '../../checklistCard';
+import {
+  ChecklistCard,
+  DefaultFooterText,
+  DefaultCtaButton,
+} from '../../checklistCard';
 import { DESIGN_COPY } from '../constants';
 import { useRegisterCheck } from '../countContext';
 import { useIsChecklistMounted } from '../popupMountedContext';
@@ -36,9 +40,13 @@ export function firstPageAnimation(animations) {
 
 const FirstPageAnimation = () => {
   const isChecklistMounted = useIsChecklistMounted();
-  const isRendered = useStory(({ state: { pages } }) =>
-    firstPageAnimation(pages[0]?.animations)
+  const { updatePageProperties, firstPage } = useStory(
+    ({ actions: { updatePageProperties }, state: { pages } }) => ({
+      updatePageProperties,
+      firstPage: pages?.at(0),
+    })
   );
+  const isRendered = firstPageAnimation(firstPage?.animations);
 
   const onClick = useCallback((evt) => {
     trackClick(evt, 'click_checklist_cover_animations');
@@ -50,16 +58,31 @@ const FirstPageAnimation = () => {
   return isRendered && isChecklistMounted ? (
     <ChecklistCard
       title={title}
+      cta={
+        <DefaultCtaButton
+          aria-label={'Remove Animations'}
+          onClick={() =>
+            updatePageProperties({
+              pageId: firstPage?.id,
+              properties: { animations: [] },
+            })
+          }
+        >
+          {'Remove Animations'}
+        </DefaultCtaButton>
+      }
       footer={
         <>
           <DefaultFooterText>{footer}</DefaultFooterText>
-          <Link
-            onClick={onClick}
-            href="https://wp.stories.google/docs/how-to/animations/"
-            size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
-          >
-            {'Learn more'}
-          </Link>
+          <DefaultFooterText as="span">
+            <Link
+              onClick={onClick}
+              href="https://wp.stories.google/docs/how-to/animations/"
+              size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
+            >
+              {'Learn more'}
+            </Link>
+          </DefaultFooterText>
         </>
       }
     />

--- a/packages/story-editor/src/components/checklist/karma/firstPageAnimation.karma.js
+++ b/packages/story-editor/src/components/checklist/karma/firstPageAnimation.karma.js
@@ -24,6 +24,7 @@ import { waitFor } from '@testing-library/react';
  */
 import { Fixture } from '../../../karma';
 import { DESIGN_COPY } from '../constants';
+import { useStory } from '../../../app/story';
 
 describe('firstPageAnimation', function () {
   let fixture;
@@ -32,18 +33,24 @@ describe('firstPageAnimation', function () {
     fixture = new Fixture();
     await fixture.render();
     await fixture.collapseHelpCenter();
+
+    // adding animations to the first page
+    await addNewPage();
+    await addElementWithAnimation();
+    await removeFirstPage();
   });
 
   afterEach(() => {
     fixture.restore();
   });
 
-  it('should see First Page Animation text in checklist design panel', async function () {
-    // add a second page
+  async function addNewPage() {
     await fixture.events.click(fixture.editor.canvas.pageActions.addPage);
     await fixture.editor.library.textTab.click();
+  }
 
-    // add text component
+  async function addElementWithAnimation() {
+    // add element
     await fixture.events.click(fixture.editor.library.text.preset('Paragraph'));
     await waitFor(() => {
       if (!fixture.editor.canvas.framesLayer.frames[1].node) {
@@ -64,25 +71,36 @@ describe('firstPageAnimation', function () {
     await fixture.events.click(
       fixture.screen.getByRole('option', { name: /^"Fade In" Effect$/ })
     );
+  }
 
-    // move to the first page
-    const previousPageButton = fixture.screen.getByRole('button', {
-      name: /Previous Page/,
-    });
-    await fixture.events.click(previousPageButton, { clickCount: 1 });
+  async function removeFirstPage() {
+    // switch to the first page
+    const pageAtIndex = fixture.editor.footer.carousel.pages[0].node;
+    await fixture.events.click(pageAtIndex);
 
     // delete the first page making the second page move to the first page
     const deleteBtn = fixture.screen.getByRole('button', {
       name: /^Delete Page$/,
     });
     await fixture.events.click(deleteBtn);
+  }
 
+  async function openCheckList() {
     // now the checklist should have the FirstPageAnimation checklist item
     // open the checklist
     await fixture.events.click(fixture.editor.checklist.toggleButton);
     // wait for animation
     await fixture.events.sleep(500);
+  }
 
+  async function getCurrentPage() {
+    return await fixture.renderHook(() =>
+      useStory(({ state: { currentPage } }) => currentPage)
+    );
+  }
+
+  fit('should see First Page Animation text in checklist design panel', async function () {
+    await openCheckList();
     // open the Design tab
     await fixture.events.click(fixture.editor.checklist.designTab);
     // check for firstPageAnimation footer
@@ -91,5 +109,27 @@ describe('firstPageAnimation', function () {
     );
 
     expect(seeFirstPageAnimationText).toBeDefined();
+  });
+
+  fit('should remove all first page animations when "Remove Animations" button is clicked', async () => {
+    // check for first page animations
+    let page = await getCurrentPage();
+    expect(page.animations.length).toBe(1);
+    await openCheckList();
+
+    // check for remove animations button
+    const seeRemoveAnimations = fixture.screen.getByText(
+      new RegExp(`^Remove Animations`)
+    );
+    expect(seeRemoveAnimations).toBeDefined();
+
+    const removeAnimationsBtn = fixture.screen.getByRole('button', {
+      name: /^Remove Animations$/,
+    });
+
+    await fixture.events.click(removeAnimationsBtn);
+    page = await getCurrentPage();
+    // check that the first page animations are removed
+    expect(Boolean(page.animations?.length)).toBeFalsy();
   });
 });

--- a/packages/story-editor/src/components/checklist/karma/firstPageAnimation.karma.js
+++ b/packages/story-editor/src/components/checklist/karma/firstPageAnimation.karma.js
@@ -94,9 +94,10 @@ describe('firstPageAnimation', function () {
   }
 
   async function getCurrentPage() {
-    return fixture.renderHook(() =>
+    const currentPage = await fixture.renderHook(() =>
       useStory(({ state: { currentPage } }) => currentPage)
     );
+    return currentPage;
   }
 
   it('should see First Page Animation text in checklist design panel', async function () {

--- a/packages/story-editor/src/components/checklist/karma/firstPageAnimation.karma.js
+++ b/packages/story-editor/src/components/checklist/karma/firstPageAnimation.karma.js
@@ -94,10 +94,10 @@ describe('firstPageAnimation', function () {
   }
 
   async function getCurrentPage() {
-    const currentPage = await fixture.renderHook(() =>
+    const page = await fixture.renderHook(() =>
       useStory(({ state: { currentPage } }) => currentPage)
     );
-    return currentPage;
+    return page;
   }
 
   it('should see First Page Animation text in checklist design panel', async function () {

--- a/packages/story-editor/src/components/checklist/karma/firstPageAnimation.karma.js
+++ b/packages/story-editor/src/components/checklist/karma/firstPageAnimation.karma.js
@@ -99,7 +99,7 @@ describe('firstPageAnimation', function () {
     );
   }
 
-  fit('should see First Page Animation text in checklist design panel', async function () {
+  it('should see First Page Animation text in checklist design panel', async function () {
     await openCheckList();
     // open the Design tab
     await fixture.events.click(fixture.editor.checklist.designTab);
@@ -111,7 +111,7 @@ describe('firstPageAnimation', function () {
     expect(seeFirstPageAnimationText).toBeDefined();
   });
 
-  fit('should remove all first page animations when "Remove Animations" button is clicked', async () => {
+  it('should remove all first page animations when "Remove Animations" button is clicked', async () => {
     // check for first page animations
     let page = await getCurrentPage();
     expect(page.animations.length).toBe(1);

--- a/packages/story-editor/src/components/checklist/karma/firstPageAnimation.karma.js
+++ b/packages/story-editor/src/components/checklist/karma/firstPageAnimation.karma.js
@@ -94,7 +94,7 @@ describe('firstPageAnimation', function () {
   }
 
   async function getCurrentPage() {
-    return await fixture.renderHook(() =>
+    return fixture.renderHook(() =>
       useStory(({ state: { currentPage } }) => currentPage)
     );
   }


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
Give the user a simple way to remove all first page animations, AMP no longer supports animations on the first page and currently first page animations cannot be added or changed from the first page after #11416.

## Summary

<!-- A brief description of what this PR does. -->
Adds a 'Remove Animation' button to the 'First Page Animations' checklist item, to remove all animations on the first page and the checklist item.

## Relevant Technical Choices

<!-- Please describe your changes. -->
The 'Remove Animations' button needs to update the UI in multiple place, used `useStory` `actions.updatePageProperties` to remove first page animations and update the UI accordingly.
## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->
before/after:
https://user-images.githubusercontent.com/14057928/167944149-8eac7b74-82ad-4dea-a1b8-2db6f6735092.mp4

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Go to Story Editor
2. Add a component and an animation to that component (not the first page)
3. Make the page with the animation the first page, by deleting all the other pages or moving the page
- Notice a new checklist item for 'First Page Animations' along with a warning in the animations panel

On Staging:
- Notice there is no 'Remove Animations' button

On Branch:
- Notice there is a 'Remove Animations' button
4. Click 'Remove Animations' button
- Notice that the animations on the first page are removed along with the checklist item


## Reviews

### Does this PR have a security-related impact?
No
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
No
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
No
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11474 
