### PR TITLE
Karma: Fix failing lasso integration test

### DIFF
--- a/packages/story-editor/src/components/canvas/karma/lasso.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/lasso.karma.js
@@ -75,7 +75,7 @@ describe('Lasso integration', () => {
   }
 
   it('should have the last element selected by default', async () => {
-    expect(await getSelection()).toEqual([element2.id]);
+    expect(await getSelection()).toEqual([element3.id]);
   });
 
   it('should select right on the top-left corner', async () => {


### PR DESCRIPTION
## Context

This fixes a test issue lingering after merging #11429.

## Testing Instructions

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #11428
