### PR TITLE
Changed keybinding for play stop animations to mod+enter

### DIFF
--- a/packages/karma-fixture/src/events.js
+++ b/packages/karma-fixture/src/events.js
@@ -21,6 +21,7 @@ const KEY_MAP = {
   CONTROL: 'Control',
   CNTRL: 'Control',
   DOWN: 'ArrowDown',
+  ENTER: 'Enter',
   ESC: 'Escape',
   LEFT: 'ArrowLeft',
   META: 'Meta',

--- a/packages/story-editor/src/app/canvas/useCanvasKeys.js
+++ b/packages/story-editor/src/app/canvas/useCanvasKeys.js
@@ -239,7 +239,7 @@ function useCanvasKeys(ref) {
     STORY_ANIMATION_STATE.PLAYING_SELECTED,
   ].includes(animationState);
   useGlobalKeyDownEffect(
-    { key: ['mod+space'] },
+    { key: ['mod+enter'] },
     (evt) => {
       evt.preventDefault();
       if (currentPageNumber === 1) {

--- a/packages/story-editor/src/components/canvas/karma/canvasKeys.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/canvasKeys.karma.js
@@ -101,7 +101,7 @@ describe('Canvas Keyboard Shortcuts', () => {
     }
   });
 
-  it('should play pause animation when pressing mod+space shortcut', async () => {
+  it('should play pause animation when pressing mod+enter shortcut', async () => {
     // add a second page to allow for animations
     await fixture.events.click(fixture.editor.canvas.pageActions.addPage);
 
@@ -143,15 +143,15 @@ describe('Canvas Keyboard Shortcuts', () => {
     let toggle = fixture.screen.getByLabelText('Play Page Animations');
     expect(toggle).toBeDefined();
 
-    // press mod+space
-    await fixture.events.keyboard.shortcut('mod+space');
+    // press mod+enter
+    await fixture.events.keyboard.shortcut('mod+enter');
 
     // check that 'Stop Animation' toggle button is there
     toggle = fixture.screen.getByLabelText('Stop Page Animations');
     expect(toggle).toBeDefined();
 
-    // press mod+space
-    await fixture.events.keyboard.shortcut('mod+space');
+    // press mod+enter
+    await fixture.events.keyboard.shortcut('mod+enter');
 
     // check that 'Play Animation' toggle button is there
     toggle = fixture.screen.getByLabelText('Play Page Animations');

--- a/packages/story-editor/src/components/canvas/pagemenu/animationToggle.js
+++ b/packages/story-editor/src/components/canvas/pagemenu/animationToggle.js
@@ -57,7 +57,7 @@ function AnimationToggle() {
     : isPlaying
     ? __('Stop Page Animations', 'web-stories')
     : __('Play Page Animations', 'web-stories');
-  const shortcut = isFirstPage ? null : 'mod+space';
+  const shortcut = isFirstPage ? null : 'mod+enter';
   const Icon = isPlaying ? Icons.StopOutline : Icons.PlayOutline;
 
   const toggleAnimationState = useCallback(() => {

--- a/packages/story-editor/src/components/canvas/test/useCanvasKeys.js
+++ b/packages/story-editor/src/components/canvas/test/useCanvasKeys.js
@@ -162,7 +162,7 @@ describe('useCanvasKeys', function () {
     });
   });
 
-  it('should should play/pause animation when mod+space is pressed.', () => {
+  it('should should play/pause animation when mod+enter is pressed.', () => {
     const updateAnimationState = jest.fn();
 
     const { container } = render(
@@ -180,8 +180,8 @@ describe('useCanvasKeys', function () {
     );
 
     fireEvent.keyDown(container, {
-      key: 'Space',
-      which: 32,
+      key: 'Enter',
+      which: 13,
       ctrlKey: true,
     });
 

--- a/packages/story-editor/src/components/keyboardShortcutsMenu/keyboardShortcutList.js
+++ b/packages/story-editor/src/components/keyboardShortcutsMenu/keyboardShortcutList.js
@@ -111,7 +111,7 @@ const shortcuts = {
           shortcut: (
             <kbd>
               <kbd className="large-key">{prettifyShortcut('mod')}</kbd>
-              <LargeKey>{'Space'}</LargeKey>
+              <kbd>{prettifyShortcut('enter')}</kbd>
             </kbd>
           ),
         },


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
Change play/stop animations key binding to `mod+enter`, `mod+space` causing issues with spotlight on MacOS.
## Summary

<!-- A brief description of what this PR does. -->
Replaces `mod+space` key binding with `mod+enter` key binding

## Relevant Technical Choices

<!-- Please describe your changes. -->
Just updated the use of `mod+space` with `mod+enter`
## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Go to the Story Editor
2. Add a page with animations
3. press `cmd + enter` on mac or `ctrl + enter` on windows

On Staging:
- Notice nothing happens - currently animation play/stop is mapped to `mod + space`

On Branch
- Notice the animation will toggle between play/stop

## Reviews

### Does this PR have a security-related impact?
No
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
No
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
No
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11498 
