### PR TITLE
Shopping: Add right click menu for products 

### DIFF
--- a/packages/story-editor/src/app/rightClickMenu/menus/index.js
+++ b/packages/story-editor/src/app/rightClickMenu/menus/index.js
@@ -20,3 +20,4 @@ export { default as PageMenu } from './pageMenu';
 export { default as ShapeMenu } from './shapeMenu';
 export { default as StickerMenu } from './stickerMenu';
 export { default as TextMenu } from './textMenu';
+export { default as ProductMenu } from './productMenu';

--- a/packages/story-editor/src/app/rightClickMenu/menus/productMenu.js
+++ b/packages/story-editor/src/app/rightClickMenu/menus/productMenu.js
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+
+import {
+  ContextMenu,
+  ContextMenuComponents,
+} from '@googleforcreators/design-system';
+import { useRef } from '@googleforcreators/react';
+/**
+ * Internal dependencies
+ */
+import {
+  RIGHT_CLICK_MENU_LABELS,
+  RIGHT_CLICK_MENU_SHORTCUTS,
+} from '../constants';
+import { useLayerActions } from '../hooks';
+import useLayerSelect from '../useLayerSelect';
+import { LayerLock, LayerName, LayerUngroup } from '../items';
+import useRightClickMenu from '../useRightClickMenu';
+import {
+  DEFAULT_DISPLACEMENT,
+  MenuPropType,
+  SubMenuContainer,
+  SUB_MENU_ARIA_LABEL,
+} from './shared';
+
+function ProductMenu({ parentMenuRef }) {
+  const {
+    canElementMoveBackwards,
+    canElementMoveForwards,
+    handleSendBackward,
+    handleSendToBack,
+    handleBringForward,
+    handleBringToFront,
+  } = useLayerActions();
+
+  const subMenuRef = useRef();
+  const { menuPosition, onCloseMenu } = useRightClickMenu();
+  const layerSelectProps = useLayerSelect({
+    menuPosition,
+    isMenuOpen: true,
+  });
+
+  const { closeSubMenu, isSubMenuOpen, subMenuItems, ...subMenuTriggerProps } =
+    layerSelectProps || {};
+
+  return (
+    <>
+      {layerSelectProps && (
+        <>
+          <ContextMenuComponents.SubMenuTrigger
+            closeSubMenu={closeSubMenu}
+            parentMenuRef={parentMenuRef}
+            subMenuRef={subMenuRef}
+            isSubMenuOpen={isSubMenuOpen}
+            {...subMenuTriggerProps}
+          />
+          <SubMenuContainer
+            ref={subMenuRef}
+            position={{
+              x:
+                (parentMenuRef.current.firstChild?.offsetWidth ||
+                  DEFAULT_DISPLACEMENT) + 2,
+              y: 0,
+            }}
+          >
+            <ContextMenu
+              onDismiss={onCloseMenu}
+              isOpen={isSubMenuOpen}
+              onCloseSubMenu={closeSubMenu}
+              aria-label={SUB_MENU_ARIA_LABEL}
+              isSubMenu
+              parentMenuRef={parentMenuRef}
+            >
+              {subMenuItems.map(({ key, ...menuItemProps }) => (
+                <ContextMenuComponents.MenuItem key={key} {...menuItemProps} />
+              ))}
+            </ContextMenu>
+          </SubMenuContainer>
+          <ContextMenuComponents.MenuSeparator />
+        </>
+      )}
+
+      <ContextMenuComponents.MenuButton
+        disabled={!canElementMoveBackwards}
+        onClick={handleSendBackward}
+      >
+        {RIGHT_CLICK_MENU_LABELS.SEND_BACKWARD}
+        <ContextMenuComponents.MenuShortcut>
+          {RIGHT_CLICK_MENU_SHORTCUTS.SEND_BACKWARD.display}
+        </ContextMenuComponents.MenuShortcut>
+      </ContextMenuComponents.MenuButton>
+      <ContextMenuComponents.MenuButton
+        disabled={!canElementMoveBackwards}
+        onClick={handleSendToBack}
+      >
+        {RIGHT_CLICK_MENU_LABELS.SEND_TO_BACK}
+        <ContextMenuComponents.MenuShortcut>
+          {RIGHT_CLICK_MENU_SHORTCUTS.SEND_TO_BACK.display}
+        </ContextMenuComponents.MenuShortcut>
+      </ContextMenuComponents.MenuButton>
+      <ContextMenuComponents.MenuButton
+        disabled={!canElementMoveForwards}
+        onClick={handleBringForward}
+      >
+        {RIGHT_CLICK_MENU_LABELS.BRING_FORWARD}
+        <ContextMenuComponents.MenuShortcut>
+          {RIGHT_CLICK_MENU_SHORTCUTS.BRING_FORWARD.display}
+        </ContextMenuComponents.MenuShortcut>
+      </ContextMenuComponents.MenuButton>
+      <ContextMenuComponents.MenuButton
+        disabled={!canElementMoveForwards}
+        onClick={handleBringToFront}
+      >
+        {RIGHT_CLICK_MENU_LABELS.BRING_TO_FRONT}
+        <ContextMenuComponents.MenuShortcut>
+          {RIGHT_CLICK_MENU_SHORTCUTS.BRING_TO_FRONT.display}
+        </ContextMenuComponents.MenuShortcut>
+      </ContextMenuComponents.MenuButton>
+
+      <LayerName />
+      <LayerLock />
+      <LayerUngroup />
+    </>
+  );
+}
+ProductMenu.propTypes = MenuPropType;
+
+export default ProductMenu;

--- a/packages/story-editor/src/components/canvas/karma/rightClickMenu.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/rightClickMenu.karma.js
@@ -34,6 +34,7 @@ describe('Right Click Menu integration', () => {
 
   beforeEach(async () => {
     fixture = new Fixture();
+    fixture.setFlags({ shoppingIntegration: true });
     await fixture.render();
     await fixture.collapseHelpCenter();
     await fixture.events.click(fixture.editor.footer.layerPanel.togglePanel);
@@ -365,6 +366,28 @@ describe('Right Click Menu integration', () => {
         },
         link: null,
         ...shapePartial,
+      })
+    );
+  }
+
+  /**
+   * Add product to canvas
+   *
+   * @param productPartial Object with product properties to override defaults.
+   * @return {Object} the product element
+   */
+  function addProduct(productPartial = {}) {
+    return fixture.act(() =>
+      insertElement('product', {
+        x: 10,
+        y: 10,
+        width: 50,
+        height: 50,
+        product: {
+          productId: 'kt-38',
+          productTitle: 'Logo Collection',
+        },
+        ...productPartial,
       })
     );
   }
@@ -1424,6 +1447,27 @@ describe('Right Click Menu integration', () => {
       );
 
       expect(unmaskedElement.mask.type).toEqual('rectangle');
+    });
+  });
+
+  describe('right click menu: product', () => {
+    it('product has right click menu', async () => {
+      const product = await addProduct({});
+      const productElement = fixture.editor.canvas.framesLayer.frame(
+        product.id
+      ).node;
+      await rightClickOnTarget(productElement);
+      await fixture.events.click(selectLayerButton());
+
+      const productItem = fixture.screen.getByRole('menuitem', {
+        name: /^Logo Collection$/,
+      });
+
+      expect(productItem).toBeDefined();
+      expect(sendBackward().disabled).toBeTrue();
+      expect(sendToBack().disabled).toBeTrue();
+      expect(bringForward().disabled).toBeTrue();
+      expect(bringToFront().disabled).toBeTrue();
     });
   });
 });

--- a/packages/story-editor/src/components/canvas/karma/rightClickMenu.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/rightClickMenu.karma.js
@@ -373,7 +373,7 @@ describe('Right Click Menu integration', () => {
   /**
    * Add product to canvas
    *
-   * @param productPartial Object with product properties to override defaults.
+   * @param {Object} productPartial Object with product properties to override defaults.
    * @return {Object} the product element
    */
   function addProduct(productPartial = {}) {

--- a/packages/story-editor/src/components/canvas/rightClickMenu.js
+++ b/packages/story-editor/src/components/canvas/rightClickMenu.js
@@ -40,6 +40,7 @@ import {
   ShapeMenu,
   StickerMenu,
   TextMenu,
+  ProductMenu,
 } from '../../app/rightClickMenu';
 import isEmptyStory from '../../app/story/utils/isEmptyStory';
 import EmptyStateMenu from '../../app/rightClickMenu/menus/emptyStateMenu';
@@ -97,6 +98,8 @@ const RightClickMenu = () => {
         return TextMenu;
       case ELEMENT_TYPES.STICKER:
         return StickerMenu;
+      case ELEMENT_TYPES.PRODUCT:
+        return ProductMenu;
       default:
         return PageMenu;
     }


### PR DESCRIPTION
## Context

Right now there's no right click menu defined for products so when you try to right click on a product you'll actually see the menu for the page underneath it.

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Adds right click menu for products.  This matches the `stickers` menu outside of the `duplicate elements` has been removed.

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

Add test

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Enable shopping feature
2. Add a product 
3. Right click to display the new product menu


## Reviews

### Does this PR have a security-related impact?

No

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

No

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

No

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11711
