### PR TITLE
Design System: Fix showing multiple snackbars at once

### DIFF
--- a/packages/design-system/src/components/snackbar/snackbarContainer.js
+++ b/packages/design-system/src/components/snackbar/snackbarContainer.js
@@ -147,7 +147,7 @@ export const SnackbarContainer = ({
       }
     });
   }, [notifications, speak]);
-  const nodeRef = useRef();
+  const nodeRefs = useRef({});
   return (
     <StyledContainer placement={placement}>
       <TransitionGroup>
@@ -163,16 +163,23 @@ export const SnackbarContainer = ({
             ...notificationProps
           } = notification;
 
+          const id = notification.id || ids[index];
+
           return (
             <CSSTransition
               in
-              key={notification.id || ids[index]}
+              key={id}
               timeout={300}
               unmountOnExit
-              nodeRef={nodeRef}
+              nodeRef={nodeRefs.current[id]}
               classNames="react-snackbar-alert__snackbar-container"
             >
-              <ChildContainer ref={nodeRef} placement={placement}>
+              <ChildContainer
+                ref={(el) => {
+                  nodeRefs.current[id] = el;
+                }}
+                placement={placement}
+              >
                 <Component
                   {...notificationProps}
                   aria-hidden


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

We prevent users from adding the same product to the same page more than once. However, if the user selects 2 or more products at the same time and tries to paste/duplicate them, only 1 snackbar message was shown. The second one never appeared.

## Summary

<!-- A brief description of what this PR does. -->

This PR addresses the issue where not all snackbar messages were visible when they were added at the same time.

## Relevant Technical Choices

<!-- Please describe your changes. -->

This PR makes it so that every notification has its own ref, instead of all of them using the same one / overriding the previous one.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

https://user-images.githubusercontent.com/841956/172807251-8f3291bb-2948-4d5d-81cd-c279a7a1632b.mov


## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add 3 products, A, B and C to the page, in this order
2. Select all products on the page
3. Press CTRL + D to duplicate them.
4. See three snackbar messages, with animations.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11654
