### PR TITLE
Animations: Disallow negative Duration or Delay values

### DIFF
--- a/packages/animation/src/parts/simpleAnimation.js
+++ b/packages/animation/src/parts/simpleAnimation.js
@@ -26,9 +26,11 @@ import { AnimationOutput, WithAnimation } from '../outputs';
 import getInitialStyleFromKeyframes from '../utils/getInitialStyleFromKeyframes';
 import { AMPAnimationProps } from './types';
 
-export const sanitizeTimings = (timings) => ({
-  ...timings,
-  easing: timings.easing || 'linear',
+export const sanitizeTimings = ({ easing, duration, delay, ...other }) => ({
+  ...other,
+  easing: easing || 'linear',
+  duration: !isNaN(Number(duration)) ? Math.max(duration, 0) : 0,
+  delay: !isNaN(Number(delay)) ? Math.max(delay, 0) : 0,
 });
 
 function SimpleAnimation(

--- a/packages/animation/src/parts/test/index.js
+++ b/packages/animation/src/parts/test/index.js
@@ -17,6 +17,7 @@
  * Internal dependencies
  */
 import { ANIMATION_TYPES } from '../../constants';
+import { sanitizeTimings } from '../simpleAnimation';
 import { AnimationPart, throughput } from '..';
 
 describe('AnimationPart', () => {
@@ -71,6 +72,37 @@ describe('AnimationPart', () => {
       // 'type' is being added to the assertion so we'll
       // know which animation part was being tested
       expect({ [type]: properties }).toStrictEqual({ [type]: throughputNames });
+    });
+  });
+
+  it('should return 0 for values of `duration` and `delay` animation properties that are less than 0', () => {
+    [-1, -0, 0].forEach((value) => {
+      const { duration, delay } = sanitizeTimings({
+        duration: value,
+        delay: value,
+      });
+      expect(duration).toBe(0);
+      expect(delay).toBe(0);
+    });
+    [1, 0].forEach((value) => {
+      const { duration, delay } = sanitizeTimings({
+        duration: value,
+        delay: value,
+      });
+      expect(duration).toBe(value);
+      expect(delay).toBe(value);
+    });
+  });
+
+  it('should return 0 for non-numeric values of `duration` and `delay` animation properties', () => {
+    // test will fail if value is an array with a single numeric element [1]
+    ['x', [], {}, NaN, null, '1.2.3.4', '1+2'].forEach((value) => {
+      const { duration, delay } = sanitizeTimings({
+        duration: value,
+        delay: value,
+      });
+      expect(duration).toBe(0);
+      expect(delay).toBe(0);
     });
   });
 });

--- a/packages/animation/src/parts/test/index.js
+++ b/packages/animation/src/parts/test/index.js
@@ -84,7 +84,7 @@ describe('AnimationPart', () => {
       expect(duration).toBe(0);
       expect(delay).toBe(0);
     });
-    [1, 0].forEach((value) => {
+    [1, 0, 12, 51, 500, 2000].forEach((value) => {
       const { duration, delay } = sanitizeTimings({
         duration: value,
         delay: value,

--- a/packages/story-editor/src/components/panels/design/animation/effectPanel.js
+++ b/packages/story-editor/src/components/panels/design/animation/effectPanel.js
@@ -126,7 +126,7 @@ function EffectPanel({
         effectConfig={config}
         field={field}
         onChange={(value, submitArg) =>
-          handleInputChange({ [field]: value }, submitArg)
+          handleInputChange({ [field]: Math.max(value, 0) }, submitArg)
         }
         disabledOptions={disabledTypeOptionsMap[type]?.options || []}
         disabled={disabled}

--- a/packages/story-editor/src/components/panels/design/animation/test/effectInput.js
+++ b/packages/story-editor/src/components/panels/design/animation/test/effectInput.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { FIELD_TYPES } from '@googleforcreators/animation';
 import { renderWithTheme } from '@googleforcreators/test-utils';
 
@@ -56,5 +56,16 @@ describe('<EffectInput />', () => {
     const testInput = screen.getByDisplayValue(0);
     expect(testInput).toBeInTheDocument();
     expect(testInput).toHaveAttribute('aria-label', testFieldKey);
+  });
+
+  it('should reject negative values and replace with "0"', () => {
+    renderWithTheme(<EffectInput {...defaultProps} />);
+    const input = screen.getByLabelText(testFieldKey);
+    fireEvent.change(input, {
+      target: { value: '-1' },
+    });
+    // negative value should be reset to 0 on blur
+    fireEvent.blur(input);
+    expect(input.value).toBe('0');
   });
 });


### PR DESCRIPTION
## Context

The UI would crash when a user entered a negative value for one of the animation properties.

## Summary

Changes to the `sanitizeTimings` function as well as the `onChange` handler were made to reset negative values set by the user to `0`.

## Relevant Technical Choices

Negative values are caught and reset to `0` before those values can be applied to the Duration or Delay parameters.

## To-do

None

## User-facing changes

Negative values can be entered, but will be reset to `0` to avoid a UI crash.

**Before**
https://user-images.githubusercontent.com/4173034/168925062-015dc285-1a72-4edb-92db-7735269cb242.mov

**After**
https://user-images.githubusercontent.com/4173034/168925040-79df4209-b77d-4a8e-8a3a-3e203f282e8d.mov


## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

- For a new or existing story, add animation to a page element (on a page that allows animations)
- Enter a negative value into the `Duration` or `Delay` field
- Value should reset to `0` on blur or <key>Enter</key>

This PR can be tested by following these steps:

1. Clone this branch
2. Startup a local dev server
3. Follow testing instructions above


## Reviews

### Does this PR have a security-related impact?
No

### Does this PR change what data or activity we track or use?
No

### Does this PR have a legal-related impact?
No

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

Fixes #11439 
