### PR TITLE
Avoid setting numeric story slugs

### DIFF
--- a/packages/story-editor/src/components/header/title.js
+++ b/packages/story-editor/src/components/header/title.js
@@ -26,7 +26,6 @@ import { themeHelpers } from '@googleforcreators/design-system';
  * Internal dependencies
  */
 import { useStory } from '../../app/story';
-import { useConfig } from '../../app/config';
 import { updateSlug } from '../../utils/storyUpdates';
 import { styles, states, useHighlights } from '../../app/highlights';
 
@@ -73,8 +72,6 @@ function HeaderTitle() {
     })
   );
 
-  const { storyId } = useConfig();
-
   const handleChange = useCallback(
     (evt) => updateStory({ properties: { title: evt.target.value } }),
     [updateStory]
@@ -84,10 +81,9 @@ function HeaderTitle() {
     updateSlug({
       currentSlug: slug,
       currentTitle: title,
-      storyId,
       updateStory,
     });
-  }, [slug, storyId, title, updateStory]);
+  }, [slug, title, updateStory]);
 
   if (typeof title !== 'string') {
     return null;

--- a/packages/story-editor/src/components/publishModal/content/mainStoryInfo.js
+++ b/packages/story-editor/src/components/publishModal/content/mainStoryInfo.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * External dependencies
  */
@@ -24,10 +25,11 @@ import {
 } from '@googleforcreators/design-system';
 import styled from 'styled-components';
 import { __ } from '@googleforcreators/i18n';
+
 /**
  * Internal dependencies
  */
-import { useConfig, useStory } from '../../../app';
+import { useStory } from '../../../app';
 import { updateSlug } from '../../../utils/storyUpdates';
 import useSidebar from '../../sidebar/useSidebar';
 import { EXCERPT_MAX_LENGTH } from '../../panels/document/excerpt';
@@ -50,8 +52,6 @@ const _TextArea = styled(TextArea)`
 `;
 
 const MainStoryInfo = () => {
-  const storyId = useConfig(({ storyId }) => storyId);
-
   const updateStory = useStory(({ actions }) => actions.updateStory);
   const _inputValues = useStory(({ state: { story } }) => ({
     [INPUT_KEYS.EXCERPT]: story.excerpt,
@@ -77,11 +77,10 @@ const MainStoryInfo = () => {
       updateSlug({
         currentSlug: slug,
         currentTitle: newTitle,
-        storyId,
         updateStory,
       });
     },
-    [slug, updateStory, storyId]
+    [slug, updateStory]
   );
 
   const handleUpdateStoryInfo = useCallback(

--- a/packages/story-editor/src/utils/storyUpdates.js
+++ b/packages/story-editor/src/utils/storyUpdates.js
@@ -30,18 +30,12 @@ import cleanForSlug from './cleanForSlug';
  * @param {Object} args Necessary data for update.
  * @param {string} args.currentSlug The currently assigned value to story's slug.
  * @param {string} args.currentTitle The currently assigned value to story's title.
- * @param {number} args.storyId The currently assigned value to story's id.
  * @param {Function} args.updateStory The callback to useStory's action for updating the story with new slug.
  * @return {void}
  */
-export const updateSlug = ({
-  currentSlug,
-  currentTitle,
-  storyId,
-  updateStory,
-}) => {
-  if (!currentSlug || Number(currentSlug) === storyId) {
-    const cleanSlug = encodeURIComponent(cleanForSlug(currentTitle)) || storyId;
+export const updateSlug = ({ currentSlug, currentTitle, updateStory }) => {
+  if (!currentSlug) {
+    const cleanSlug = encodeURIComponent(cleanForSlug(currentTitle));
     updateStory({ properties: { slug: cleanSlug } });
   }
 };

--- a/packages/story-editor/src/utils/test/storyUpdates.js
+++ b/packages/story-editor/src/utils/test/storyUpdates.js
@@ -30,7 +30,6 @@ describe('storyUpdates', () => {
       updateSlug({
         currentSlug: '',
         currentTitle: 'Top 10 Summer Sparkling Water Flavors',
-        storyId: 58,
         updateStory,
       });
 
@@ -39,11 +38,10 @@ describe('storyUpdates', () => {
       });
     });
 
-    it('should call fn with updated slug as story title when story id matches current slug and story title exists', () => {
+    it('should call fn with updated slug as story title when slug is empty and story title exists', () => {
       updateSlug({
-        currentSlug: '59',
+        currentSlug: '',
         currentTitle: 'Top 10 Summer Blockbusters',
-        storyId: 59,
         updateStory,
       });
 
@@ -52,16 +50,15 @@ describe('storyUpdates', () => {
       });
     });
 
-    it('should call fn with updated slug as story id when story id matches current slug and story title does not exist (fallback)', () => {
+    it('should call fn with empty slug when story title does not exist (fallback)', () => {
       updateSlug({
-        currentSlug: '59',
+        currentSlug: '',
         currentTitle: '',
-        storyId: 59,
         updateStory,
       });
 
       expect(updateStory).toHaveBeenCalledWith({
-        properties: { slug: 59 },
+        properties: { slug: '' },
       });
     });
 
@@ -69,7 +66,6 @@ describe('storyUpdates', () => {
       updateSlug({
         currentSlug: '10-reasons-to-go-for-a-walk',
         currentTitle: '',
-        storyId: 10,
         updateStory,
       });
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

There was an edge case issue with saving stories without titles, resulting in console errors due to an error response from the REST API.

Previously, if the story doesn't have a title, the `updateSlug` util (which is called when clicking on the title input and then out of it again) set the current story ID (which is a number) as the story slug.

That is not correct, because the story slug must be a string. Also, there's no need to set the story ID as the slug anyway; it can just continue to be an empty string.

## Summary

<!-- A brief description of what this PR does. -->

Fixes `updateSlug` by ensuring that the slug is an empty string and not using the story ID at all.

Not sure why this was done this way, especially on blur. But alas.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Create a new story
2. Click on title input field
3. Click somewhere else, add some content to the story
4. Save the story
5. Verify that there are no console errors


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
