### PR TITLE
Admin UI issues

### DIFF
--- a/packages/dashboard/src/components/tooltip/tooltip.js
+++ b/packages/dashboard/src/components/tooltip/tooltip.js
@@ -36,13 +36,6 @@ export default function Tooltip({
   const { isRTL } = useConfig();
   const derivedPlacement = isRTL ? TOOLTIP_RTL_PLACEMENT[placement] : placement;
 
-  return (
-    <BaseTooltip
-      placement={derivedPlacement}
-      //TODO: https://github.com/GoogleForCreators/web-stories-wp/issues/11200
-      ignoreMaxOffsetY
-      {...props}
-    />
-  );
+  return <BaseTooltip placement={derivedPlacement} {...props} />;
 }
 Tooltip.propTypes = TooltipPropTypes;

--- a/packages/design-system/src/components/tooltip/index.js
+++ b/packages/design-system/src/components/tooltip/index.js
@@ -100,10 +100,6 @@ let lastVisibleDelayedTooltip = null;
  * @param {string} props.className Classname.
  * @param {string} props.isDelayed If this tooltip is to be displayed instantly on hover (default) or by a short delay.
  * @param {number} props.popupZIndexOverride If present, passes an override for z-index to popup
- * @param {boolean} props.ignoreMaxOffsetY  Defaults to false. Sometimes, we want the popup to respect the y value
- * as perceived by the page because of scroll. This is really only true of dropDowns that
- * exist beyond the initial page scroll. Because the editor is a fixed view this only
- * comes up in peripheral pages (dashboard, settings).
  * @return {import('react').Component} BaseTooltip element
  */
 
@@ -120,7 +116,6 @@ function BaseTooltip({
   // to the whole canvas
   className = null,
   popupZIndexOverride,
-  ignoreMaxOffsetY = false,
   styleOverride,
   ...props
 }) {
@@ -396,7 +391,6 @@ const BaseTooltipPropTypes = {
   className: PropTypes.string,
   isDelayed: PropTypes.bool,
   popupZIndexOverride: PropTypes.number,
-  ignoreMaxOffsetY: PropTypes.bool,
 };
 BaseTooltip.propTypes = BaseTooltipPropTypes;
 

--- a/packages/design-system/src/components/tooltip/index.js
+++ b/packages/design-system/src/components/tooltip/index.js
@@ -166,11 +166,11 @@ function BaseTooltip({
             anchor: forceAnchorRef || anchorRef,
             popup,
             isRTL,
-            ignoreMaxOffsetY,
+            ignoreMaxOffsetY: true,
           })
         : {},
     });
-  }, [dynamicPlacement, spacing, forceAnchorRef, isRTL, ignoreMaxOffsetY]);
+  }, [dynamicPlacement, spacing, forceAnchorRef, isRTL]);
 
   // When near the edge of the viewport we want to force the tooltip to a new placement as to not
   // cutoff the contents of the tooltip.

--- a/packages/wp-story-editor/src/style.css
+++ b/packages/wp-story-editor/src/style.css
@@ -28,7 +28,7 @@
 
 body.js.edit-story #wpcontent {
   position: fixed;
-  width: calc(100% - 36px);
+  width: 100%;
 }
 
 body.js.edit-story #wpcontent,
@@ -136,6 +136,22 @@ button {
 
 @media screen and (max-width: 783px) {
   body.js.edit-story #wpcontent {
-    width: 100%;
+    position: relative;
+  }
+  ul#adminmenu {
+    overflow-y: scroll;
+    height: 100vh;
+  }
+}
+
+@media screen and (min-width: 783px) {
+  #adminmenuwrap, #adminmenuback {
+    z-index: 0;
+  }
+  #adminmenuwrap:hover {
+    z-index: 1;
+  }
+  body.js.edit-story #wpcontent {
+    width: calc(100% - 36px);
   }
 }

--- a/packages/wp-story-editor/src/style.css
+++ b/packages/wp-story-editor/src/style.css
@@ -31,6 +31,11 @@ body.js.edit-story #wpbody-content {
   padding: 0;
 }
 
+#wpcontent {
+  position: fixed;
+  width: calc(100% - 36px);
+}
+
 body.edit-story .web-stories-wp {
   position: relative;
 }
@@ -127,4 +132,10 @@ body.edit-story #wpfooter {
 
 button {
   font-size: inherit;
+}
+
+@media screen and (max-width: 783px) {
+  #wpcontent {
+    width: 100%;
+  }
 }

--- a/packages/wp-story-editor/src/style.css
+++ b/packages/wp-story-editor/src/style.css
@@ -28,7 +28,11 @@
 
 body.js.edit-story #wpcontent {
   position: fixed;
-  width: 100%;
+  width: calc(100% - 160px);
+}
+
+body.js.edit-story.folded #adminmenuback {
+  top: 32px;
 }
 
 body.js.edit-story #wpcontent,
@@ -137,6 +141,7 @@ button {
 @media screen and (max-width: 783px) {
   body.js.edit-story #wpcontent {
     position: relative;
+    width: 100%;
   }
   ul#adminmenu {
     overflow-y: scroll;
@@ -152,7 +157,7 @@ button {
   #adminmenuwrap:hover {
     z-index: 1;
   }
-  body.js.edit-story #wpcontent {
+  body.js.edit-story.folded #wpcontent {
     width: calc(100% - 36px);
   }
 }

--- a/packages/wp-story-editor/src/style.css
+++ b/packages/wp-story-editor/src/style.css
@@ -145,7 +145,8 @@ button {
 }
 
 @media screen and (min-width: 783px) {
-  #adminmenuwrap, #adminmenuback {
+  #adminmenuwrap,
+  #adminmenuback {
     z-index: 0;
   }
   #adminmenuwrap:hover {

--- a/packages/wp-story-editor/src/style.css
+++ b/packages/wp-story-editor/src/style.css
@@ -26,14 +26,14 @@
   display: none;
 }
 
+body.js.edit-story #wpcontent {
+  position: fixed;
+  width: calc(100% - 36px);
+}
+
 body.js.edit-story #wpcontent,
 body.js.edit-story #wpbody-content {
   padding: 0;
-}
-
-#wpcontent {
-  position: fixed;
-  width: calc(100% - 36px);
 }
 
 body.edit-story .web-stories-wp {
@@ -135,7 +135,7 @@ button {
 }
 
 @media screen and (max-width: 783px) {
-  #wpcontent {
+  body.js.edit-story #wpcontent {
     width: 100%;
   }
 }


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
Allow the user to have lots of plugins and/or work with a small screen and not have a blank space under the editor.

## Summary

<!-- A brief description of what this PR does. -->
Sets the wp content css style to span the entire page, also sets `ignoreMaxOffsetY` to `true` for all tooltips so that the tooltips stay in place on scroll (now that the wp content has fixed position it shouldn't scroll, the admin plugin menu scrolls)

## Relevant Technical Choices

<!-- Please describe your changes. -->
Setting the wp content `position` to `fixed` allows the content to span the entire page, while still maintaining the correct functionality for the admin plugin menu.  The tooltips `ignoreMaxOffsetY` was set to `true` so that the tooltips do not scroll with the admin plugin menu

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

before/after
https://user-images.githubusercontent.com/14057928/168895399-10e338bd-5702-4e19-92f4-478fc4841175.mp4

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Go to the Story Editor as admin
2. Adjust the window height where some of the admin plugins can't be seen

On Staging:
- Notice when you scroll the canvas there is a blank section under the editor and the admin plugin menu spans the full screen

On Branch:
- Notice when you scroll the canvas stays fixed and the admin plugin menu scrolls

Notes: this change adjusts the position of the wp content which could cause UI discrepancies - the tooltips needed to be adjusted to display correctly, there may be other UI elements that need tweaking, please test popups and tooltips and scroll functionality.  

## Reviews

### Does this PR have a security-related impact?
No
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
No
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
No
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #5076 
