### PR TITLE
Tracking: Add hardening for user role retrieval

### DIFF
--- a/includes/Tracking.php
+++ b/includes/Tracking.php
@@ -172,7 +172,7 @@ class Tracking extends Service_Base {
 	 * @return array User properties.
 	 */
 	private function get_user_properties(): array {
-		$role = ! empty( wp_get_current_user()->roles ) && array_key_exists(0, wp_get_current_user()->roles) ? wp_get_current_user()->roles[0] : ''; 
+		$role        = ! empty( wp_get_current_user()->roles ) && \array_key_exists( 0, wp_get_current_user()->roles ) ? wp_get_current_user()->roles[0] : ''; 
 		$experiments = implode( ',', $this->experiments->get_enabled_experiments() );
 
 		$active_plugins = [];

--- a/includes/Tracking.php
+++ b/includes/Tracking.php
@@ -172,7 +172,7 @@ class Tracking extends Service_Base {
 	 * @return array User properties.
 	 */
 	private function get_user_properties(): array {
-		$role        = ! empty( wp_get_current_user()->roles ) ? wp_get_current_user()->roles[0] : '';
+		$role = ! empty( wp_get_current_user()->roles ) && array_key_exists(0, wp_get_current_user()->roles) ? wp_get_current_user()->roles[0] : ''; 
 		$experiments = implode( ',', $this->experiments->get_enabled_experiments() );
 
 		$active_plugins = [];

--- a/includes/Tracking.php
+++ b/includes/Tracking.php
@@ -172,7 +172,7 @@ class Tracking extends Service_Base {
 	 * @return array User properties.
 	 */
 	private function get_user_properties(): array {
-		$role        = ! empty( wp_get_current_user()->roles ) && is_array( wp_get_current_user()->roles ) ? array_shift( wp_get_current_user()->roles ) : ''; 
+		$role        = ! empty( wp_get_current_user()->roles ) && \is_array( wp_get_current_user()->roles ) ? array_shift( wp_get_current_user()->roles ) : ''; 
 		$experiments = implode( ',', $this->experiments->get_enabled_experiments() );
 
 		$active_plugins = [];

--- a/includes/Tracking.php
+++ b/includes/Tracking.php
@@ -172,7 +172,7 @@ class Tracking extends Service_Base {
 	 * @return array User properties.
 	 */
 	private function get_user_properties(): array {
-		$role        = ! empty( wp_get_current_user()->roles ) && \array_key_exists( 0, wp_get_current_user()->roles ) ? wp_get_current_user()->roles[0] : ''; 
+		$role        = ! empty( wp_get_current_user()->roles ) && is_array( wp_get_current_user()->roles ) ? array_shift( wp_get_current_user()->roles ) : ''; 
 		$experiments = implode( ',', $this->experiments->get_enabled_experiments() );
 
 		$active_plugins = [];

--- a/tests/phpunit/integration/tests/Tracking.php
+++ b/tests/phpunit/integration/tests/Tracking.php
@@ -169,4 +169,35 @@ class Tracking extends DependencyInjectedTestCase {
 
 		$this->assertTrue( $tracking_allowed );
 	}
+
+	/**
+	 * @covers ::get_user_properties
+	 */
+	public function test_get_settings_user_malformed_roles(): void {
+		$user_id = self::factory()->user->create(
+			[
+				'role' => 'administrator',
+			]
+		);
+
+		wp_set_current_user( $user_id );
+
+		global $current_user;
+		$current_user->roles = [ 1 => 'administrator' ];
+
+		$this->site_kit->method( 'get_plugin_status' )->willReturn(
+			[
+				'installed'       => true,
+				'active'          => true,
+				'analyticsActive' => true,
+				'link'            => 'https://example.com',
+			]
+		);
+		$this->experiments->method( 'get_enabled_experiments' )
+			->willReturn( [ 'enableFoo', 'enableBar' ] );
+
+		$settings = $this->instance->get_settings();
+
+		$this->assertSame( 'administrator', $settings['userProperties']['userRole'] );
+	}
 }


### PR DESCRIPTION
## Context


<!-- A clear and concise description of what the problem is and what you want to happen. -->

According to [this report](https://wordpress.org/support/topic/php-warning-tracking-php-175/), there can be a PHP warning triggered here:

https://github.com/GoogleForCreators/web-stories-wp/blob/cefc2736398ab391e3fbd0a437b675b83bfa3039/includes/Tracking.php#L175

```
PHP Warning: Undefined array key 0 in /var/web/site/public_html/wp-content/plugins/web-stories/includes/Tracking.php on line 175
```

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Updates check to not depend on specific index 

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

Created a code snippet to test this ...

```php
function wp_get_current_user(){
    $user = new stdClass();
    $user->roles = array("admin");
    return $user;
}

// PHP Notice:  Undefined offset: 1
// $role        = ! empty( wp_get_current_user()->roles ) ? wp_get_current_user()->roles[1] : ''; 

// works as expected
$role        = ! empty( wp_get_current_user()->roles ) && \is_array( wp_get_current_user()->roles ) ? array_shift( wp_get_current_user()->roles ) : '';  


echo '--role: '.$role.' --';
```


## Reviews

### Does this PR have a security-related impact?

No 

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

No 

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

No 

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11352
