### PR TITLE
Floating Menu: Color Opacity Focus

### DIFF
--- a/packages/story-editor/src/components/form/color/activeOpacity.js
+++ b/packages/story-editor/src/components/form/color/activeOpacity.js
@@ -53,16 +53,20 @@ const ActiveOpacity = ({
   const opacityFocusTrapRef = useRef();
 
   return opacityFocusTrap ? (
-    <FocusTrapButton
-      ref={opacityFocusTrapButtonRef}
-      inputRef={opacityFocusTrapRef}
-      inputLabel={__('Opacity', 'web-stories')}
-      styleOverride={css`
-        width: ${isInDesignMenu ? 'calc(39%)' : 'calc(47%)'};
-      `}
-    >
+    <>
       <Space />
-      <OpacityWrapper isInDesignMenu={isInDesignMenu}>
+      <FocusTrapButton
+        ref={opacityFocusTrapButtonRef}
+        inputRef={opacityFocusTrapRef}
+        inputLabel={__('Opacity', 'web-stories')}
+        styleOverride={css`
+          width: ${isInDesignMenu ? 'calc(39%)' : 'calc(47%)'};
+          &::before: {
+            margin-left: 8px;
+          }
+        `}
+      >
+        <OpacityWrapper isInDesignMenu={isInDesignMenu}>
         <OpacityInput
           ref={opacityFocusTrapRef}
           tabIndex={tabIndex}
@@ -74,8 +78,9 @@ const ActiveOpacity = ({
             handleReturnTrappedFocus(e, opacityFocusTrapButtonRef)
           }
         />
-      </OpacityWrapper>
-    </FocusTrapButton>
+        </OpacityWrapper>
+      </FocusTrapButton>
+    </>
   ) : (
     <>
       <Space />

--- a/packages/story-editor/src/components/form/color/activeOpacity.js
+++ b/packages/story-editor/src/components/form/color/activeOpacity.js
@@ -32,11 +32,6 @@ import {
 } from '../../floatingMenu/elements/shared/focusTrapButton';
 import OpacityInput from './opacityInput';
 
-const Space = styled.div`
-  width: 8px;
-  height: 1px;
-  background-color: ${({ theme }) => theme.colors.divider.primary};
-`;
 const OpacityWrapper = styled.div`
   width: ${({ isInDesignMenu }) =>
     isInDesignMenu ? 'calc(39% - 10px)' : 'calc(47% - 10px)'};
@@ -53,20 +48,15 @@ const ActiveOpacity = ({
   const opacityFocusTrapRef = useRef();
 
   return opacityFocusTrap ? (
-    <>
-      <Space />
-      <FocusTrapButton
-        ref={opacityFocusTrapButtonRef}
-        inputRef={opacityFocusTrapRef}
-        inputLabel={__('Opacity', 'web-stories')}
-        styleOverride={css`
-          width: ${isInDesignMenu ? 'calc(39%)' : 'calc(47%)'};
-          &::before: {
-            margin-left: 8px;
-          }
-        `}
-      >
-        <OpacityWrapper isInDesignMenu={isInDesignMenu}>
+    <FocusTrapButton
+      ref={opacityFocusTrapButtonRef}
+      inputRef={opacityFocusTrapRef}
+      inputLabel={__('Opacity', 'web-stories')}
+      styleOverride={css`
+        width: ${isInDesignMenu ? 'calc(35%)' : 'calc(45%)'};
+      `}
+    >
+      <OpacityWrapper isInDesignMenu={isInDesignMenu}>
         <OpacityInput
           ref={opacityFocusTrapRef}
           tabIndex={tabIndex}
@@ -78,21 +68,17 @@ const ActiveOpacity = ({
             handleReturnTrappedFocus(e, opacityFocusTrapButtonRef)
           }
         />
-        </OpacityWrapper>
-      </FocusTrapButton>
-    </>
-  ) : (
-    <>
-      <Space />
-      <OpacityWrapper isInDesignMenu={isInDesignMenu}>
-        <OpacityInput
-          tabIndex={tabIndex}
-          value={value}
-          onChange={handleOpacityChange}
-          isInDesignMenu={isInDesignMenu}
-        />
       </OpacityWrapper>
-    </>
+    </FocusTrapButton>
+  ) : (
+    <OpacityWrapper isInDesignMenu={isInDesignMenu}>
+      <OpacityInput
+        tabIndex={tabIndex}
+        value={value}
+        onChange={handleOpacityChange}
+        isInDesignMenu={isInDesignMenu}
+      />
+    </OpacityWrapper>
   );
 };
 

--- a/packages/story-editor/src/components/form/color/color.js
+++ b/packages/story-editor/src/components/form/color/color.js
@@ -66,6 +66,12 @@ const ColorInputsWrapper = styled.div`
   gap: ${({ isInDesignMenu }) => (isInDesignMenu ? 0 : 6)}px;
 `;
 
+const Space = styled.div`
+  width: 8px;
+  height: 1px;
+  background-color: ${({ theme }) => theme.colors.divider.primary};
+`;
+
 // 10px comes from divider / 2
 const InputWrapper = styled.div`
   ${({ hasInputs }) => hasInputs && `width: calc(53% - 10px);`}
@@ -131,11 +137,6 @@ const Color = forwardRef(function Color(
       ? TOOLTIP_PLACEMENT.BOTTOM
       : TOOLTIP_PLACEMENT.BOTTOM_START;
 
-  const Space = styled.div`
-    width: 8px;
-    height: 1px;
-    background-color: ${({ theme }) => theme.colors.divider.primary};
-  `;
   // Sometimes there's more than 1 color to an element.
   // When there's multiple colors the input displays "Mixed" (in english) and takes up a different amount of space.
   // By checking here to ignore that value based on mixed colors we prevent visual spill over of content.

--- a/packages/story-editor/src/components/form/color/color.js
+++ b/packages/story-editor/src/components/form/color/color.js
@@ -131,6 +131,11 @@ const Color = forwardRef(function Color(
       ? TOOLTIP_PLACEMENT.BOTTOM
       : TOOLTIP_PLACEMENT.BOTTOM_START;
 
+  const Space = styled.div`
+    width: 8px;
+    height: 1px;
+    background-color: ${({ theme }) => theme.colors.divider.primary};
+  `;
   // Sometimes there's more than 1 color to an element.
   // When there's multiple colors the input displays "Mixed" (in english) and takes up a different amount of space.
   // By checking here to ignore that value based on mixed colors we prevent visual spill over of content.
@@ -193,13 +198,16 @@ const Color = forwardRef(function Color(
           />
         </InputWrapper>
         {allowsOpacity && displayOpacity && (
-          <ActiveOpacity
-            handleOpacityChange={handleOpacityChange}
-            isInDesignMenu={isInDesignMenu}
-            opacityFocusTrap={opacityFocusTrap}
-            tabIndex={tabIndex}
-            value={value}
-          />
+          <>
+            <Space />
+            <ActiveOpacity
+              handleOpacityChange={handleOpacityChange}
+              isInDesignMenu={isInDesignMenu}
+              opacityFocusTrap={opacityFocusTrap}
+              tabIndex={tabIndex}
+              value={value}
+            />
+          </>
         )}
       </ColorInputsWrapper>
     </Container>


### PR DESCRIPTION
## Context

This PR should resolve an issue seen with the focus border around the color opacity in the design menus. 

## Summary

## Relevant Technical Choices

Moved the `Space` out of the component and adjusted the width.

## To-do

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

Before (image from original issue #11312):
![Before Example Image](https://user-images.githubusercontent.com/10720454/164112400-012296b5-68fa-40a0-9abb-88539f651fbb.png)

After:
![Fix Image Example 1](https://user-images.githubusercontent.com/7110244/171022252-cc6aaf37-4dbd-4041-8bd3-28b6de996534.png)


## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. On multiple browsers, please add a shape to the canvas area.
2. Click on the shape to see the floating menu.
3. Navigation through the floating menu (click on Opacity, click tab, and navigate through) and you should see the focus border around the opacity item look appropriately sized.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->
No.

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->
No.

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->
No.

## Checklist

<!-- Check these after PR creation -->

- [X] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [X] I have tested this code to the best of my abilities
- [X] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [X] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11312
