### PR TITLE
Editor: Make text selectable in Checklist and Shortcuts panels

### DIFF
--- a/packages/story-editor/src/components/keyboardShortcutsMenu/landmarkShortcuts.js
+++ b/packages/story-editor/src/components/keyboardShortcutsMenu/landmarkShortcuts.js
@@ -31,11 +31,12 @@ const LandmarksWrapper = styled.dl`
   padding: 16px 24px;
   display: flex;
   justify-content: space-between;
+  user-select: text;
 `;
 
 const Landmark = styled.div`
   display: flex;
-  flex-direction: column-reverse;
+  flex-direction: column;
 `;
 
 const Label = styled(Text).attrs({
@@ -53,10 +54,10 @@ function LandmarkShortcuts() {
     <LandmarksWrapper>
       {landmarks.map(({ label, shortcut }) => (
         <Landmark key={label}>
+          <ShortcutLabel keys={shortcut} />
           <dt>
             <Label>{label}</Label>
           </dt>
-          <ShortcutLabel keys={shortcut} />
         </Landmark>
       ))}
     </LandmarksWrapper>

--- a/packages/story-editor/src/components/keyboardShortcutsMenu/regularShortcuts.js
+++ b/packages/story-editor/src/components/keyboardShortcutsMenu/regularShortcuts.js
@@ -29,6 +29,10 @@ const ContentWrapper = styled.div`
   display: flex;
   flex-direction: column;
   margin: 0 24px 24px;
+
+  * {
+    user-select: text;
+  }
 `;
 
 function RegularShortcuts() {

--- a/packages/story-editor/src/components/keyboardShortcutsMenu/shortcutMenuSection.js
+++ b/packages/story-editor/src/components/keyboardShortcutsMenu/shortcutMenuSection.js
@@ -79,10 +79,10 @@ function ShortcutMenuSection({ title, commands }) {
       <List title={title}>
         {commands.map(({ label, shortcut }) => (
           <ListRow key={label}>
+            <ShortcutLabel keys={shortcut} alignment={'left'} />
             <dt>
               <Label>{label}</Label>
             </dt>
-            <ShortcutLabel keys={shortcut} alignment={'left'} />
           </ListRow>
         ))}
       </List>

--- a/packages/story-editor/src/components/tablist/styles.js
+++ b/packages/story-editor/src/components/tablist/styles.js
@@ -35,6 +35,10 @@ import { PANEL_STATES } from './constants';
 
 export const Tablist = styled.div.attrs({ role: 'tablist' })`
   background: ${({ theme }) => theme.colors.bg.primary};
+
+  * {
+    user-select: text;
+  }
 `;
 Tablist.propTypes = {
   // label to describe purpose of tabs


### PR DESCRIPTION
## Context

Text in 'Checklist' and 'Keyboard Shortcuts' panels should be user-selectable.

## Summary

'Checklist' and 'Keyboard Shortcuts' panels now have selectable text.

## Relevant Technical Choices

CSS rule `user-select: text` was applied to ancestor of the affected elements.

## To-do

None

## User-facing changes

<img width="336" alt="image" src="https://user-images.githubusercontent.com/4173034/172941120-cbbadee2-6742-4def-bd26-be78e2d13cf3.png">

<img width="336" alt="image" src="https://user-images.githubusercontent.com/4173034/172941245-c11cc23c-a3f4-4759-8064-5e1753d9d561.png">

<img width="379" alt="image" src="https://user-images.githubusercontent.com/4173034/172941338-3b7d3c81-2bfc-4115-8722-b11d9a0914da.png">

## Testing Instructions

Click the 'Checklist' or 'Keyboard Shortcuts' buttons on the left side (LTR) of the canvas footer to open the respective panels. Drag mouse cursor to select text in the body of the panel. Text should be selected and able to be copied.

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #11540 
