### PR TITLE
History: Reduce number of actions causing history pollution 

### DIFF
--- a/packages/story-editor/src/app/story/effects/useHistoryEntry.js
+++ b/packages/story-editor/src/app/story/effects/useHistoryEntry.js
@@ -25,7 +25,7 @@ import { useEffect, useRef } from '@googleforcreators/react';
  */
 import { useHistory } from '../../history';
 import deleteNestedKeys from '../utils/deleteNestedKeys';
-import skipBlobUrls from '../utils/skipBlobUrls';
+import pageContainsBlobUrl from '../utils/pageContainsBlobUrl';
 
 // Changes to these properties of elements do not create a new history entry
 // if only one (or multiple) of these properties change but nothing else changes.
@@ -112,7 +112,7 @@ function useHistoryEntry({ story, current, pages, selection, capabilities }) {
           JSON.stringify(adjustedPages) === JSON.stringify(adjustedEntryPages);
       }
 
-      if (skipBlobUrls(pages)) {
+      if (pageContainsBlobUrl(pages)) {
         skipAddingEntry = true;
       }
     }

--- a/packages/story-editor/src/app/story/effects/useHistoryEntry.js
+++ b/packages/story-editor/src/app/story/effects/useHistoryEntry.js
@@ -36,6 +36,7 @@ const ELEMENT_PROPS_TO_IGNORE = [
   'resource.isMuted',
   'resource.posterId',
   'resource.poster',
+  'resource.isOptimized',
   'resource.font.metrics',
   'resource.font.weights',
   'resource.font.variants',
@@ -103,6 +104,16 @@ function useHistoryEntry({ story, current, pages, selection, capabilities }) {
         skipAddingEntry =
           JSON.stringify(adjustedPages) === JSON.stringify(adjustedEntryPages);
       }
+
+      // skip entries that have a blob url
+      // https://github.com/GoogleForCreators/web-stories-wp/issues/10289
+      pages.map((page) => {
+        page.elements.forEach((element) => {
+          if (element?.resource?.src.includes('blob:')) {
+            skipAddingEntry = true;
+          }
+        });
+      });
     }
 
     if (!skipAddingEntry) {

--- a/packages/story-editor/src/app/story/effects/useHistoryEntry.js
+++ b/packages/story-editor/src/app/story/effects/useHistoryEntry.js
@@ -37,12 +37,18 @@ const ELEMENT_PROPS_TO_IGNORE = [
   'resource.isMuted',
   'resource.posterId',
   'resource.poster',
-  'resource.isOptimized',
   'resource.font.metrics',
   'resource.font.weights',
   'resource.font.variants',
   'resource.font.fallbacks',
   'resource.font.styles',
+  'resource.isOptimized',
+  'resource.length',
+  'resource.lengthFormatted',
+  'resource.trimData.original',
+  'resource.trimData.start',
+  'resource.trimData.end',
+  'resource.creationDate',
 ];
 
 // Record any change to core variables in history (history will know if it's a replay)
@@ -118,6 +124,15 @@ function useHistoryEntry({ story, current, pages, selection, capabilities }) {
     }
 
     if (!skipAddingEntry) {
+
+      console.log({
+        story,
+        current: currentPageIndexRef.current,
+        selection: selectedElementIdsRef.current,
+        pages,
+        capabilities,
+      });
+
       stateToHistory({
         story,
         current: currentPageIndexRef.current,

--- a/packages/story-editor/src/app/story/effects/useHistoryEntry.js
+++ b/packages/story-editor/src/app/story/effects/useHistoryEntry.js
@@ -19,6 +19,7 @@
  */
 import cloneDeep from 'clone-deep';
 import { useEffect, useRef } from '@googleforcreators/react';
+import { isBlobURL } from '@googleforcreators/media';
 
 /**
  * Internal dependencies
@@ -109,7 +110,7 @@ function useHistoryEntry({ story, current, pages, selection, capabilities }) {
       // https://github.com/GoogleForCreators/web-stories-wp/issues/10289
       pages.map((page) => {
         page.elements.forEach((element) => {
-          if (element?.resource?.src.includes('blob:')) {
+          if (isBlobURL(element?.resource?.src)) {
             skipAddingEntry = true;
           }
         });

--- a/packages/story-editor/src/app/story/effects/useHistoryEntry.js
+++ b/packages/story-editor/src/app/story/effects/useHistoryEntry.js
@@ -19,13 +19,13 @@
  */
 import cloneDeep from 'clone-deep';
 import { useEffect, useRef } from '@googleforcreators/react';
-import { isBlobURL } from '@googleforcreators/media';
 
 /**
  * Internal dependencies
  */
 import { useHistory } from '../../history';
 import deleteNestedKeys from '../utils/deleteNestedKeys';
+import skipBlobUrls from '../utils/skipBlobUrls';
 
 // Changes to these properties of elements do not create a new history entry
 // if only one (or multiple) of these properties change but nothing else changes.
@@ -106,15 +106,9 @@ function useHistoryEntry({ story, current, pages, selection, capabilities }) {
           JSON.stringify(adjustedPages) === JSON.stringify(adjustedEntryPages);
       }
 
-      // skip entries that have a blob url
-      // https://github.com/GoogleForCreators/web-stories-wp/issues/10289
-      pages.map((page) => {
-        page.elements.forEach((element) => {
-          if (isBlobURL(element?.resource?.src)) {
-            skipAddingEntry = true;
-          }
-        });
-      });
+      if (skipBlobUrls(pages)) {
+        skipAddingEntry = true;
+      }
     }
 
     if (!skipAddingEntry) {

--- a/packages/story-editor/src/app/story/effects/useHistoryEntry.js
+++ b/packages/story-editor/src/app/story/effects/useHistoryEntry.js
@@ -124,15 +124,6 @@ function useHistoryEntry({ story, current, pages, selection, capabilities }) {
     }
 
     if (!skipAddingEntry) {
-
-      console.log({
-        story,
-        current: currentPageIndexRef.current,
-        selection: selectedElementIdsRef.current,
-        pages,
-        capabilities,
-      });
-
       stateToHistory({
         story,
         current: currentPageIndexRef.current,

--- a/packages/story-editor/src/app/story/utils/pageContainsBlobUrl.js
+++ b/packages/story-editor/src/app/story/utils/pageContainsBlobUrl.js
@@ -21,7 +21,7 @@ import { isBlobURL } from '@googleforcreators/media';
 function pageContainsBlobUrl(pages) {
   // skip entries that have a blob url
   // https://github.com/GoogleForCreators/web-stories-wp/issues/10289
-  return pages.map((page) => {
+  const result = pages.map((page) => {
     return page.elements.some((element) => {
       if (
         isBlobURL(element?.resource?.src) ||
@@ -30,7 +30,9 @@ function pageContainsBlobUrl(pages) {
         return true;
       }
     });
-  })[0];
+  });
+
+  return result.includes(true);
 }
 
 export default pageContainsBlobUrl;

--- a/packages/story-editor/src/app/story/utils/pageContainsBlobUrl.js
+++ b/packages/story-editor/src/app/story/utils/pageContainsBlobUrl.js
@@ -21,18 +21,13 @@ import { isBlobURL } from '@googleforcreators/media';
 function pageContainsBlobUrl(pages) {
   // skip entries that have a blob url
   // https://github.com/GoogleForCreators/web-stories-wp/issues/10289
-  const result = pages.map((page) => {
-    return page.elements.some((element) => {
-      if (
+  return pages.some((page) =>
+    page.elements.some(
+      (element) =>
         isBlobURL(element?.resource?.src) ||
         isBlobURL(element?.resource?.poster)
-      ) {
-        return true;
-      }
-    });
-  });
-
-  return result.includes(true);
+    )
+  );
 }
 
 export default pageContainsBlobUrl;

--- a/packages/story-editor/src/app/story/utils/pageContainsBlobUrl.js
+++ b/packages/story-editor/src/app/story/utils/pageContainsBlobUrl.js
@@ -18,22 +18,19 @@
  */
 import { isBlobURL } from '@googleforcreators/media';
 
-function skipBlobUrls(pages) {
+function pageContainsBlobUrl(pages) {
   // skip entries that have a blob url
   // https://github.com/GoogleForCreators/web-stories-wp/issues/10289
-  let skip = false;
-  pages.map((page) => {
-    page.elements.forEach((element) => {
+  return pages.map((page) => {
+    return page.elements.some((element) => {
       if (
         isBlobURL(element?.resource?.src) ||
         isBlobURL(element?.resource?.poster)
       ) {
-        skip = true;
+        return true;
       }
     });
-  });
-
-  return skip;
+  })[0];
 }
 
-export default skipBlobUrls;
+export default pageContainsBlobUrl;

--- a/packages/story-editor/src/app/story/utils/skipBlobUrls.js
+++ b/packages/story-editor/src/app/story/utils/skipBlobUrls.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { isBlobURL } from '@googleforcreators/media';
+
+function skipBlobUrls(pages) {
+  // skip entries that have a blob url
+  // https://github.com/GoogleForCreators/web-stories-wp/issues/10289
+  let skip = false;
+  pages.map((page) => {
+    page.elements.forEach((element) => {
+      if (
+        isBlobURL(element?.resource?.src) ||
+        isBlobURL(element?.resource?.poster)
+      ) {
+        skip = true;
+      }
+    });
+  });
+
+  return skip;
+}
+
+export default skipBlobUrls;

--- a/packages/story-editor/src/app/story/utils/test/pageContainsBlobUrl.js
+++ b/packages/story-editor/src/app/story/utils/test/pageContainsBlobUrl.js
@@ -2,64 +2,81 @@ import pageContainsBlobUrl from '../pageContainsBlobUrl';
 
 describe('pageContainsBlobUrl', () => {
   it('should find resource entry with blob url', () => {
-    const pages = {
-      elements: [
-        {
-          resource: {
-            src: 'https://example.com/bcee4374-8f8a-4210-8f2d-9c5f8d6a6c5a',
+    const pages = [
+      {
+        elements: [
+          {
+            resource: {
+              src: 'https://example.com/bcee4374-8f8a-4210-8f2d-9c5f8d6a6c5a',
+            },
           },
-        },
-        {
-          resource: {
-            src: 'blob:https://example.com/ecee4374-8f8a-4210-8f2d-9c5f8d6a6c5a',
+          {
+            resource: {
+              src: 'blob:https://example.com/ecee4374-8f8a-4210-8f2d-9c5f8d6a6c5a',
+            },
           },
-        },
-      ],
-    };
+        ]
+      },
+    ];
     expect(pageContainsBlobUrl(pages)).toStrictEqual(true);
   });
 
   it('should find resource poster entry with blob url', () => {
-    const pages = {
-      elements: [
-        {
-          resource: {
-            poster: 'https://example.com/ecee4374-8f8a-4210-8f2d-9c5f8d6a6c5a',
+    const pages = [
+      {
+        elements: [
+          {
+            type: 'text',
+            font: {
+              family: 'Arial',
+              service: 'system',
+            }
           },
-        },
-        {
-          resource: {
-            poster:
-              'blob:https://example.com/ecee4374-8f8a-4210-8f2d-9c5f8d6a6c5a',
+        ]
+      },
+      {
+        elements: [
+          {
+            resource: {
+              poster: 'https://example.com/ecee4374-8f8a-4210-8f2d-9c5f8d6a6c5a',
+            },
           },
-        },
-      ],
-    };
+          {
+            resource: {
+              poster:
+                'blob:https://example.com/ecee4374-8f8a-4210-8f2d-9c5f8d6a6c5a',
+            },
+          },
+        ]
+      },
+    ];
     expect(pageContainsBlobUrl(pages)).toStrictEqual(true);
   });
 
   it('should allow page entries without blob urls', () => {
-    const pages = {
-      elements: [
-        {
-          type: 'text',
-          font: {
-            family: 'Arial',
-            service: 'system',
+    const pages = [
+      {
+        elements: [
+          {
+            type: 'text',
+            font: {
+              family: 'Arial',
+              service: 'system',
+            },
           },
-        },
-        {
-          resource: {
-            src: 'https://example.com/bcee4374-8f8a-4210-8f2d-9c5f8d6a6c5a',
+          {
+            resource: {
+              src: 'https://example.com/bcee4374-8f8a-4210-8f2d-9c5f8d6a6c5a',
+            },
           },
-        },
-        {
-          resource: {
-            src: 'https://example.com/ccee4374-8f8a-4210-8f2d-9c5f8d6a6c5a',
+          {
+            resource: {
+              src: 'https://example.com/ccee4374-8f8a-4210-8f2d-9c5f8d6a6c5a',
+            },
           },
-        },
-      ],
-    };
+        ]
+      },
+    ];
 
     expect(pageContainsBlobUrl(pages)).toStrictEqual(false);
   });

--- a/packages/story-editor/src/app/story/utils/test/pageContainsBlobUrl.js
+++ b/packages/story-editor/src/app/story/utils/test/pageContainsBlobUrl.js
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
 import pageContainsBlobUrl from '../pageContainsBlobUrl';
 
 describe('pageContainsBlobUrl', () => {
@@ -15,10 +33,10 @@ describe('pageContainsBlobUrl', () => {
               src: 'blob:https://example.com/ecee4374-8f8a-4210-8f2d-9c5f8d6a6c5a',
             },
           },
-        ]
+        ],
       },
     ];
-    expect(pageContainsBlobUrl(pages)).toStrictEqual(true);
+    expect(pageContainsBlobUrl(pages)).toBe(true);
   });
 
   it('should find resource poster entry with blob url', () => {
@@ -30,15 +48,16 @@ describe('pageContainsBlobUrl', () => {
             font: {
               family: 'Arial',
               service: 'system',
-            }
+            },
           },
-        ]
+        ],
       },
       {
         elements: [
           {
             resource: {
-              poster: 'https://example.com/ecee4374-8f8a-4210-8f2d-9c5f8d6a6c5a',
+              poster:
+                'https://example.com/ecee4374-8f8a-4210-8f2d-9c5f8d6a6c5a',
             },
           },
           {
@@ -47,10 +66,10 @@ describe('pageContainsBlobUrl', () => {
                 'blob:https://example.com/ecee4374-8f8a-4210-8f2d-9c5f8d6a6c5a',
             },
           },
-        ]
+        ],
       },
     ];
-    expect(pageContainsBlobUrl(pages)).toStrictEqual(true);
+    expect(pageContainsBlobUrl(pages)).toBe(true);
   });
 
   it('should allow page entries without blob urls', () => {
@@ -74,10 +93,10 @@ describe('pageContainsBlobUrl', () => {
               src: 'https://example.com/ccee4374-8f8a-4210-8f2d-9c5f8d6a6c5a',
             },
           },
-        ]
+        ],
       },
     ];
 
-    expect(pageContainsBlobUrl(pages)).toStrictEqual(false);
+    expect(pageContainsBlobUrl(pages)).toBe(false);
   });
 });

--- a/packages/story-editor/src/app/story/utils/test/pageContainsBlobUrl.js
+++ b/packages/story-editor/src/app/story/utils/test/pageContainsBlobUrl.js
@@ -1,0 +1,66 @@
+import pageContainsBlobUrl from '../pageContainsBlobUrl';
+
+describe('pageContainsBlobUrl', () => {
+  it('should find resource entry with blob url', () => {
+    const pages = {
+      elements: [
+        {
+          resource: {
+            src: 'https://example.com/bcee4374-8f8a-4210-8f2d-9c5f8d6a6c5a',
+          },
+        },
+        {
+          resource: {
+            src: 'blob:https://example.com/ecee4374-8f8a-4210-8f2d-9c5f8d6a6c5a',
+          },
+        },
+      ],
+    };
+    expect(pageContainsBlobUrl(pages)).toStrictEqual(true);
+  });
+
+  it('should find resource poster entry with blob url', () => {
+    const pages = {
+      elements: [
+        {
+          resource: {
+            poster: 'https://example.com/ecee4374-8f8a-4210-8f2d-9c5f8d6a6c5a',
+          },
+        },
+        {
+          resource: {
+            poster:
+              'blob:https://example.com/ecee4374-8f8a-4210-8f2d-9c5f8d6a6c5a',
+          },
+        },
+      ],
+    };
+    expect(pageContainsBlobUrl(pages)).toStrictEqual(true);
+  });
+
+  it('should allow page entries without blob urls', () => {
+    const pages = {
+      elements: [
+        {
+          type: 'text',
+          font: {
+            family: 'Arial',
+            service: 'system',
+          },
+        },
+        {
+          resource: {
+            src: 'https://example.com/bcee4374-8f8a-4210-8f2d-9c5f8d6a6c5a',
+          },
+        },
+        {
+          resource: {
+            src: 'https://example.com/ccee4374-8f8a-4210-8f2d-9c5f8d6a6c5a',
+          },
+        },
+      ],
+    };
+
+    expect(pageContainsBlobUrl(pages)).toStrictEqual(false);
+  });
+});


### PR DESCRIPTION
## Context

Currently, some actions require multiple clicks of "Undo" because of history pollution (unnecessary entries). 

See: https://github.com/GoogleForCreators/web-stories-wp/issues/10289


<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

This PR adds an ignore for `resource.isOptimized` and skips entries that have a `blob` url for an element.

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

This PR needs testing across the various scenarios see testing Instructions

- Demo video with fix  https://www.youtube.com/watch?v=QMy05XaCDjg

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

👉  Note what's happening on current main
Actions take multiple undos to revert and sometimes end up in a broken state
- https://www.youtube.com/watch?v=9VpjT2PbjDw
- https://github.com/GoogleForCreators/web-stories-wp/issues/10289#issuecomment-1148664264

<hr>

 **1) Uploading Video directly onto a Page**
Upload a video onto the stage --- undo the upload .... video should be removed from the stage with a single undo. 

**2) Trim a video**
Note the original video length.  Trim video to x amount. Undo the trim -- the video length should now be reverted to the original length with a single undo.

**3) Remove audio from a video**
Remove the audio, undo --- the undo should restore the audio with a single undo.




## Reviews

### Does this PR have a security-related impact?

No

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

No

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

No

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10289
