### PR TITLE
REST API: Set `null` date for new `auto-draft` stories

### DIFF
--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -140,7 +140,7 @@ class Stories_Controller extends Stories_Base_Controller {
 		 * @link https://core.trac.wordpress.org/ticket/38883
 		 * @link https://github.com/GoogleForCreators/web-stories-wp/issues/11403
 		 */
-		if ( 'auto-draft' === $post->post_status ) {
+		if ( 'auto-draft' === $post->post_status || 'draft' === $post->post_status ) {
 			if ( '0000-00-00 00:00:00' === $post->post_date_gmt ) {
 				if ( rest_is_field_included( 'date', $fields ) ) {
 					$data['date'] = null;

--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -132,6 +132,35 @@ class Stories_Controller extends Stories_Base_Controller {
 			$data['embed_post_link'] = add_query_arg( [ 'from-web-story' => $post->ID ], admin_url( 'post-new.php' ) );
 		}
 
+		/*
+		 * Internally, WordPress uses a special post_date_gmt value of 0000-00-00 00:00:00
+		 * to indicate that a draft's date is "floating" and should be updated whenever the post is saved.
+		 * This makes it much more difficult for API clients to know the correct date of a draft post.
+		 *
+		 * @link https://core.trac.wordpress.org/ticket/38883
+		 * @link https://github.com/GoogleForCreators/web-stories-wp/issues/11403
+		 */
+		if ( 'auto-draft' === $post->post_status ) {
+			if ( '0000-00-00 00:00:00' === $post->post_date_gmt ) {
+				if ( rest_is_field_included( 'date', $fields ) ) {
+					$data['date'] = null;
+				}
+				if ( rest_is_field_included( 'date_gmt', $fields ) ) {
+					$data['date_gmt'] = null;
+				}
+			}
+
+			if ( '0000-00-00 00:00:00' === $post->post_modified_gmt ) {
+				if ( rest_is_field_included( 'modified', $fields ) ) {
+					$data['modified'] = null;
+				}
+
+				if ( rest_is_field_included( 'modified_gmt', $fields ) ) {
+					$data['modified_gmt'] = null;
+				}
+			}
+		}
+
 		$data  = $this->filter_response_by_context( $data, $context );
 		$links = $response->get_links();
 

--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -62,6 +62,7 @@ class Stories_Controller extends Stories_Base_Controller {
 	 *
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 * @SuppressWarnings(PHPMD.NPathComplexity)
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
 	 *
 	 * @since 1.0.0
 	 *

--- a/tests/phpunit/integration/tests/REST_API/Stories_Controller.php
+++ b/tests/phpunit/integration/tests/REST_API/Stories_Controller.php
@@ -401,6 +401,38 @@ class Stories_Controller extends RestTestCase {
 	 * @covers ::get_item
 	 * @covers ::prepare_item_for_response
 	 */
+	public function test_get_item_draft_no_date(): void {
+		$this->controller->register_routes();
+
+		wp_set_current_user( self::$user_id );
+		$story = self::factory()->post->create(
+			[
+				'post_type'   => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
+				'post_status' => 'draft',
+				'post_author' => self::$user_id,
+			]
+		);
+
+		$request = new WP_REST_Request( \WP_REST_Server::READABLE, '/web-stories/v1/web-story/' . $story );
+		$request->set_param( 'context', 'edit' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertArrayHasKey( 'date', $data );
+		$this->assertArrayHasKey( 'date_gmt', $data );
+		$this->assertArrayHasKey( 'modified', $data );
+		$this->assertArrayHasKey( 'modified_gmt', $data );
+		$this->assertNull( $data['date'] );
+		$this->assertNull( $data['date_gmt'] );
+		$this->assertNull( $data['modified'] );
+		$this->assertNull( $data['modified_gmt'] );
+	}
+
+	/**
+	 * @link https://github.com/GoogleForCreators/web-stories-wp/issues/11403
+	 *
+	 * @covers ::get_item
+	 * @covers ::prepare_item_for_response
+	 */
 	public function test_get_item_auto_draft_no_date(): void {
 		$this->controller->register_routes();
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

See #11578, #11403

## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
