### PR TITLE
Dashboard dropdown filter displayed over stories when user scrolls up/down

### DIFF
--- a/packages/dashboard/src/app/views/shared/bodyViewOptions.js
+++ b/packages/dashboard/src/app/views/shared/bodyViewOptions.js
@@ -104,6 +104,7 @@ export default function BodyViewOptions({
                 placeholder={__('Author', 'web-stories')}
                 primaryOptions={author.queriedAuthors}
                 options={author.queriedAuthors}
+                offsetOverride
               />
             </StorySortDropdownContainer>
           )}

--- a/packages/design-system/src/components/datalist/datalist.js
+++ b/packages/design-system/src/components/datalist/datalist.js
@@ -72,6 +72,7 @@ const Container = styled.div`
  * @param {number} props.zIndex an override for default zIndex of popup
  * @param {string} props.title The title of the dialog (popup) container of the list.
  * @param {string} props.dropdownButtonLabel The label attached to the unexpanded datalist (button)
+ * @param {boolean} props.offsetOverride override popup offsets updates, use x and y offset based on anchor
  * @return {*} Render.
  */
 const Datalist = forwardRef(function Datalist(
@@ -253,6 +254,7 @@ Datalist.propTypes = {
   listStyleOverrides: PropTypes.array,
   title: PropTypes.string,
   dropdownButtonLabel: PropTypes.string,
+  offsetOverride: PropTypes.bool,
 };
 
 export default Datalist;

--- a/packages/design-system/src/components/datalist/datalist.js
+++ b/packages/design-system/src/components/datalist/datalist.js
@@ -98,6 +98,7 @@ const Datalist = forwardRef(function Datalist(
     containerStyleOverrides,
     title,
     dropdownButtonLabel,
+    offsetOverride = false,
     ...rest
   },
   ref
@@ -219,6 +220,7 @@ const Datalist = forwardRef(function Datalist(
           isOpen={isOpen}
           fillWidth={DEFAULT_WIDTH}
           zIndex={zIndex}
+          offsetOverride={offsetOverride}
         >
           {list}
         </Popup>

--- a/packages/design-system/src/components/popup/index.js
+++ b/packages/design-system/src/components/popup/index.js
@@ -215,6 +215,7 @@ Popup.propTypes = {
   refCallback: PropTypes.func,
   zIndex: PropTypes.number,
   ignoreMaxOffsetY: PropTypes.bool,
+  offsetOverride: PropTypes.bool,
 };
 
 export { Popup, PLACEMENT };

--- a/packages/design-system/src/components/popup/index.js
+++ b/packages/design-system/src/components/popup/index.js
@@ -51,6 +51,7 @@ function Popup({
   refCallback = noop,
   zIndex = DEFAULT_POPUP_Z_INDEX,
   ignoreMaxOffsetY,
+  offsetOverride = false,
 }) {
   const {
     topOffset = DEFAULT_TOP_OFFSET,
@@ -81,6 +82,7 @@ function Popup({
             isRTL,
             topOffset,
             ignoreMaxOffsetY,
+            offsetOverride,
           })
         : {};
       const { height, x, width, right } = popup.current
@@ -137,6 +139,7 @@ function Popup({
       topOffset,
       leftOffset,
       ignoreMaxOffsetY,
+      offsetOverride,
     ]
   );
 

--- a/packages/design-system/src/components/popup/utils/getOffset.js
+++ b/packages/design-system/src/components/popup/utils/getOffset.js
@@ -112,6 +112,7 @@ export function getOffset({
   popup,
   isRTL,
   ignoreMaxOffsetY,
+  offsetOverride,
   topOffset = 0,
 }) {
   const anchorRect = anchor.current.getBoundingClientRect();
@@ -140,14 +141,24 @@ export function getOffset({
   const maxOffsetY =
     bodyRect.height + bodyRect.y - height - getYTransforms(placement) * height;
 
-  // Clamp values
-  return {
-    x: Math.max(0, Math.min(offsetX, maxOffsetX)),
-    y: ignoreMaxOffsetY
-      ? offsetY
-      : Math.max(topOffset, Math.min(offsetY, maxOffsetY)),
+  const offset = {
     width: anchorRect.width,
     height: anchorRect.height,
     bodyRight: bodyRect?.right,
   };
+
+  // Clamp values
+  return offsetOverride
+    ? {
+        x: offsetX,
+        y: offsetY,
+        ...offset,
+      }
+    : {
+        x: Math.max(0, Math.min(offsetX, maxOffsetX)),
+        y: ignoreMaxOffsetY
+          ? offsetY
+          : Math.max(topOffset, Math.min(offsetY, maxOffsetY)),
+        ...offset,
+      };
 }

--- a/packages/design-system/src/components/popup/utils/getOffset.js
+++ b/packages/design-system/src/components/popup/utils/getOffset.js
@@ -98,6 +98,8 @@ export function getYOffset(placement, spacing = 0, anchorRect) {
  * @param {MutableRefObject<HTMLElement>} args.popup Popup element.
  * @param {boolean} args.isRTL isRTL.
  * @param {number} args.topOffset Header Offset.
+ * @param {boolean} args.offsetOverride Defaults to false. Mainly used for Dropdowns that do not need to stay on
+ * the screen at all times like a popup needs to.  The x and y offset of the popup will stay in line with the anchorRect
  * @param {boolean} args.ignoreMaxOffsetY Defaults to false. Sometimes, we want the popup to respect the y value
  * as perceived by the page because of scroll. This is really only true of dropDowns that
  * exist beyond the initial page scroll. Because the editor is a fixed view this only


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
Keep dropdown stationary, to keep the dropdown options from moving with user scroll or window resize.

## Summary

<!-- A brief description of what this PR does. -->
Adds a property to the Popup component to use x and y offset based on anchorRect, instead of using max offsets.

## Relevant Technical Choices

<!-- Please describe your changes. -->
The underlying issue comes from the tight integration between the popup component and the dropdown component.  I opted to add a new property here to let the popup component know that this 'popup' does not need move away from the anchorRect while scrolling.  A bigger code change to separate the popup and dropdown components is probably going to be necessary if the functionality continues to differ.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->
✔️  PR #11625 will need to be updated to add this property to the new taxonomy filters.

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Go to Story Dashboard
2. Open the authors filter
3. Scroll through the stories and resize the browser window (vertically and horizontally)

On Staging
- Notice the dropdown options stays on the screen even when the filter is not visible.

On Branch
- Notice the dropdown stays anchored to the filter.


## Reviews

### Does this PR have a security-related impact?
No
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
No
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
No
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11582 
