### PR TITLE
Use icon button for products sort dropdown

### DIFF
--- a/packages/design-system/src/icons/index.js
+++ b/packages/design-system/src/icons/index.js
@@ -123,6 +123,7 @@ export { default as Rotate } from './rotate.svg';
 export { default as Scissors } from './scissors.svg';
 export { default as Shapes } from './shapes.svg';
 export { default as Shopping } from './shopping.svg';
+export { default as Sort } from './sort.svg';
 export { default as Sparkles } from './sparkles.svg';
 export { default as StopFilled } from './stop_filled.svg';
 export { default as StopOutline } from './stop_outline.svg';

--- a/packages/design-system/src/icons/sort.svg
+++ b/packages/design-system/src/icons/sort.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="48" width="48"><path d="M6 36V33H18V36ZM6 15V12H42V15ZM6 25.5V22.5H30V25.5Z" fill="currentColor"/></svg>

--- a/packages/story-editor/src/components/library/panes/shopping/productSort.js
+++ b/packages/story-editor/src/components/library/panes/shopping/productSort.js
@@ -17,62 +17,109 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
+import styled, { css } from 'styled-components';
 import { __ } from '@googleforcreators/i18n';
-import { Datalist } from '@googleforcreators/design-system';
-import styled from 'styled-components';
+import { Icons } from '@googleforcreators/design-system';
+import { useCallback, useState } from '@googleforcreators/react';
 
-const StyledContainer = styled.div`
+/**
+ * Internal dependencies
+ */
+import Tooltip from '../../../tooltip';
+import DropDownMenu from '../../../panels/shared/media/dropDownMenu';
+
+const StyledDropDownMenu = styled(DropDownMenu)`
   margin-left: 12px;
 `;
 
-function SortDropdown({ onChange, sortId }) {
-  const options = [
-    {
-      orderby: 'date',
-      order: 'desc',
-      name: __('Recently Added', 'web-stories'),
+const StyledIcon = styled(Icons.Sort)`
+  width: 28px !important;
+  height: 28px !important;
+`;
+
+const menuStylesOverride = css`
+  min-width: 180px;
+  margin-top: 0;
+`;
+
+const options = [
+  {
+    value: 'date-desc',
+    orderby: 'date',
+    order: 'desc',
+    label: __('Recently Added', 'web-stories'),
+  },
+  {
+    value: 'title-asc',
+    orderby: 'title',
+    order: 'asc',
+    label: __('Alphabetical: A-Z', 'web-stories'),
+  },
+  {
+    value: 'title-desc',
+    orderby: 'title',
+    order: 'desc',
+    label: __('Alphabetical: Z-A', 'web-stories'),
+  },
+  {
+    value: 'price-asc',
+    orderby: 'price',
+    order: 'asc',
+    label: __('Lowest Price', 'web-stories'),
+  },
+  {
+    value: 'price-desc',
+    orderby: 'price',
+    order: 'desc',
+    label: __('Highest Price', 'web-stories'),
+  },
+];
+
+function ProductSort({ onChange, value = 'date-desc' }) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const onMenuOpen = () => setIsMenuOpen(true);
+  const onMenuClose = () => setIsMenuOpen(false);
+  const onMenuSelected = useCallback(
+    (newValue) => {
+      setIsMenuOpen(false);
+      onChange(options.find((option) => option.value === newValue));
     },
+    [onChange]
+  );
+
+  const optionsWithGroup = [
     {
-      orderby: 'title',
-      order: 'asc',
-      name: __('Alphabetical: A-Z', 'web-stories'),
-    },
-    {
-      orderby: 'title',
-      order: 'desc',
-      name: __('Alphabetical: Z-A', 'web-stories'),
-    },
-    {
-      orderby: 'price',
-      order: 'asc',
-      name: __('Price: low to high', 'web-stories'),
-    },
-    {
-      orderby: 'price',
-      order: 'desc',
-      name: __('Price: high to low', 'web-stories'),
+      group: options.map((option) => ({
+        value: `${option.orderby}-${option.order}`,
+        ...option,
+      })),
     },
   ];
 
   return (
-    <StyledContainer>
-      <Datalist.DropDown
-        dropDownLabel={__('Sort', 'web-stories')}
-        onChange={onChange}
-        selectedId={sortId}
-        options={options.map((option) => ({
-          id: `${option.orderby}-${option.order}`,
-          ...option,
-        }))}
-        aria-label={__('Product sort options', 'web-stories')}
-      />
-    </StyledContainer>
+    <StyledDropDownMenu
+      onMenuOpen={onMenuOpen}
+      isMenuOpen={isMenuOpen}
+      onMenuSelected={onMenuSelected}
+      display
+      onMenuClose={onMenuClose}
+      options={optionsWithGroup}
+      ariaLabel={__('Product sort options', 'web-stories')}
+      activeValue={value}
+      dropDownHeight={340}
+      menuStylesOverride={menuStylesOverride}
+    >
+      <Tooltip title={__('Sort', 'web-stories')}>
+        <StyledIcon />
+      </Tooltip>
+    </StyledDropDownMenu>
   );
 }
 
-SortDropdown.propTypes = {
-  sortId: PropTypes.string,
+ProductSort.propTypes = {
+  value: PropTypes.string,
   onChange: PropTypes.func.isRequired,
 };
 
-export default SortDropdown;
+export default ProductSort;

--- a/packages/story-editor/src/components/library/panes/shopping/shoppingPane.js
+++ b/packages/story-editor/src/components/library/panes/shopping/shoppingPane.js
@@ -233,7 +233,7 @@ function ShoppingPane(props) {
               clearId="clear-product-search"
               handleClearInput={handleClearInput}
             />
-            <ProductSort onChange={onSortBy} sortId={`${orderby}-${order}`} />
+            <ProductSort onChange={onSortBy} value={`${orderby}-${order}`} />
           </Row>
         )}
         {isLoading && (

--- a/packages/story-editor/src/components/panels/shared/media/dropDownMenu.js
+++ b/packages/story-editor/src/components/panels/shared/media/dropDownMenu.js
@@ -29,10 +29,11 @@ import { __ } from '@googleforcreators/i18n';
 import { v4 as uuidv4 } from 'uuid';
 import {
   Menu,
-  PLACEMENT,
   Popup,
   useKeyDownEffect,
   noop,
+  PLACEMENT,
+  Icons,
   Button,
   BUTTON_VARIANTS,
   BUTTON_TYPES,
@@ -66,9 +67,13 @@ const MenuContainer = styled.div`
 const menuStylesOverride = css`
   min-width: 160px;
   margin-top: 0;
-  li {
-    display: block;
-  }
+`;
+
+const ActiveIcon = styled(Icons.CheckmarkSmall)`
+  position: absolute;
+  left: 4px;
+  top: 50%;
+  transform: translateY(-50%);
 `;
 
 // This is used for nested roving tab index to detect parent siblings.
@@ -116,6 +121,14 @@ const CustomItemRenderer = forwardRef(function CustomItemRenderer(
       disabled={option.disabled}
       aria-disabled={option.disabled}
     >
+      {isSelected && (
+        <ActiveIcon
+          data-testid={'dropdownMenuItem_active_icon'}
+          aria-label={__('Selected', 'web-stories')}
+          width={32}
+          height={32}
+        />
+      )}
       <DefaultListItemLabelDisplayText
         forwardedAs="span"
         size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}
@@ -143,7 +156,8 @@ CustomItemRenderer.propTypes = {
  * @param {Function} props.setParentActive Sets the parent element active.
  * @param {Array} props.options Menu items.
  * @param {Object} props.children Children.
- * @param {Object} props.ariaLabel ARIA label for the toggle button.
+ * @param {string} props.ariaLabel ARIA label for the toggle button.
+ * @param {string} props.className Class name.
  * @return {null|*} Element or null.
  */
 function DropDownMenu({
@@ -156,6 +170,8 @@ function DropDownMenu({
   options,
   children,
   ariaLabel = __('More', 'web-stories'),
+  className,
+  ...rest
 }) {
   const MenuButtonRef = useRef();
 
@@ -186,7 +202,7 @@ function DropDownMenu({
 
   // Keep icon and menu displayed if menu is open (even if user's mouse leaves the area).
   return (
-    <MenuContainer>
+    <MenuContainer className={className}>
       <MenuButton
         type={BUTTON_TYPES.TERTIARY}
         size={BUTTON_SIZES.SMALL}
@@ -220,6 +236,7 @@ function DropDownMenu({
               hasMenuRole
               menuStylesOverride={menuStylesOverride}
               renderItem={CustomItemRenderer}
+              {...rest}
             />
           </DropDownContainer>
         </Popup>
@@ -238,6 +255,7 @@ DropDownMenu.propTypes = {
   options: PropTypes.array,
   children: PropTypes.node,
   ariaLabel: PropTypes.string,
+  className: PropTypes.string,
 };
 
 export default DropDownMenu;


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

This is a follow-up to #11253

## Summary

<!-- A brief description of what this PR does. -->

Uses an icon button for products sort dropdown that uses less space.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->
![Screenshot 2022-06-13 at 15 14 06](https://user-images.githubusercontent.com/841956/173367005-df1348bd-1431-461c-8e53-8078a9735497.png)
![Screenshot 2022-06-13 at 15 14 18](https://user-images.githubusercontent.com/841956/173367010-46052625-f3b3-441c-afc1-84ef6983c869.png)

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Sort products by all the options and verify that it works as expected
2. The selected sort option should have a checkmark next to it


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
