### PR TITLE
Editor: Ensure tooltips consistently show tails (#11304)

### DIFF
--- a/packages/story-editor/src/components/tooltip/tooltip.js
+++ b/packages/story-editor/src/components/tooltip/tooltip.js
@@ -30,12 +30,15 @@ import {
 import { useConfig } from '../../app/config';
 
 export default function Tooltip({
+  hasTail = true,
   placement = TOOLTIP_PLACEMENT.BOTTOM,
   ...props
 }) {
   const { isRTL } = useConfig();
   const derivedPlacement = isRTL ? TOOLTIP_RTL_PLACEMENT[placement] : placement;
 
-  return <BaseTooltip placement={derivedPlacement} {...props} />;
+  return (
+    <BaseTooltip placement={derivedPlacement} hasTail={hasTail} {...props} />
+  );
 }
 Tooltip.propTypes = TooltipPropTypes;


### PR DESCRIPTION
## Context

Tooltips should be rendered consistently with 'tails'.

## Summary

Tooltips in the story editor are now rendered with 'tails' by default.

## Relevant Technical Choices

The core `Tooltip` component in the story editor was modified to show tails by default.

## To-do

None

## User-facing changes

https://user-images.githubusercontent.com/4173034/169901207-68054fa4-0701-436c-add9-7f81ab6b2a5e.mov


## Testing Instructions

In the story editor, hover over UI elements with tooltips - they should all have 'tails'.

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

<!-- This PR can be tested by following these steps: -->

<!-- 1. -->


## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

Fixes #11304 
