### PR TITLE
Media: Catch errors when trying to update BlurHash and base color

### DIFF
--- a/includes/templates/admin/edit-story.php
+++ b/includes/templates/admin/edit-story.php
@@ -39,7 +39,7 @@ $initial_edits     = [ 'story' => null ];
 $preload_paths = [
 	'/web-stories/v1/media/?' . build_query(
 		[
-			'context'               => 'edit',
+			'context'               => 'view',
 			'per_page'              => 50,
 			'page'                  => 1,
 			'_web_stories_envelope' => 'true',
@@ -69,7 +69,7 @@ $preload_paths = [
 	),
 	'/web-stories/v1/media/?' . build_query(
 		[
-			'context'  => 'edit',
+			'context'  => 'view',
 			'per_page' => 10,
 			'_fields'  => 'source_url',
 		]

--- a/packages/story-editor/src/app/media/utils/useDetectBaseColor.js
+++ b/packages/story-editor/src/app/media/utils/useDetectBaseColor.js
@@ -68,7 +68,9 @@ function useDetectBaseColor({ updateMediaElement }) {
           }
         }
       } catch (error) {
-        // Do nothing for now.
+        // This might happen as an author when trying to updateMedia() that
+        // was uploaded by someone else.
+        // Do nothing with the error for now.
       }
     },
     [
@@ -87,11 +89,18 @@ function useDetectBaseColor({ updateMediaElement }) {
       if (type === 'image') {
         imageSrc = getSmallestUrlForWidth(0, resource);
       } else if (!isExternal) {
-        const posterResource = getPosterMediaById
-          ? await getPosterMediaById(id)
-          : null;
-        if (posterResource) {
-          imageSrc = getSmallestUrlForWidth(0, posterResource);
+        try {
+          const posterResource = getPosterMediaById
+            ? await getPosterMediaById(id)
+            : null;
+          if (posterResource) {
+            imageSrc = getSmallestUrlForWidth(0, posterResource);
+          }
+        } catch (error) {
+          // The user might not have the permission to access the video with context=edit.
+          // This might happen as an author when the video
+          // was uploaded by someone else.
+          // Do nothing with the error for now.
         }
       }
 

--- a/packages/story-editor/src/app/media/utils/useDetectBlurhash.js
+++ b/packages/story-editor/src/app/media/utils/useDetectBlurhash.js
@@ -67,7 +67,9 @@ function useDetectBlurHash({ updateMediaElement }) {
           });
         }
       } catch (error) {
-        // Do nothing for now.
+        // This might happen as an author when trying to updateMedia() that
+        // was uploaded by someone else.
+        // Do nothing with the error for now.
       }
     },
     [
@@ -86,11 +88,18 @@ function useDetectBlurHash({ updateMediaElement }) {
       if (type === 'image') {
         imageSrc = getSmallestUrlForWidth(300, resource);
       } else if (!isExternal) {
-        const posterResource = getPosterMediaById
-          ? await getPosterMediaById(id)
-          : null;
-        if (posterResource) {
-          imageSrc = getSmallestUrlForWidth(300, posterResource);
+        try {
+          const posterResource = getPosterMediaById
+            ? await getPosterMediaById(id)
+            : null;
+          if (posterResource) {
+            imageSrc = getSmallestUrlForWidth(300, posterResource);
+          }
+        } catch (error) {
+          // The user might not have the permission to access the video with context=edit.
+          // This might happen as an author when the video
+          // was uploaded by someone else.
+          // Do nothing with the error for now.
         }
       }
 

--- a/packages/wp-story-editor/src/api/media.js
+++ b/packages/wp-story-editor/src/api/media.js
@@ -35,7 +35,7 @@ export function getMedia(
   { mediaType, searchTerm, pagingNum, cacheBust }
 ) {
   let path = addQueryArgs(config.api.media, {
-    context: 'edit',
+    context: 'view',
     per_page: 50,
     page: pagingNum,
     _web_stories_envelope: true,
@@ -72,7 +72,7 @@ export function getMedia(
 // Important: Keep in sync with REST API preloading definition.
 export function getMediaForCorsCheck(config) {
   const path = addQueryArgs(config.api.media, {
-    context: 'edit',
+    context: 'view',
     per_page: 10,
     _fields: 'source_url',
   });
@@ -91,7 +91,7 @@ export function getMediaForCorsCheck(config) {
  */
 export function getMediaById(config, mediaId) {
   const path = addQueryArgs(`${config.api.media}${mediaId}/`, {
-    context: 'edit',
+    context: 'view',
     _fields: MEDIA_FIELDS,
   });
 
@@ -107,7 +107,7 @@ export function getMediaById(config, mediaId) {
  */
 export async function getMutedMediaById(config, mediaId) {
   const path = addQueryArgs(`${config.api.media}${mediaId}/`, {
-    context: 'edit',
+    context: 'view',
     _fields: 'meta.web_stories_muted_id',
   });
 
@@ -129,7 +129,7 @@ export async function getMutedMediaById(config, mediaId) {
  */
 export async function getOptimizedMediaById(config, mediaId) {
   const path = addQueryArgs(`${config.api.media}${mediaId}/`, {
-    context: 'edit',
+    context: 'view',
     _fields: 'meta.web_stories_optimized_id',
   });
 
@@ -151,7 +151,7 @@ export async function getOptimizedMediaById(config, mediaId) {
  */
 export async function getPosterMediaById(config, mediaId) {
   const path = addQueryArgs(`${config.api.media}${mediaId}/`, {
-    context: 'edit',
+    context: 'view',
     _fields: 'featured_media',
   });
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

This addresses some editor crashes reported in #11504 that are related to media and how we update base color and BlurHash strings for attachments.

When you open the editor, we go through all the images and videos in the media library in the sidebar and generate base color and BlurHash values if missing. Then, we try to update the media items via the REST API so that this won't need to be done the next time around.

Now, users with author or contributor role in WordPress are not allowed to edit media that was uploaded by some other user. (Related: #9241)

So when trying to make these API calls with `context=edit`, there will be errors returned.

We did not previously catch these errors.

## Summary

<!-- A brief description of what this PR does. -->

This resolves the issue by wrapping relevant REST API calls in `try {} catch {}` blocks, as well as by using `context=view` wherever possible, to avoid running into this issue in other cases as much as possible.

## Relevant Technical Choices

<!-- Please describe your changes. -->

Updates REST API preloading to use `context=view` as well.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. As an **administrator**, got to Media -> Add New and upload a video or image
2. As an **author**, go create a new story
3. You should be able to insert the new video/image in a story without any issues. There should be no crash.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11504
