### PR TITLE
Output: disable JSON minification

### DIFF
--- a/includes/AMP/Optimization.php
+++ b/includes/AMP/Optimization.php
@@ -38,6 +38,7 @@ use Google\Web_Stories_Dependencies\AmpProject\Optimizer\LocalFallback;
 use Google\Web_Stories_Dependencies\AmpProject\Optimizer\TransformationEngine;
 use Google\Web_Stories_Dependencies\AmpProject\Optimizer\Transformer\AmpRuntimeCss;
 use Google\Web_Stories_Dependencies\AmpProject\Optimizer\Transformer\AmpStoryCssOptimizer;
+use Google\Web_Stories_Dependencies\AmpProject\Optimizer\Transformer\MinifyHtml;
 use Google\Web_Stories_Dependencies\AmpProject\Optimizer\Transformer\OptimizeAmpBind;
 use Google\Web_Stories_Dependencies\AmpProject\Optimizer\Transformer\OptimizeHeroImages;
 use Google\Web_Stories_Dependencies\AmpProject\Optimizer\Transformer\RewriteAmpUrls;
@@ -163,6 +164,10 @@ class Optimization {
 			Configuration::KEY_TRANSFORMERS => $transformers,
 			AmpStoryCssOptimizer::class     => [
 				AmpStoryCssOptimizerConfiguration::OPTIMIZE_AMP_STORY => true,
+			],
+			MinifyHtml::class               => [
+				// Prevents issues with rounding floats, relevant for things like shopping (product prices).
+				Configuration\MinifyHtmlConfiguration::MINIFY_JSON => false,
 			],
 		];
 

--- a/tests/phpunit/integration/tests/AMP/Optimization.php
+++ b/tests/phpunit/integration/tests/AMP/Optimization.php
@@ -85,7 +85,7 @@ class Optimization extends TestCase {
 		$transformers   = Configuration::DEFAULT_TRANSFORMERS;
 		$transformers[] = AmpStoryCssOptimizer::class;
 
-		$this->assertCount( 2, $config_array );
+		$this->assertCount( 3, $config_array );
 		$this->assertArrayHasKey( 'transformers', $config_array );
 		$this->assertEqualSets( $transformers, $config_array['transformers'] );
 	}
@@ -110,7 +110,7 @@ class Optimization extends TestCase {
 			ReorderHead::class,
 		];
 
-		$this->assertCount( 2, $config_array );
+		$this->assertCount( 3, $config_array );
 		$this->assertArrayHasKey( 'transformers', $config_array );
 		$this->assertEqualSets( $transformers, $config_array['transformers'] );
 	}


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

When adding products to a story there will be an inline script like this:

```html
<script type="application/json">{
  "items": [
    {
      "productId": "wc-29",
      "productUrl": "https://web-stories.local/product/wordpress-pennant/",
      "productTitle": "WordPress Pennant",
      "productBrand": "",
      "productPrice": 11.05,
      "productPriceCurrency": "GBP",
      "productDetails": "This is an external product.",
      "productImages": [
        {
          "url": "https://web-stories.local/wp-content/uploads/2019/01/pennant-1.jpg",
          "alt": ""
        }
      ],
      "aggregateRating": {
        "ratingValue": 0,
        "reviewCount": 0,
        "reviewUrl": "https://web-stories.local/product/wordpress-pennant/"
      }
    }
  ]
}</script>
```

When testing products earlier, I noticed the `productPrice` field is unexpectedly changed to `11.050000000000001` by the `MinifyHtml` transformer.

```diff
<script type="application/json">{
  "items": [
    {
      "productId": "wc-29",
      "productUrl": "https://web-stories.local/product/wordpress-pennant/",
      "productTitle": "WordPress Pennant",
      "productBrand": "",
-     "productPrice": 11.05,
+     "productPrice": 11.050000000000001,
      "productPriceCurrency": "GBP",
      "productDetails": "This is an external product.",
      "productImages": [
        {
          "url": "https://web-stories.local/wp-content/uploads/2019/01/pennant-1.jpg",
          "alt": ""
        }
      ],
      "aggregateRating": {
        "ratingValue": 0,
        "reviewCount": 0,
        "reviewUrl": "https://web-stories.local/product/wordpress-pennant/"
      }
    }
  ]
}</script>
```

I suppose the issue is the `json_decode()` usage in `MinifyHtml::minifyJson();`. Related: https://bugs.php.net/bug.php?id=68200,  https://bugs.php.net/bug.php?id=68456.

## Summary

<!-- A brief description of what this PR does. -->

This PR disables JSON optimization since all our JSON is already inlined and minified, can't really optimize that.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. A floating point price should not be mangled on the frontend, JSON should be left untouched.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
