### PR TITLE
Products: Improving loading of product dropdown.

### DIFF
--- a/packages/story-editor/src/components/library/panes/shopping/productDropdown.js
+++ b/packages/story-editor/src/components/library/panes/shopping/productDropdown.js
@@ -18,7 +18,12 @@
  */
 import { useFeature } from 'flagged';
 import { __ } from '@googleforcreators/i18n';
-import { useCallback, useEffect, useState } from '@googleforcreators/react';
+import {
+  useCallback,
+  useEffect,
+  useState,
+  useMemo,
+} from '@googleforcreators/react';
 import { Datalist } from '@googleforcreators/design-system';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
@@ -34,8 +39,12 @@ const StyledDropDown = styled(Datalist.DropDown)`
 function ProductDropdown({ product, setProduct }) {
   const isShoppingIntegrationEnabled = useFeature('shoppingIntegration');
 
+  const initialProducts = useMemo(
+    () => [{ id: product?.productId, name: product?.productTitle, product }],
+    [product]
+  );
   const [isLoading, setIsLoading] = useState(false);
-  const [initialOptions, setInitialOptions] = useState([]);
+  const [initialOptions, setInitialOptions] = useState(initialProducts);
 
   const {
     actions: { getProducts },
@@ -69,12 +78,12 @@ function ProductDropdown({ product, setProduct }) {
         const products = await getProductsByQuery();
         setInitialOptions(products);
       } catch (err) {
-        setInitialOptions([]);
+        setInitialOptions(initialProducts);
       } finally {
         setIsLoading(false);
       }
     })();
-  }, [getProductsByQuery]);
+  }, [getProductsByQuery, initialProducts]);
 
   const dropDownParams = {
     hasSearch: true,
@@ -83,9 +92,8 @@ function ProductDropdown({ product, setProduct }) {
     getOptionsByQuery: getProductsByQuery,
     selectedId: product?.productId,
     dropDownLabel: __('Product', 'web-stories'),
-    placeholder: isLoading ? __('Loading…', 'web-stories') : '',
-    disabled: isLoading ? true : isSaving,
-    primaryOptions: isLoading ? [] : initialOptions,
+    disabled: isSaving,
+    primaryOptions: isLoading ? initialProducts : initialOptions,
     zIndex: 10,
   };
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

While testing other PRs, I noticed the products dropdown was a little jumpy, this PR makes the loading process a little cleaner and stops it from jumping in. 

This error helps, the API call fails or something goes wrong, the dropdown is somewhat usable. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

#### Before

https://user-images.githubusercontent.com/237508/170468600-228e4b8e-486a-46b0-a127-adcc2314244e.mov

#### After

https://user-images.githubusercontent.com/237508/170468193-63a11c9a-28c4-45f8-bcc1-828dc98519ec.mov

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
