### PR TITLE
Hotlinking: Fix audio length retrieval in Safari

### DIFF
--- a/includes/REST_API/Hotlinking_Controller.php
+++ b/includes/REST_API/Hotlinking_Controller.php
@@ -49,6 +49,7 @@ class Hotlinking_Controller extends REST_Controller implements HasRequirements {
 		'Cache-Control',
 		'Etag',
 		'Last-Modified',
+		'Content-Range',
 	];
 
 	/**
@@ -280,8 +281,6 @@ class Hotlinking_Controller extends REST_Controller implements HasRequirements {
 	 * @since 1.13.0
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 *
-	 * @todo Forward the Range request header.
 	 */
 	public function proxy_url( $request ): void {
 		/**
@@ -301,10 +300,14 @@ class Hotlinking_Controller extends REST_Controller implements HasRequirements {
 		}
 
 		header( 'Cache-Control: max-age=3600' );
+		header( 'Accept-Ranges: bytes' );
 
 		$args = [
 			'timeout'  => 60, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 			'blocking' => false,
+			'headers'  => [
+				'Range' => $request->get_header( 'Range' ),
+			],
 		];
 
 		$http      = _wp_http_get_object();

--- a/packages/story-editor/src/components/panels/shared/backgroundAudioPanelContent.js
+++ b/packages/story-editor/src/components/panels/shared/backgroundAudioPanelContent.js
@@ -295,7 +295,7 @@ function BackgroundAudioPanelContent({
               renderUploadButton={renderUploadCaptionButton}
             />
           )}
-          {showLoopControl && resource?.length && (
+          {showLoopControl && resource?.length > 0 && (
             <Row spaceBetween={false}>
               <LoopPanelContent loop={loop} onChange={onChangeLoop} />
             </Row>


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

Audio length retrieval wasn't properly working in Safari when using the CORS proxy, due to Range requests not working as Safari expects it.

## Summary

<!-- A brief description of what this PR does. -->

Fixes audio length retrieval in Safari, avoids "0" being printed on the page if length is zero.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. **In Safari**, create a new story
2. Add the following file as page-level background audio: https://download.samplelib.com/mp3/sample-3s.mp3
3. Verify that loop controls are shown


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

Involves a change to the CORS proxy (supporting Range requests), but no security impact.

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11511
