### PR TITLE
New Story details modal doesn't show the checklist icon in Safari

### DIFF
--- a/packages/story-editor/src/components/publishModal/content/checklistButton.js
+++ b/packages/story-editor/src/components/publishModal/content/checklistButton.js
@@ -17,6 +17,7 @@
  * External dependencies
  */
 import { Icons } from '@googleforcreators/design-system';
+import styled from 'styled-components';
 import { __ } from '@googleforcreators/i18n';
 import PropTypes from 'prop-types';
 /**
@@ -27,12 +28,18 @@ import { ISSUE_TYPES } from '../../checklist/constants';
 import { useCategoryCount } from '../../checklist/countContext';
 import { ToggleButton } from '../../toggleButton';
 
+const MainIcon = styled(Icons.Checkbox)`
+  height: 32px;
+  width: auto;
+  display: block;
+`;
+
 const ChecklistButton = ({ handleReviewChecklist }) => {
   const priorityCount = useCategoryCount(ISSUE_TYPES.PRIORITY);
 
   return (
     <ToggleButton
-      MainIcon={Icons.Checkbox}
+      MainIcon={MainIcon}
       label={__('Checklist', 'web-stories')}
       aria-label={__('Checklist', 'web-stories')}
       popupZIndexOverride={Z_INDEX_STORY_DETAILS}


### PR DESCRIPTION
## Context

This PR adds height, width, and display to the icon within the New Story Publish modal, eliminating the issue of a lack of icon in Safari.

## Summary

![Screen Shot 2022-05-18 at 5 05 30 PM](https://user-images.githubusercontent.com/7110244/169156350-234ea5a0-7083-4c61-a196-8bf96502175e.png)
(Screenshot from Safari)

## Relevant Technical Choices

Simply adds styling to the button so the SVG renders properly in Safari.

## To-do

None

## User-facing changes

Displays an icon that was originally missing in Safari.

## Testing Instructions

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Open Safari and navigate to create a new story
2. Go to publish a new story
3. Within the Story Details modal before publishing, you should see the checklist icon render.

Would be good to test other browsers too, I've confirmed this also looks good in Chrome (macOS) still.


## Reviews

### Does this PR have a security-related impact?

No.

### Does this PR change what data or activity we track or use?

No.

### Does this PR have a legal-related impact?

No.

## Checklist

<!-- Check these after PR creation -->

- [X] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [X] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [X] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11052
