### PR TITLE
Fonts: Avoid unnecessary API request on dashboard 

### DIFF
--- a/packages/wp-dashboard/src/api/hooks/useFontsApi.js
+++ b/packages/wp-dashboard/src/api/hooks/useFontsApi.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { useCallback, useEffect, useState } from '@googleforcreators/react';
+import { useCallback, useState } from '@googleforcreators/react';
 import { useConfig } from '@googleforcreators/dashboard';
 
 /**

--- a/packages/wp-dashboard/src/api/hooks/useFontsApi.js
+++ b/packages/wp-dashboard/src/api/hooks/useFontsApi.js
@@ -50,12 +50,6 @@ export default function useFontsApi() {
     }
   }, [fontsApiPath]);
 
-  useEffect(() => {
-    if (null === customFonts) {
-      fetchCustomFonts();
-    }
-  }, [fetchCustomFonts, customFonts]);
-
   const deleteCustomFont = useCallback(
     async (id) => {
       const response = await deleteCustomFontCallback(fontsApiPath, id);
@@ -79,6 +73,6 @@ export default function useFontsApi() {
 
   return {
     customFonts,
-    api: { addCustomFont, deleteCustomFont },
+    api: { addCustomFont, deleteCustomFont, fetchCustomFonts },
   };
 }

--- a/packages/wp-dashboard/src/components/editorSettings/editorSettings.js
+++ b/packages/wp-dashboard/src/components/editorSettings/editorSettings.js
@@ -66,6 +66,7 @@ function EditorSettings() {
     customFonts,
     addCustomFont,
     deleteCustomFont,
+    fetchCustomFonts,
     publisherLogos,
     addPublisherLogo,
     fetchPublisherLogos,
@@ -77,7 +78,7 @@ function EditorSettings() {
   } = useEditorSettings(
     ({
       actions: {
-        fontsApi: { addCustomFont, deleteCustomFont },
+        fontsApi: { addCustomFont, deleteCustomFont, fetchCustomFonts },
         settingsApi: { fetchSettings, updateSettings },
         pagesApi: { searchPages, getPageById },
         mediaApi: { uploadMedia },
@@ -127,6 +128,7 @@ function EditorSettings() {
       customFonts,
       addCustomFont,
       deleteCustomFont,
+      fetchCustomFonts,
       fetchPublisherLogos,
       addPublisherLogo,
       removePublisherLogo,
@@ -169,8 +171,9 @@ function EditorSettings() {
     if (canManageSettings) {
       fetchSettings();
       fetchPublisherLogos();
+      fetchCustomFonts();
     }
-  }, [fetchSettings, fetchPublisherLogos, canManageSettings]);
+  }, [fetchSettings, fetchPublisherLogos, canManageSettings, fetchCustomFonts]);
 
   useEffect(() => {
     if (newlyCreatedMediaIds.length > 0) {
@@ -224,21 +227,21 @@ function EditorSettings() {
         const errorText =
           files.length === 1
             ? sprintf(
-                /* translators: %s: max upload size for media */
-                __(
-                  'Sorry, this file is too big. Make sure your logo is under %s.',
-                  'web-stories'
-                ),
-                maxUploadFormatted
-              )
+              /* translators: %s: max upload size for media */
+              __(
+                'Sorry, this file is too big. Make sure your logo is under %s.',
+                'web-stories'
+              ),
+              maxUploadFormatted
+            )
             : sprintf(
-                /* translators: %s: max upload size for media */
-                __(
-                  'Sorry, one or more of these files are too big. Make sure your logos are all under %s.',
-                  'web-stories'
-                ),
-                maxUploadFormatted
-              );
+              /* translators: %s: max upload size for media */
+              __(
+                'Sorry, one or more of these files are too big. Make sure your logos are all under %s.',
+                'web-stories'
+              ),
+              maxUploadFormatted
+            );
         return setMediaError(errorText);
       }
 
@@ -246,13 +249,13 @@ function EditorSettings() {
         const errorText =
           files.length === 1
             ? __(
-                'Sorry, this file type is not supported. Only jpg, png, and static gifs are supported for publisher logos.',
-                'web-stories'
-              )
+              'Sorry, this file type is not supported. Only jpg, png, and static gifs are supported for publisher logos.',
+              'web-stories'
+            )
             : __(
-                'Sorry, one or more of these files are of an unsupported file type. Only jpg, png, and static gifs are supported for publisher logos.',
-                'web-stories'
-              );
+              'Sorry, one or more of these files are of an unsupported file type. Only jpg, png, and static gifs are supported for publisher logos.',
+              'web-stories'
+            );
         return setMediaError(errorText);
       }
 
@@ -264,13 +267,13 @@ function EditorSettings() {
         const errorText =
           files.length === 1
             ? __(
-                'Sorry, there was an error processing your upload. Please try again.',
-                'web-stories'
-              )
+              'Sorry, there was an error processing your upload. Please try again.',
+              'web-stories'
+            )
             : __(
-                'Sorry, there was an error processing one or more of your uploads. Please try again.',
-                'web-stories'
-              );
+              'Sorry, there was an error processing one or more of your uploads. Please try again.',
+              'web-stories'
+            );
         return setMediaError(errorText);
       }
 
@@ -283,21 +286,21 @@ function EditorSettings() {
         const errorText =
           files.length === 1
             ? sprintf(
-                /* translators: 1 = minimum width, 2 = minimum height */
-                __(
-                  'Sorry, this file is too small. Make sure your logo is larger than %s.',
-                  'web-stories'
-                ),
-                sprintf('%1$dx%2$dpx', MIN_IMG_WIDTH, MIN_IMG_HEIGHT)
-              )
+              /* translators: 1 = minimum width, 2 = minimum height */
+              __(
+                'Sorry, this file is too small. Make sure your logo is larger than %s.',
+                'web-stories'
+              ),
+              sprintf('%1$dx%2$dpx', MIN_IMG_WIDTH, MIN_IMG_HEIGHT)
+            )
             : sprintf(
-                /* translators: %s: image dimensions in pixels. */
-                __(
-                  'Sorry, one or more files are too small. Make sure your logos are all larger than %s.',
-                  'web-stories'
-                ),
-                sprintf('%1$dx%2$dpx', MIN_IMG_WIDTH, MIN_IMG_HEIGHT)
-              );
+              /* translators: %s: image dimensions in pixels. */
+              __(
+                'Sorry, one or more files are too small. Make sure your logos are all larger than %s.',
+                'web-stories'
+              ),
+              sprintf('%1$dx%2$dpx', MIN_IMG_WIDTH, MIN_IMG_HEIGHT)
+            );
         return setMediaError(errorText);
       }
 

--- a/packages/wp-dashboard/src/components/editorSettings/editorSettings.js
+++ b/packages/wp-dashboard/src/components/editorSettings/editorSettings.js
@@ -227,21 +227,21 @@ function EditorSettings() {
         const errorText =
           files.length === 1
             ? sprintf(
-              /* translators: %s: max upload size for media */
-              __(
-                'Sorry, this file is too big. Make sure your logo is under %s.',
-                'web-stories'
-              ),
-              maxUploadFormatted
-            )
+                /* translators: %s: max upload size for media */
+                __(
+                  'Sorry, this file is too big. Make sure your logo is under %s.',
+                  'web-stories'
+                ),
+                maxUploadFormatted
+              )
             : sprintf(
-              /* translators: %s: max upload size for media */
-              __(
-                'Sorry, one or more of these files are too big. Make sure your logos are all under %s.',
-                'web-stories'
-              ),
-              maxUploadFormatted
-            );
+                /* translators: %s: max upload size for media */
+                __(
+                  'Sorry, one or more of these files are too big. Make sure your logos are all under %s.',
+                  'web-stories'
+                ),
+                maxUploadFormatted
+              );
         return setMediaError(errorText);
       }
 
@@ -249,13 +249,13 @@ function EditorSettings() {
         const errorText =
           files.length === 1
             ? __(
-              'Sorry, this file type is not supported. Only jpg, png, and static gifs are supported for publisher logos.',
-              'web-stories'
-            )
+                'Sorry, this file type is not supported. Only jpg, png, and static gifs are supported for publisher logos.',
+                'web-stories'
+              )
             : __(
-              'Sorry, one or more of these files are of an unsupported file type. Only jpg, png, and static gifs are supported for publisher logos.',
-              'web-stories'
-            );
+                'Sorry, one or more of these files are of an unsupported file type. Only jpg, png, and static gifs are supported for publisher logos.',
+                'web-stories'
+              );
         return setMediaError(errorText);
       }
 
@@ -267,13 +267,13 @@ function EditorSettings() {
         const errorText =
           files.length === 1
             ? __(
-              'Sorry, there was an error processing your upload. Please try again.',
-              'web-stories'
-            )
+                'Sorry, there was an error processing your upload. Please try again.',
+                'web-stories'
+              )
             : __(
-              'Sorry, there was an error processing one or more of your uploads. Please try again.',
-              'web-stories'
-            );
+                'Sorry, there was an error processing one or more of your uploads. Please try again.',
+                'web-stories'
+              );
         return setMediaError(errorText);
       }
 
@@ -286,21 +286,21 @@ function EditorSettings() {
         const errorText =
           files.length === 1
             ? sprintf(
-              /* translators: 1 = minimum width, 2 = minimum height */
-              __(
-                'Sorry, this file is too small. Make sure your logo is larger than %s.',
-                'web-stories'
-              ),
-              sprintf('%1$dx%2$dpx', MIN_IMG_WIDTH, MIN_IMG_HEIGHT)
-            )
+                /* translators: 1 = minimum width, 2 = minimum height */
+                __(
+                  'Sorry, this file is too small. Make sure your logo is larger than %s.',
+                  'web-stories'
+                ),
+                sprintf('%1$dx%2$dpx', MIN_IMG_WIDTH, MIN_IMG_HEIGHT)
+              )
             : sprintf(
-              /* translators: %s: image dimensions in pixels. */
-              __(
-                'Sorry, one or more files are too small. Make sure your logos are all larger than %s.',
-                'web-stories'
-              ),
-              sprintf('%1$dx%2$dpx', MIN_IMG_WIDTH, MIN_IMG_HEIGHT)
-            );
+                /* translators: %s: image dimensions in pixels. */
+                __(
+                  'Sorry, one or more files are too small. Make sure your logos are all larger than %s.',
+                  'web-stories'
+                ),
+                sprintf('%1$dx%2$dpx', MIN_IMG_WIDTH, MIN_IMG_HEIGHT)
+              );
         return setMediaError(errorText);
       }
 

--- a/packages/wp-dashboard/src/components/editorSettings/test/editorSettings.js
+++ b/packages/wp-dashboard/src/components/editorSettings/test/editorSettings.js
@@ -180,7 +180,7 @@ function createProviderValues({
         fontsApi: {
           addCustomFont: mockAddCustomFont,
           deleteCustomFont: mockDeleteCustomFont,
-          fetchCustomFonts:  mockFetchCustomFonts,
+          fetchCustomFonts: mockFetchCustomFonts,
         },
       },
     },

--- a/packages/wp-dashboard/src/components/editorSettings/test/editorSettings.js
+++ b/packages/wp-dashboard/src/components/editorSettings/test/editorSettings.js
@@ -92,6 +92,7 @@ const mockRemovePublisherLogo = jest.fn();
 const mockSetPublisherLogoAsDefault = jest.fn();
 const mockAddCustomFont = jest.fn();
 const mockDeleteCustomFont = jest.fn();
+const mockFetchCustomFonts = jest.fn();
 
 function createProviderValues({
   canUploadFiles,
@@ -179,6 +180,7 @@ function createProviderValues({
         fontsApi: {
           addCustomFont: mockAddCustomFont,
           deleteCustomFont: mockDeleteCustomFont,
+          fetchCustomFonts:  mockFetchCustomFonts,
         },
       },
     },


### PR DESCRIPTION
## Context

The custom fonts REST API request should only be made when visiting the Settings page.

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Update to only call `fetchCustomFonts` when on the settings page

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Open dashboard
See no HTTP request in Network tab

2. Visit settings -- test for no regressions with Custom fonts


## Reviews

### Does this PR have a security-related impact?

No

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

No

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

No

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11650
