### PR TITLE
KSES: also sanitize story data for page templates

### DIFF
--- a/includes/KSES.php
+++ b/includes/KSES.php
@@ -94,11 +94,11 @@ class KSES extends Service_Base implements HasRequirements {
 	 *
 	 * @since 1.22.0
 	 *
-	 * @param string $post_type   Post type slug.
-	 * @param string $post_parent Parent post type slug.
+	 * @param string   $post_type   Post type slug.
+	 * @param int|null $post_parent Parent post ID.
 	 * @return bool Whether the user can edit the provided post type.
 	 */
-	private function is_allowed_post_type( string $post_type, string $post_parent ): bool {
+	private function is_allowed_post_type( string $post_type, ?int $post_parent ): bool {
 		if ( $this->story_post_type->get_slug() === $post_type && $this->story_post_type->has_cap( 'edit_posts' ) ) {
 			return true;
 		}

--- a/includes/KSES.php
+++ b/includes/KSES.php
@@ -45,14 +45,26 @@ class KSES extends Service_Base implements HasRequirements {
 	private $story_post_type;
 
 	/**
+	 * Page_Template_Post_Type instance.
+	 *
+	 * @var Page_Template_Post_Type Page_Template_Post_Type instance.
+	 */
+	private $page_template_post_type;
+
+	/**
 	 * KSES constructor.
 	 *
 	 * @since 1.12.0
 	 *
-	 * @param Story_Post_Type $story_post_type Story_Post_Type instance.
+	 * @param Story_Post_Type         $story_post_type         Story_Post_Type instance.
+	 * @param Page_Template_Post_Type $page_template_post_type Page_Template_Post_Type instance.
 	 */
-	public function __construct( Story_Post_Type $story_post_type ) {
-		$this->story_post_type = $story_post_type;
+	public function __construct(
+		Story_Post_Type $story_post_type,
+		Page_Template_Post_Type $page_template_post_type
+	) {
+		$this->story_post_type         = $story_post_type;
+		$this->page_template_post_type = $page_template_post_type;
 	}
 
 	/**
@@ -74,7 +86,37 @@ class KSES extends Service_Base implements HasRequirements {
 	 * @return string[] List of required services.
 	 */
 	public static function get_requirements(): array {
-		return [ 'story_post_type' ];
+		return [ 'story_post_type', 'page_template_post_type' ];
+	}
+
+	/**
+	 * Checks whether user has capability to edit the post type.
+	 *
+	 * @since 1.22.0
+	 *
+	 * @param string $post_type Post type slug.
+	 * @return bool Whether the user can edit the provided post type.
+	 */
+	private function has_capability( string $post_type ): bool {
+		return (
+			( $this->story_post_type->get_slug() === $post_type && $this->story_post_type->has_cap( 'edit_posts' ) ) ||
+			( $this->page_template_post_type->get_slug() === $post_type && $this->page_template_post_type->has_cap( 'edit_posts' ) )
+		);
+	}
+
+	/**
+	 * Filters story data.
+	 *
+	 * Provides simple sanity check to ensure story data is valid JSON.
+	 *
+	 * @since 1.22.0
+	 *
+	 * @param string $story_data JSON-encoded story data.
+	 * @return string Sanitized & slashed story data.
+	 */
+	private function filter_story_data( string $story_data ): string {
+		$decoded = json_decode( (string) wp_unslash( $story_data ), true );
+		return null === $decoded ? '' : wp_slash( (string) wp_json_encode( $decoded ) );
 	}
 
 	/**
@@ -99,8 +141,10 @@ class KSES extends Service_Base implements HasRequirements {
 			return $data;
 		}
 
+		$supported_post_types = [ $this->story_post_type->get_slug(), $this->page_template_post_type->get_slug() ];
+
 		if (
-			( $this->story_post_type->get_slug() !== $data['post_type'] ) && !
+			! \in_array( $data['post_type'], $supported_post_types, true ) && !
 			(
 				'revision' === $data['post_type'] &&
 				! empty( $data['post_parent'] ) &&
@@ -110,29 +154,26 @@ class KSES extends Service_Base implements HasRequirements {
 			return $data;
 		}
 
-		if ( ! $this->story_post_type->has_cap( 'edit_posts' ) ) {
+		if ( ! $this->has_capability( $data['post_type'] ) ) {
 			return $data;
 		}
 
-		// Simple sanity check to ensure story data is valid JSON.
 		if ( isset( $unsanitized_postarr['post_content_filtered'] ) ) {
-			$story_data                    = json_decode( (string) wp_unslash( $unsanitized_postarr['post_content_filtered'] ), true );
-			$data['post_content_filtered'] = null === $story_data ? '' : wp_slash( (string) wp_json_encode( $story_data ) );
+			$data['post_content_filtered'] = $this->filter_story_data( $unsanitized_postarr['post_content_filtered'] );
 		}
 
-		if ( ! isset( $unsanitized_postarr['post_content'] ) ) {
-			return $data;
+		if ( isset( $unsanitized_postarr['post_content'] ) ) {
+			add_filter( 'safe_style_css', [ $this, 'filter_safe_style_css' ] );
+			add_filter( 'wp_kses_allowed_html', [ $this, 'filter_kses_allowed_html' ], 10, 2 );
+
+			$unsanitized_postarr['post_content'] = $this->filter_content_save_pre_before_kses( $unsanitized_postarr['post_content'] );
+
+			$data['post_content'] = wp_filter_post_kses( $unsanitized_postarr['post_content'] );
+			$data['post_content'] = $this->filter_content_save_pre_after_kses( $data['post_content'] );
+
+			remove_filter( 'safe_style_css', [ $this, 'filter_safe_style_css' ] );
+			remove_filter( 'wp_kses_allowed_html', [ $this, 'filter_kses_allowed_html' ] );
 		}
-
-		add_filter( 'safe_style_css', [ $this, 'filter_safe_style_css' ] );
-		add_filter( 'wp_kses_allowed_html', [ $this, 'filter_kses_allowed_html' ], 10, 2 );
-
-		$unsanitized_postarr['post_content'] = $this->filter_content_save_pre_before_kses( $unsanitized_postarr['post_content'] );
-		$data['post_content']                = wp_filter_post_kses( $unsanitized_postarr['post_content'] );
-		$data['post_content']                = $this->filter_content_save_pre_after_kses( $data['post_content'] );
-
-		remove_filter( 'safe_style_css', [ $this, 'filter_safe_style_css' ] );
-		remove_filter( 'wp_kses_allowed_html', [ $this, 'filter_kses_allowed_html' ] );
 
 		return $data;
 	}

--- a/packages/wp-story-editor/src/api/pageTemplate.js
+++ b/packages/wp-story-editor/src/api/pageTemplate.js
@@ -79,7 +79,7 @@ export function getCustomPageTemplates(config, page = 1) {
  */
 export function addPageTemplate(config, data) {
   return apiFetch({
-    path: `${config.api.pageTemplates}/`,
+    path: config.api.pageTemplates,
     data: {
       ...data,
       status: 'publish',

--- a/tests/phpunit/integration/includes/Kses_Setup.php
+++ b/tests/phpunit/integration/includes/Kses_Setup.php
@@ -32,9 +32,11 @@ trait Kses_Setup {
 	 * Setup KSES init class.
 	 */
 	protected function kses_int(): void {
-		$settings   = $this->createMock( \Google\Web_Stories\Settings::class );
-		$this->kses = new \Google\Web_Stories\KSES(
-			new \Google\Web_Stories\Story_Post_Type( $settings )
+		$settings        = $this->createMock( \Google\Web_Stories\Settings::class );
+		$story_post_type = new \Google\Web_Stories\Story_Post_Type( $settings );
+		$this->kses      = new \Google\Web_Stories\KSES(
+			$story_post_type,
+			new \Google\Web_Stories\Page_Template_Post_Type( $story_post_type )
 		);
 		$this->kses->register();
 	}
@@ -45,8 +47,8 @@ trait Kses_Setup {
 	protected function kses_remove_filters(): void {
 		if ( ! current_user_can( 'unfiltered_html' ) ) {
 			remove_filter( 'safe_style_css', [ $this->kses, 'filter_safe_style_css' ] );
-			remove_filter( 'wp_kses_allowed_html', [ $this->kses, 'filter_kses_allowed_html' ], 10 );
-			remove_filter( 'content_save_pre', [ $this->kseshis, 'filter_content_save_pre_before_kses' ], 0 );
+			remove_filter( 'wp_kses_allowed_html', [ $this->kses, 'filter_kses_allowed_html' ] );
+			remove_filter( 'content_save_pre', [ $this->kses, 'filter_content_save_pre_before_kses' ], 0 );
 			remove_filter( 'content_save_pre', [ $this->kses, 'filter_content_save_pre_after_kses' ], 20 );
 		}
 		kses_init();

--- a/tests/phpunit/integration/tests/REST_API/Page_Template_Controller.php
+++ b/tests/phpunit/integration/tests/REST_API/Page_Template_Controller.php
@@ -163,4 +163,29 @@ class Page_Template_Controller extends RestTestCase {
 
 		$this->assertEquals( 3, $data['headers']['X-WP-Total'] );
 	}
+
+	/**
+	 * @covers ::create_item
+	 */
+	public function test_create_item_as_author_should_not_strip_markup(): void {
+		$this->controller->register_routes();
+
+		wp_set_current_user( self::$author_id );
+
+		$this->kses_int();
+
+		$unsanitized_story_data = json_decode( file_get_contents( WEB_STORIES_TEST_DATA_DIR . '/story_post_content_filtered.json' ), true );
+
+		$request = new WP_REST_Request( \WP_REST_Server::CREATABLE, '/web-stories/v1/web-story-page' );
+		$request->set_body_params(
+			[
+				'story_data' => $unsanitized_story_data,
+			]
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$new_data = $response->get_data();
+		$this->assertArrayHasKey( 'story_data', $new_data );
+		$this->assertSame( $unsanitized_story_data, $new_data['story_data'] );
+	}
 }


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

It was reported that contributors sometimes were unable to save custom page templates.

Turns out this was because the story_data JSON was not slashed properly (or too often), causing the data to be lost during save.

## Summary

<!-- A brief description of what this PR does. -->

This PR updates the KSES class so that it also runs for the `web-story-page` post type, so that the story data in `post_content_filtered` is preserved as expected. (`\Google\Web_Stories\KSES::filter_story_data()` is relevant here)

## Relevant Technical Choices

<!-- Please describe your changes. -->

Created a couple of helper methods to reduce complexity, avoiding PHPMD warnings.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. As a **Contributor** user, create a new story
2. Add some text and images to the page
3. Save page as a custom page template
4. Verify that the template is saved correctly and can be inserted to the story as expected


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

Updates the KSES class to run also for another post type, but that's it.

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11647