### PR TITLE
REST API: support filtering taxonomies by hierarchical attribute

### DIFF
--- a/includes/REST_API/Stories_Taxonomies_Controller.php
+++ b/includes/REST_API/Stories_Taxonomies_Controller.php
@@ -99,9 +99,16 @@ class Stories_Taxonomies_Controller extends WP_REST_Taxonomies_Controller implem
 		$registered = $this->get_collection_params();
 
 		if ( isset( $registered['type'] ) && ! empty( $request['type'] ) ) {
-			$taxonomies = get_object_taxonomies( $request['type'], 'objects' );
+			/**
+			 * Object type.
+			 *
+			 * @var string Object type.
+			 */
+			$type = $request['type'];
+
+			$taxonomies = get_object_taxonomies( $type, 'objects' );
 		} else {
-			$taxonomies = get_taxonomies( '', 'objects' );
+			$taxonomies = get_taxonomies( [], 'objects' );
 		}
 
 		if ( isset( $registered['hierarchical'], $request['hierarchical'] ) ) {
@@ -110,6 +117,11 @@ class Stories_Taxonomies_Controller extends WP_REST_Taxonomies_Controller implem
 
 		$data = [];
 
+		/**
+		 * Taxonomy.
+		 *
+		 * @var WP_Taxonomy $value
+		 */
 		foreach ( $taxonomies as $tax_type => $value ) {
 			if ( empty( $value->show_in_rest ) || ( 'edit' === $request['context'] && ! current_user_can( $value->cap->assign_terms ) ) ) {
 				continue;

--- a/includes/REST_API/Stories_Taxonomies_Controller.php
+++ b/includes/REST_API/Stories_Taxonomies_Controller.php
@@ -145,7 +145,6 @@ class Stories_Taxonomies_Controller extends WP_REST_Taxonomies_Controller implem
 		$query_params['hierarchical'] = [
 			'description' => __( 'Whether to show only hierarchical taxonomies.', 'web-stories' ),
 			'type'        => 'boolean',
-			'default'     => false,
 		];
 
 		return $query_params;

--- a/includes/REST_API/Stories_Taxonomies_Controller.php
+++ b/includes/REST_API/Stories_Taxonomies_Controller.php
@@ -29,6 +29,7 @@ namespace Google\Web_Stories\REST_API;
 use Google\Web_Stories\Infrastructure\Delayed;
 use Google\Web_Stories\Infrastructure\Registerable;
 use Google\Web_Stories\Infrastructure\Service;
+use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Taxonomies_Controller;
@@ -81,6 +82,73 @@ class Stories_Taxonomies_Controller extends WP_REST_Taxonomies_Controller implem
 
 		/** This filter is documented in wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php */
 		return apply_filters( 'rest_prepare_taxonomy', $response, $taxonomy, $request );
+	}
+
+	/**
+	 * Retrieves all public taxonomies.
+	 *
+	 * Adds support for filtering by the hierarchical attribute.
+	 *
+	 * @since 1.22.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_items( $request ) {
+		// Retrieve the list of registered collection query parameters.
+		$registered = $this->get_collection_params();
+
+		if ( isset( $registered['type'] ) && ! empty( $request['type'] ) ) {
+			$taxonomies = get_object_taxonomies( $request['type'], 'objects' );
+		} else {
+			$taxonomies = get_taxonomies( '', 'objects' );
+		}
+
+		if ( isset( $registered['hierarchical'], $request['hierarchical'] ) ) {
+			$taxonomies = wp_filter_object_list( $taxonomies, [ 'hierarchical' => (bool) $request['hierarchical'] ] );
+		}
+
+		$data = [];
+
+		foreach ( $taxonomies as $tax_type => $value ) {
+			if ( empty( $value->show_in_rest ) || ( 'edit' === $request['context'] && ! current_user_can( $value->cap->assign_terms ) ) ) {
+				continue;
+			}
+
+			$tax               = $this->prepare_item_for_response( $value, $request );
+			$tax               = $this->prepare_response_for_collection( $tax );
+			$data[ $tax_type ] = $tax;
+		}
+
+		if ( empty( $data ) ) {
+			// Response should still be returned as a JSON object when it is empty.
+			$data = (object) $data;
+		}
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Retrieves the query params for collections.
+	 *
+	 * Adds support for filtering by the hierarchical attribute.
+	 *
+	 * @since 1.22.0
+	 *
+	 * @return array Collection parameters.
+	 */
+	public function get_collection_params(): array {
+		$query_params = parent::get_collection_params();
+
+		$query_params['per_page']['default'] = 100;
+
+		$query_params['hierarchical'] = [
+			'description' => __( 'Whether to show only hierarchical taxonomies.', 'web-stories' ),
+			'type'        => 'boolean',
+			'default'     => false,
+		];
+
+		return $query_params;
 	}
 
 	/**

--- a/tests/phpunit/integration/tests/REST_API/Stories_Taxonomies_Controller.php
+++ b/tests/phpunit/integration/tests/REST_API/Stories_Taxonomies_Controller.php
@@ -50,4 +50,60 @@ class Stories_Taxonomies_Controller extends DependencyInjectedRestTestCase {
 		$this->assertArrayHasKey( 'https://api.w.org/items', $links );
 		$this->assertStringContainsString( 'web-stories/v1', $links['https://api.w.org/items'][0]['href'] );
 	}
+
+	/**
+	 * @covers ::get_items
+	 */
+	public function test_get_items(): void {
+		$this->controller->register();
+
+		$request  = new WP_REST_Request( WP_REST_Server::READABLE, '/web-stories/v1/taxonomies' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertFalse( $response->is_error() );
+
+		$this->assertCount( 7, $response->get_data() );
+	}
+
+	/**
+	 * @covers ::get_items
+	 * @covers ::get_collection_params
+	 */
+	public function test_get_items_hierarchical_false(): void {
+		$this->controller->register();
+
+		$request = new WP_REST_Request( WP_REST_Server::READABLE, '/web-stories/v1/taxonomies' );
+		$request->set_param( 'hierarchical', false );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertFalse( $response->is_error() );
+		$this->assertCount( 5, $response->get_data() );
+
+		$hierarchical_values = wp_list_pluck( array_values( $response->get_data() ), 'hierarchical' );
+
+		foreach ( $hierarchical_values as $hierarchical ) {
+			$this->assertFalse( $hierarchical );
+		}
+	}
+
+	/**
+	 * @covers ::get_items
+	 * @covers ::get_collection_params
+	 */
+	public function test_get_items_hierarchical_true(): void {
+		$this->controller->register();
+
+		$request = new WP_REST_Request( WP_REST_Server::READABLE, '/web-stories/v1/taxonomies' );
+		$request->set_param( 'hierarchical', true );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertFalse( $response->is_error() );
+		$this->assertCount( 2, $response->get_data() );
+
+		$hierarchical_values = wp_list_pluck( array_values( $response->get_data() ), 'hierarchical' );
+
+		foreach ( $hierarchical_values as $hierarchical ) {
+			$this->assertTrue( $hierarchical );
+		}
+	}
 }

--- a/tests/phpunit/integration/tests/REST_API/Stories_Taxonomies_Controller.php
+++ b/tests/phpunit/integration/tests/REST_API/Stories_Taxonomies_Controller.php
@@ -77,7 +77,7 @@ class Stories_Taxonomies_Controller extends DependencyInjectedRestTestCase {
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertFalse( $response->is_error() );
-		$this->assertCount( 5, $response->get_data() );
+		$this->assertNotEmpty( $response->get_data() );
 
 		$hierarchical_values = wp_list_pluck( array_values( $response->get_data() ), 'hierarchical' );
 
@@ -98,7 +98,7 @@ class Stories_Taxonomies_Controller extends DependencyInjectedRestTestCase {
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertFalse( $response->is_error() );
-		$this->assertCount( 2, $response->get_data() );
+		$this->assertNotEmpty( $response->get_data() );
 
 		$hierarchical_values = wp_list_pluck( array_values( $response->get_data() ), 'hierarchical' );
 

--- a/tests/phpunit/integration/tests/REST_API/Stories_Taxonomies_Controller.php
+++ b/tests/phpunit/integration/tests/REST_API/Stories_Taxonomies_Controller.php
@@ -60,9 +60,18 @@ class Stories_Taxonomies_Controller extends DependencyInjectedRestTestCase {
 		$request  = new WP_REST_Request( WP_REST_Server::READABLE, '/web-stories/v1/taxonomies' );
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertFalse( $response->is_error() );
+		$request->set_param( 'hierarchical', false );
+		$response_flat = rest_get_server()->dispatch( $request );
 
-		$this->assertCount( 7, $response->get_data() );
+		$request->set_param( 'hierarchical', true );
+		$response_hierarchical = rest_get_server()->dispatch( $request );
+
+		$this->assertFalse( $response->is_error() );
+		$this->assertNotEmpty( $response->get_data() );
+		$this->assertCount( 
+			\count( $response_hierarchical->get_data() ) + \count( $response_flat->get_data() ),
+			$response->get_data()
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

Based on the discussion at #11625 / https://github.com/GoogleForCreators/web-stories-wp/pull/11625#discussion_r892228319

## Summary

<!-- A brief description of what this PR does. -->

Adds support for filtering hierarchical and flat taxonomies:

* `/wp-json/web-stories/v1/taxonomies`: shows all taxonomies
* `/wp-json/web-stories/v1/taxonomies?hierarchical=true`: shows only hierarchical taxonomies
* `/wp-json/web-stories/v1/taxonomies?hierarchical=flat`: shows only flat taxonomies

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
