### PR TITLE
Editor: Ensure consistent positioning of tooltips for page side menu buttons

### DIFF
--- a/packages/story-editor/src/app/highlights/quickActions/useQuickActions.js
+++ b/packages/story-editor/src/app/highlights/quickActions/useQuickActions.js
@@ -245,7 +245,6 @@ MediaPicker.propTypes = {
 const useQuickActions = () => {
   const {
     capabilities: { hasUploadMediaAction },
-    isRTL,
   } = useConfig();
   const dispatchStoryEvent = useStoryTriggersDispatch();
   const {
@@ -428,10 +427,11 @@ const useQuickActions = () => {
 
   const actionMenuProps = useMemo(
     () => ({
-      tooltipPlacement: isRTL ? PLACEMENT.LEFT : PLACEMENT.RIGHT,
+      // The <BaseTooltip> component will handle proper placement for RTL layout
+      tooltipPlacement: PLACEMENT.RIGHT,
       onMouseDown: handleMouseDown,
     }),
-    [handleMouseDown, isRTL]
+    [handleMouseDown]
   );
 
   const noElementSelectedActions = useMemo(() => {

--- a/packages/story-editor/src/components/canvas/pagemenu/pageMenuButton.js
+++ b/packages/story-editor/src/components/canvas/pagemenu/pageMenuButton.js
@@ -24,6 +24,7 @@ import {
   BUTTON_VARIANTS,
   BUTTON_TYPES,
   BUTTON_SIZES,
+  PLACEMENT,
 } from '@googleforcreators/design-system';
 import { forwardRef } from '@googleforcreators/react';
 
@@ -41,7 +42,12 @@ function PageMenuButtonWithRef(
   forwardedRef
 ) {
   return (
-    <Tooltip title={title} shortcut={shortcut} hasTail>
+    <Tooltip
+      title={title}
+      shortcut={shortcut}
+      placement={PLACEMENT.RIGHT}
+      hasTail
+    >
       <StyledButton
         variant={BUTTON_VARIANTS.SQUARE}
         type={BUTTON_TYPES.SECONDARY}

--- a/packages/story-editor/src/components/tooltip/tooltip.js
+++ b/packages/story-editor/src/components/tooltip/tooltip.js
@@ -18,27 +18,17 @@
  * External dependencies
  */
 import {
-  TOOLTIP_RTL_PLACEMENT,
   BaseTooltip,
   TooltipPropTypes,
   TOOLTIP_PLACEMENT,
 } from '@googleforcreators/design-system';
-
-/**
- * Internal dependencies
- */
-import { useConfig } from '../../app/config';
 
 export default function Tooltip({
   hasTail = true,
   placement = TOOLTIP_PLACEMENT.BOTTOM,
   ...props
 }) {
-  const { isRTL } = useConfig();
-  const derivedPlacement = isRTL ? TOOLTIP_RTL_PLACEMENT[placement] : placement;
-
-  return (
-    <BaseTooltip placement={derivedPlacement} hasTail={hasTail} {...props} />
-  );
+  // The <BaseTooltip> component will handle proper placement for RTL layout
+  return <BaseTooltip placement={placement} hasTail={hasTail} {...props} />;
 }
 Tooltip.propTypes = TooltipPropTypes;


### PR DESCRIPTION
## Context

Tooltips were positioned inconsistently for buttons to the side of the page layout area. There were also inconsistencies in handling positioning for RTL layouts.

## Summary

Tooltips for affected buttons are now set to display to the right (or left for RTL layouts).

## Relevant Technical Choices

Specified placement of tooltips to be on the right and refactored related components for consistent handling of RTL layouts.

## To-do

None.

## User-facing changes

Tooltips should show in the correct position

## Testing Instructions

Hover over the buttons to the right of the page layout area - buttons in both the top and bottom groups should show tooltips to the right (or left for RTL layout).

## Reviews

### Does this PR have a security-related impact?

No.

### Does this PR change what data or activity we track or use?

No.

### Does this PR have a legal-related impact?

No.

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11561 
