### PR TITLE
Separate page and shopping attachments

### DIFF
--- a/packages/output/src/page.js
+++ b/packages/output/src/page.js
@@ -52,7 +52,8 @@ function OutputPage({
     elements,
     backgroundColor,
     backgroundAudio,
-    pageAttachment,
+    pageAttachment = {},
+    shoppingAttachment = {},
   } = page;
 
   const [backgroundElement, ...otherElements] = elements;
@@ -107,6 +108,9 @@ function OutputPage({
     .filter(({ type }) => type === ELEMENT_TYPES.PRODUCT)
     .map(({ product }) => product)
     .filter(Boolean);
+
+  const hasProducts = products.length > 0 && flags?.shoppingIntegration;
+  const hasPageAttachment = pageAttachment?.url && !hasProducts;
 
   const videoCaptions = elements
     .filter(
@@ -201,9 +205,9 @@ function OutputPage({
       )}
 
       {/* <amp-story-page-outlink> needs to be the last child element */}
-      {pageAttachment?.url && <Outlink {...pageAttachment} />}
-      {products.length > 0 && flags?.shoppingIntegration && (
-        <ShoppingAttachment products={products} {...pageAttachment} />
+      {hasPageAttachment && <Outlink {...pageAttachment} />}
+      {hasProducts && (
+        <ShoppingAttachment products={products} {...shoppingAttachment} />
       )}
     </amp-story-page>
   );

--- a/packages/output/src/test/page.js
+++ b/packages/output/src/test/page.js
@@ -1590,7 +1590,7 @@ describe('Page output', () => {
         backgroundColor: { color: { r: 255, g: 255, b: 255 } },
         page: {
           id: 'bar',
-          pageAttachment: {
+          shoppingAttachment: {
             theme: 'light',
             ctaText: 'Buy now',
           },
@@ -1630,6 +1630,53 @@ describe('Page output', () => {
       await expect(shoppingAttachment).toBeInTheDocument();
       await expect(shoppingAttachment).toHaveAttribute('cta-text', 'Buy now');
       await expect(shoppingAttachment).toHaveAttribute('theme', 'light');
+    });
+
+    it('should not render page attachment if there are products', async () => {
+      const props = {
+        id: 'foo',
+        backgroundColor: { color: { r: 255, g: 255, b: 255 } },
+        page: {
+          id: 'bar',
+          elements: [
+            {
+              id: 'el1',
+              type: 'product',
+              x: 50,
+              y: 50,
+              width: 32,
+              height: 32,
+              rotationAngle: 0,
+              product: PRODUCT_LAMP,
+            },
+            {
+              id: 'el2',
+              type: 'product',
+              x: 100,
+              y: 100,
+              width: 32,
+              height: 32,
+              rotationAngle: 0,
+              product: PRODUCT_ART,
+            },
+          ],
+          pageAttachment: {
+            url: 'http://example.com',
+            ctaText: 'Click me!',
+          },
+        },
+        flags: {
+          shoppingIntegration: true,
+        },
+      };
+
+      const { container } = render(<PageOutput {...props} />);
+      const shoppingAttachment = container.querySelector(
+        'amp-story-shopping-attachment'
+      );
+      await expect(shoppingAttachment).toBeInTheDocument();
+      const pageOutlink = container.querySelector('amp-story-page-outlink');
+      await expect(pageOutlink).not.toBeInTheDocument();
     });
   });
 

--- a/packages/story-editor/src/components/canvas/displayLayer.js
+++ b/packages/story-editor/src/components/canvas/displayLayer.js
@@ -162,19 +162,26 @@ StoryAnimations.propTypes = {
 };
 
 function DisplayLayer() {
-  const { backgroundColor, isBackgroundSelected, pageAttachment, hasProducts } =
-    useStory(({ state }) => {
-      return {
-        hasCurrentPage: Boolean(state.currentPage),
-        backgroundColor: state.currentPage?.backgroundColor,
-        isBackgroundSelected: state.selectedElements?.[0]?.isBackground,
-        pageAttachment: state.currentPage?.pageAttachment || {},
-        hasProducts: state.currentPage.elements?.some(
-          ({ type, product }) =>
-            type === ELEMENT_TYPES.PRODUCT && product?.productId
-        ),
-      };
-    });
+  const {
+    backgroundColor,
+    isBackgroundSelected,
+    pageAttachment,
+    shoppingAttachment,
+    hasProducts,
+  } = useStory(({ state }) => {
+    return {
+      hasCurrentPage: Boolean(state.currentPage),
+      backgroundColor: state.currentPage?.backgroundColor,
+      isBackgroundSelected: state.selectedElements?.[0]?.isBackground,
+      pageAttachment: state.currentPage?.pageAttachment || {},
+      shoppingAttachment: state.currentPage?.shoppingAttachment || {},
+      hasProducts: state.currentPage.elements?.some(
+        ({ type, product }) =>
+          type === ELEMENT_TYPES.PRODUCT && product?.productId
+      ),
+    };
+  });
+
   // Have page elements shallowly equaled for scenarios like animation
   // updates where elements don't change, but we get a new page elements
   // array
@@ -194,13 +201,13 @@ function DisplayLayer() {
 
   const Overlay = useMemo(() => {
     if (hasProducts) {
-      return <ShoppingPageAttachment {...pageAttachment} />;
+      return <ShoppingPageAttachment {...shoppingAttachment} />;
     }
 
     // Always render <PageAttachment> because the pageAttachmentContainer ref
     // is needed in the page attachment panel and the useElementsWithLinks hook.
     return <PageAttachment pageAttachment={pageAttachment} />;
-  }, [pageAttachment, hasProducts]);
+  }, [hasProducts, pageAttachment, shoppingAttachment]);
 
   return (
     <StoryAnimations>

--- a/packages/story-editor/src/components/canvas/pageAttachment/index.js
+++ b/packages/story-editor/src/components/canvas/pageAttachment/index.js
@@ -143,12 +143,7 @@ function PageAttachment({ pageAttachment = {} }) {
 
   const { hasInvalidLinkSelected } = useElementsWithLinks();
 
-  const {
-    ctaText = __('Learn more', 'web-stories'),
-    url,
-    icon,
-    theme,
-  } = pageAttachment;
+  const { ctaText, url, icon, theme } = pageAttachment;
   const bgColor = theme === OUTLINK_THEME.DARK ? DARK_COLOR : LIGHT_COLOR;
   const fgColor = theme === OUTLINK_THEME.DARK ? LIGHT_COLOR : DARK_COLOR;
   return (
@@ -169,7 +164,7 @@ function PageAttachment({ pageAttachment = {} }) {
                 />
               )}
               <TextWrapper fgColor={fgColor} $factor={dataToEditorY}>
-                {ctaText}
+                {ctaText || __('Learn more', 'web-stories')}
               </TextWrapper>
             </OutlinkChip>
             {pageAttachmentContainer && hasInvalidLinkSelected && (
@@ -200,6 +195,7 @@ PageAttachment.propTypes = {
     ctaText: PropTypes.string,
     icon: PropTypes.string,
     theme: PropTypes.string,
+    rel: PropTypes.arrayOf(PropTypes.string),
   }),
 };
 

--- a/packages/story-editor/src/components/canvas/shoppingPageAttachment/index.js
+++ b/packages/story-editor/src/components/canvas/shoppingPageAttachment/index.js
@@ -110,7 +110,7 @@ const TextWrapper = styled.span`
 const LIGHT_COLOR = '#FFFFFF';
 const DARK_COLOR = '#000000';
 
-function PageAttachment({ ctaText = __('Shop Now', 'web-stories'), theme }) {
+function PageAttachment({ ctaText, theme }) {
   const arrowColor = theme === OUTLINK_THEME.DARK ? LIGHT_COLOR : DARK_COLOR;
   const fgColor = theme === OUTLINK_THEME.DARK ? DARK_COLOR : LIGHT_COLOR;
 
@@ -127,7 +127,7 @@ function PageAttachment({ ctaText = __('Shop Now', 'web-stories'), theme }) {
           </ArrowWrap>
           <OutlinkChip $factor={dataToEditorY}>
             <TextWrapper fgColor={fgColor} $factor={dataToEditorY}>
-              {ctaText}
+              {ctaText || __('Shop Now', 'web-stories')}
             </TextWrapper>
           </OutlinkChip>
         </Inner>

--- a/packages/story-editor/src/components/panels/design/pageAttachment/outlink.js
+++ b/packages/story-editor/src/components/panels/design/pageAttachment/outlink.js
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { useCallback, useState, useEffect } from '@googleforcreators/react';
+import { __ } from '@googleforcreators/i18n';
+import { isValidUrl, withProtocol } from '@googleforcreators/url';
+
+/**
+ * Internal dependencies
+ */
+import { useCanvas } from '../../../../app';
+import useElementsWithLinks from '../../../../utils/useElementsWithLinks';
+import { LinkRelations } from '../../shared';
+import { CallToActionText, Theme, Icon, LinkUrl } from './shared';
+
+function Outlink({ pageAttachment, updatePageAttachment }) {
+  const { setDisplayLinkGuidelines } = useCanvas((state) => ({
+    setDisplayLinkGuidelines: state.actions.setDisplayLinkGuidelines,
+  }));
+
+  const { url, ctaText, icon, theme, rel = [], needsProxy } = pageAttachment;
+  const [displayWarning, setDisplayWarning] = useState(false);
+  const [isFetching, setIsFetching] = useState(false);
+
+  const [isInvalidUrl, setIsInvalidUrl] = useState(
+    url && !isValidUrl(withProtocol(url).trim())
+  );
+
+  const hasValidUrl = Boolean(url) && !isInvalidUrl;
+
+  const { hasLinksInAttachmentArea } = useElementsWithLinks();
+
+  // Stop displaying guidelines when unmounting.
+  useEffect(() => {
+    return () => {
+      setDisplayLinkGuidelines(false);
+    };
+  }, [hasLinksInAttachmentArea, setDisplayLinkGuidelines, url]);
+
+  // If we focus on the field and there are links in the area.
+  const onFocus = useCallback(() => {
+    if (hasLinksInAttachmentArea && !url?.length) {
+      setDisplayWarning(true);
+      setDisplayLinkGuidelines(true);
+    }
+  }, [hasLinksInAttachmentArea, setDisplayLinkGuidelines, url?.length]);
+
+  // If the Page Attachment is added, stop displaying the warning.
+  useEffect(() => {
+    if (displayWarning && url?.length) {
+      setDisplayWarning(false);
+    }
+  }, [url, displayWarning]);
+
+  const onChangeRel = useCallback(
+    (newRel) => updatePageAttachment({ rel: newRel }, true),
+    [updatePageAttachment]
+  );
+
+  let hint;
+  const hasError = displayWarning || isInvalidUrl;
+  if (hasError) {
+    hint = displayWarning
+      ? __(
+          'Links cannot reside below the dashed line when a page attachment is present. If you add a page attachment, your viewers will not be able to click on the link.',
+          'web-stories'
+        )
+      : __('Invalid link', 'web-stories');
+  }
+
+  return (
+    <>
+      <LinkUrl
+        value={url}
+        onChange={updatePageAttachment}
+        isFetching={isFetching}
+        setIsFetching={setIsFetching}
+        setIsInvalidUrl={setIsInvalidUrl}
+        hint={hint}
+        onFocus={onFocus}
+        hasError={hasError}
+      />
+      {hasValidUrl && (
+        <>
+          <CallToActionText
+            value={ctaText}
+            defaultValue={__('Learn more', 'web-stories')}
+            onChange={updatePageAttachment}
+          />
+          <Theme theme={theme} onChange={updatePageAttachment} />
+        </>
+      )}
+      {hasValidUrl && (
+        <>
+          <Icon
+            icon={icon}
+            isFetching={isFetching}
+            needsProxy={needsProxy}
+            onChange={updatePageAttachment}
+          />
+          <LinkRelations onChangeRel={onChangeRel} rel={rel} />
+        </>
+      )}
+    </>
+  );
+}
+
+Outlink.propTypes = {
+  pageAttachment: PropTypes.shape({
+    url: PropTypes.string,
+    ctaText: PropTypes.string,
+    icon: PropTypes.string,
+    theme: PropTypes.string,
+    rel: PropTypes.arrayOf(PropTypes.string),
+    needsProxy: PropTypes.bool,
+  }).isRequired,
+  updatePageAttachment: PropTypes.func.isRequired,
+};
+
+export default Outlink;

--- a/packages/story-editor/src/components/panels/design/pageAttachment/pageAttachment.js
+++ b/packages/story-editor/src/components/panels/design/pageAttachment/pageAttachment.js
@@ -17,255 +17,62 @@
 /**
  * External dependencies
  */
-import {
-  useCallback,
-  useState,
-  useEffect,
-  useDebouncedCallback,
-} from '@googleforcreators/react';
+import { useCallback } from '@googleforcreators/react';
 import { __ } from '@googleforcreators/i18n';
-import {
-  isValidUrl,
-  toAbsoluteUrl,
-  withProtocol,
-} from '@googleforcreators/url';
-import {
-  Checkbox,
-  Input,
-  Text,
-  THEME_CONSTANTS,
-  ThemeGlobals,
-} from '@googleforcreators/design-system';
-import { v4 as uuidv4 } from 'uuid';
-import styled from 'styled-components';
 import { ELEMENT_TYPES } from '@googleforcreators/elements';
 
 /**
  * Internal dependencies
  */
-import { useStory, useCanvas, useAPI } from '../../../../app';
-import useElementsWithLinks from '../../../../utils/useElementsWithLinks';
-import { LinkIcon, LinkInput, Row } from '../../../form';
+import { useStory } from '../../../../app';
 import { SimplePanel } from '../../panel';
-import { OUTLINK_THEME } from '../../../../constants';
-import useCORSProxy from '../../../../utils/useCORSProxy';
-import { LinkRelations } from '../../shared';
-
-const Label = styled.label`
-  margin-left: 12px;
-`;
-
-const StyledCheckbox = styled(Checkbox)`
-  ${({ theme }) => `
-    input[type='checkbox']&.${ThemeGlobals.FOCUS_VISIBLE_SELECTOR} ~ div, input[type='checkbox']:focus ~ div {
-      box-shadow: 0px 0px 0 2px ${theme.colors.bg.secondary}, 0px 0px 0 4px ${theme.colors.border.focus} !important;
-    }
-  `}
-`;
-
-const StyledRow = styled(Row)`
-  justify-content: flex-start;
-`;
-
-const Space = styled.div`
-  width: 20px;
-`;
-
-const HelperText = styled(Text).attrs({
-  size: THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL,
-})`
-  color: ${({ theme }) => theme.colors.fg.secondary};
-`;
+import Outlink from './outlink';
+import ShoppingAttachment from './shoppingAttachment';
 
 function PageAttachmentPanel() {
-  const { currentPage, updateCurrentPageProperties, hasProducts } = useStory(
-    ({ state, actions }) => ({
-      updateCurrentPageProperties: actions.updateCurrentPageProperties,
-      currentPage: state.currentPage,
-      hasProducts: state.currentPage.elements?.some(
-        ({ type, product }) =>
-          type === ELEMENT_TYPES.PRODUCT && product?.productId
-      ),
-    })
-  );
-  const { setDisplayLinkGuidelines } = useCanvas((state) => ({
-    setDisplayLinkGuidelines: state.actions.setDisplayLinkGuidelines,
-  }));
   const {
-    actions: { getLinkMetadata },
-  } = useAPI();
+    pageAttachment,
+    shoppingAttachment,
+    updateCurrentPageProperties,
+    hasProducts,
+  } = useStory(({ state, actions }) => ({
+    updateCurrentPageProperties: actions.updateCurrentPageProperties,
+    currentPage: state.currentPage,
+    pageAttachment: state.currentPage.pageAttachment || {},
+    shoppingAttachment: state.currentPage.shoppingAttachment || {},
+    hasProducts: state.currentPage.elements?.some(
+      ({ type, product }) =>
+        type === ELEMENT_TYPES.PRODUCT && product?.productId
+    ),
+  }));
 
-  const { pageAttachment = {} } = currentPage;
-  const defaultCTA = hasProducts
-    ? __('Shop Now', 'web-stories')
-    : __('Learn more', 'web-stories');
-  const { url, ctaText = defaultCTA, icon, theme, rel = [] } = pageAttachment;
-  const [_ctaText, _setCtaText] = useState(ctaText);
-  const [_url, _setUrl] = useState(url);
-  const [displayWarning, setDisplayWarning] = useState(false);
-  const [fetchingMetadata, setFetchingMetadata] = useState(false);
-
-  const { hasLinksInAttachmentArea } = useElementsWithLinks();
-
-  // Stop displaying guidelines when unmounting.
-  useEffect(() => {
-    return () => {
-      setDisplayLinkGuidelines(false);
-    };
-  }, [hasLinksInAttachmentArea, setDisplayLinkGuidelines, url]);
-
-  // If we focus on the field and there are links in the area.
-  const onFocus = () => {
-    if (hasLinksInAttachmentArea && !url?.length) {
-      setDisplayWarning(true);
-      setDisplayLinkGuidelines(true);
-    }
-  };
-
-  // If the Page Attachment is added, stop displaying the warning.
-  useEffect(() => {
-    if (displayWarning && url?.length) {
-      setDisplayWarning(false);
-    }
-  }, [url, displayWarning]);
+  const updateShoppingAttachment = useCallback(
+    (value) => {
+      updateCurrentPageProperties({
+        properties: {
+          shoppingAttachment: {
+            ...shoppingAttachment,
+            ...value,
+          },
+        },
+      });
+    },
+    [updateCurrentPageProperties, shoppingAttachment]
+  );
 
   const updatePageAttachment = useCallback(
     (value) => {
-      const _pageAttachment = {
-        ...pageAttachment,
-        ...value,
-      };
       updateCurrentPageProperties({
-        properties: { pageAttachment: _pageAttachment },
+        properties: {
+          pageAttachment: {
+            ...pageAttachment,
+            ...value,
+          },
+        },
       });
     },
     [updateCurrentPageProperties, pageAttachment]
   );
-
-  const debouncedUpdate = useDebouncedCallback(updatePageAttachment, 300);
-  const { getProxiedUrl, checkResourceAccess } = useCORSProxy();
-
-  const populateUrlData = useDebouncedCallback(
-    useCallback(
-      async (value) => {
-        // Nothing to fetch for tel: or mailto: links.
-        if (!value.startsWith('http://') && !value.startsWith('https://')) {
-          return;
-        }
-
-        setFetchingMetadata(true);
-        try {
-          const { image } = getLinkMetadata ? await getLinkMetadata(value) : {};
-          const iconUrl = image ? toAbsoluteUrl(value, image) : '';
-          const needsProxy = iconUrl
-            ? await checkResourceAccess(iconUrl)
-            : false;
-
-          updatePageAttachment({
-            url: value,
-            icon: iconUrl,
-            needsProxy,
-          });
-        } catch (e) {
-          // We're allowing to save invalid URLs, however, remove icon in this case.
-          updatePageAttachment({ url: value, icon: '', needsProxy: false });
-          setIsInvalidUrl(true);
-        } finally {
-          setFetchingMetadata(false);
-        }
-      },
-      [checkResourceAccess, getLinkMetadata, updatePageAttachment]
-    ),
-    1200
-  );
-
-  const [isInvalidUrl, setIsInvalidUrl] = useState(
-    url && !isValidUrl(withProtocol(url).trim())
-  );
-
-  const isDefault = _ctaText === defaultCTA;
-  const hasValidUrl = Boolean(url) && !isInvalidUrl;
-
-  const handleChangeUrl = useCallback(
-    (value) => {
-      populateUrlData.cancel();
-
-      _setUrl(value);
-      setIsInvalidUrl(false);
-      const urlWithProtocol = withProtocol(value.trim());
-      const valid = isValidUrl(urlWithProtocol);
-      if (valid) {
-        populateUrlData(urlWithProtocol);
-      }
-    },
-    [populateUrlData]
-  );
-
-  const handleChangeCta = useCallback(
-    ({ target }) => {
-      const { value } = target;
-      // This allows smooth input value change without any lag.
-      _setCtaText(value);
-      debouncedUpdate({ ctaText: value });
-    },
-    [debouncedUpdate]
-  );
-
-  const handleChangeTheme = useCallback(
-    (evt) => {
-      updatePageAttachment({
-        theme: evt.target.checked ? OUTLINK_THEME.DARK : OUTLINK_THEME.LIGHT,
-      });
-    },
-    [updatePageAttachment]
-  );
-
-  const handleChangeIcon = useCallback(
-    /**
-     * Handle page attachment icon change.
-     *
-     * @param {import('@googleforcreators/media').Resource} resource The new image.
-     */
-    (resource) => {
-      updatePageAttachment({ icon: resource?.src }, true);
-    },
-    [updatePageAttachment]
-  );
-
-  const onChangeRel = useCallback(
-    (newRel) => updatePageAttachment({ rel: newRel }, true),
-    [updatePageAttachment]
-  );
-
-  const handleBlur = useCallback(
-    ({ target }) => {
-      if (!target.value) {
-        updatePageAttachment({ ctaText: defaultCTA });
-        _setCtaText(defaultCTA);
-      } else {
-        debouncedUpdate.cancel();
-        updatePageAttachment({
-          ctaText: _ctaText ? _ctaText : defaultCTA,
-        });
-      }
-    },
-    [_ctaText, debouncedUpdate, defaultCTA, updatePageAttachment]
-  );
-
-  const checkboxId = `cb-${uuidv4()}`;
-
-  const iconUrl = icon ? getProxiedUrl(pageAttachment, icon) : null;
-
-  let hint;
-  const hasError = displayWarning || isInvalidUrl;
-  if (hasError) {
-    hint = displayWarning
-      ? __(
-          'Links cannot reside below the dashed line when a page attachment is present. If you add a page attachment, your viewers will not be able to click on the link.',
-          'web-stories'
-        )
-      : __('Invalid link', 'web-stories');
-  }
 
   return (
     <SimplePanel
@@ -273,83 +80,17 @@ function PageAttachmentPanel() {
       title={__('Call to Action', 'web-stories')}
       collapsedByDefault={false}
     >
-      {hasProducts ? (
-        <Row>
-          <HelperText>
-            {__(
-              'Since there are products on this page, you cannot add a regular page attachment, but only customize the appearance of the shopping call to action.',
-              'web-stories'
-            )}
-          </HelperText>
-        </Row>
-      ) : (
-        <LinkInput
-          onChange={(value) => handleChangeUrl(value?.trim())}
-          onBlur={() => {
-            debouncedUpdate.cancel();
-            updatePageAttachment({
-              url: _url?.trim().length ? withProtocol(_url.trim()) : '',
-            });
-          }}
-          onFocus={onFocus}
-          value={_url}
-          clear
-          aria-label={__(
-            'Type an address to add a page attachment link',
-            'web-stories'
-          )}
-          hasError={hasError}
-          hint={hint}
+      {hasProducts && (
+        <ShoppingAttachment
+          shoppingAttachment={shoppingAttachment}
+          updateShoppingAttachment={updateShoppingAttachment}
         />
       )}
-      {(hasValidUrl || hasProducts) && (
-        <>
-          <Row>
-            <Input
-              onChange={handleChangeCta}
-              onBlur={handleBlur}
-              value={_ctaText}
-              aria-label={__('Page Attachment CTA text', 'web-stories')}
-              suffix={isDefault ? __('Default', 'web-stories') : null}
-            />
-          </Row>
-          <StyledRow>
-            {/* The default is light theme, only if checked, use dark theme */}
-            <StyledCheckbox
-              id={checkboxId}
-              checked={theme === OUTLINK_THEME.DARK}
-              onChange={handleChangeTheme}
-            />
-            <Label htmlFor={checkboxId}>
-              <Text
-                as="span"
-                size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}
-              >
-                {__('Use dark theme', 'web-stories')}
-              </Text>
-            </Label>
-          </StyledRow>
-        </>
-      )}
-      {hasValidUrl && (
-        <>
-          <StyledRow>
-            <LinkIcon
-              handleChange={handleChangeIcon}
-              icon={iconUrl}
-              isLoading={fetchingMetadata}
-              disabled={fetchingMetadata}
-            />
-            <Space />
-            <Text
-              as="span"
-              size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}
-            >
-              {__('Link icon', 'web-stories')}
-            </Text>
-          </StyledRow>
-          <LinkRelations onChangeRel={onChangeRel} rel={rel} />
-        </>
+      {!hasProducts && (
+        <Outlink
+          pageAttachment={pageAttachment}
+          updatePageAttachment={updatePageAttachment}
+        />
       )}
     </SimplePanel>
   );

--- a/packages/story-editor/src/components/panels/design/pageAttachment/shared.js
+++ b/packages/story-editor/src/components/panels/design/pageAttachment/shared.js
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  useCallback,
+  useDebouncedCallback,
+  useState,
+} from '@googleforcreators/react';
+import {
+  Checkbox,
+  Input,
+  Text,
+  THEME_CONSTANTS,
+  ThemeGlobals,
+} from '@googleforcreators/design-system';
+import { __ } from '@googleforcreators/i18n';
+import {
+  isValidUrl,
+  toAbsoluteUrl,
+  withProtocol,
+} from '@googleforcreators/url';
+
+/**
+ * Internal dependencies
+ */
+import { LinkIcon, LinkInput, Row } from '../../../form';
+import { OUTLINK_THEME } from '../../../../constants';
+import useCORSProxy from '../../../../utils/useCORSProxy';
+import { useAPI } from '../../../../app';
+
+const Label = styled.label`
+  margin-left: 12px;
+`;
+
+const StyledCheckbox = styled(Checkbox)`
+  ${({ theme }) => `
+    input[type='checkbox']&.${ThemeGlobals.FOCUS_VISIBLE_SELECTOR} ~ div, input[type='checkbox']:focus ~ div {
+      box-shadow: 0px 0px 0 2px ${theme.colors.bg.secondary}, 0px 0px 0 4px ${theme.colors.border.focus} !important;
+    }
+  `}
+`;
+
+const StyledRow = styled(Row)`
+  justify-content: flex-start;
+`;
+
+const Space = styled.div`
+  width: 20px;
+`;
+
+export function CallToActionText({ value, defaultValue, onChange }) {
+  const [text, setText] = useState(value || defaultValue);
+
+  const debouncedUpdate = useDebouncedCallback(onChange, 300);
+
+  const handleBlur = useCallback(
+    ({ target }) => {
+      if (!target.value) {
+        onChange({ ctaText: undefined });
+        setText(defaultValue);
+      } else {
+        debouncedUpdate.cancel();
+        onChange({
+          ctaText: text || undefined,
+        });
+      }
+    },
+    [text, debouncedUpdate, defaultValue, onChange]
+  );
+
+  const handleChangeCta = useCallback(
+    ({ target }) => {
+      const { value: newText } = target;
+      // This allows smooth input value change without any lag.
+      setText(newText);
+      debouncedUpdate({ ctaText: newText });
+    },
+    [debouncedUpdate]
+  );
+
+  const isDefault = value === defaultValue;
+
+  return (
+    <Row>
+      <Input
+        onChange={handleChangeCta}
+        onBlur={handleBlur}
+        value={text}
+        aria-label={__('Call to Action text', 'web-stories')}
+        suffix={isDefault ? __('Default', 'web-stories') : null}
+      />
+    </Row>
+  );
+}
+
+CallToActionText.propTypes = {
+  value: PropTypes.string,
+  defaultValue: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+};
+
+export function Theme({ theme, onChange }) {
+  const checkboxId = `cb-${uuidv4()}`;
+
+  const handleChangeTheme = useCallback(
+    (evt) => {
+      onChange({
+        theme: evt.target.checked ? OUTLINK_THEME.DARK : OUTLINK_THEME.LIGHT,
+      });
+    },
+    [onChange]
+  );
+
+  return (
+    <StyledRow>
+      {/* The default is light theme, only if checked, use dark theme */}
+      <StyledCheckbox
+        id={checkboxId}
+        checked={theme === OUTLINK_THEME.DARK}
+        onChange={handleChangeTheme}
+      />
+      <Label htmlFor={checkboxId}>
+        <Text as="span" size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}>
+          {__('Use dark theme', 'web-stories')}
+        </Text>
+      </Label>
+    </StyledRow>
+  );
+}
+
+Theme.propTypes = {
+  theme: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+};
+
+export function Icon({ icon, onChange, isFetching, needsProxy }) {
+  const { getProxiedUrl } = useCORSProxy();
+
+  const handleChangeIcon = useCallback(
+    /**
+     * Handle page attachment icon change.
+     *
+     * @param {import('@googleforcreators/media').Resource} resource The new image.
+     */
+    (resource) => {
+      onChange({ icon: resource?.src }, true);
+    },
+    [onChange]
+  );
+
+  const iconUrl = icon ? getProxiedUrl({ needsProxy }, icon) : null;
+
+  return (
+    <StyledRow>
+      <LinkIcon
+        handleChange={handleChangeIcon}
+        icon={iconUrl}
+        isLoading={isFetching}
+        disabled={isFetching}
+      />
+      <Space />
+      <Text as="span" size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}>
+        {__('Link icon', 'web-stories')}
+      </Text>
+    </StyledRow>
+  );
+}
+
+Icon.propTypes = {
+  icon: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  isFetching: PropTypes.bool,
+  needsProxy: PropTypes.bool,
+};
+
+export function LinkUrl({
+  value,
+  onChange,
+  setIsInvalidUrl,
+  setIsFetching,
+  onFocus,
+  hint,
+  hasError,
+}) {
+  const {
+    actions: { getLinkMetadata },
+  } = useAPI();
+
+  const [_url, _setUrl] = useState(value);
+
+  const debouncedUpdate = useDebouncedCallback(onChange, 300);
+  const { checkResourceAccess } = useCORSProxy();
+
+  const populateUrlData = useDebouncedCallback(
+    useCallback(
+      async (newValue) => {
+        // Nothing to fetch for tel: or mailto: links.
+        if (
+          !newValue.startsWith('http://') &&
+          !newValue.startsWith('https://')
+        ) {
+          return;
+        }
+
+        setIsFetching(true);
+        try {
+          const { image } = getLinkMetadata
+            ? await getLinkMetadata(newValue)
+            : {};
+          const iconUrl = image ? toAbsoluteUrl(newValue, image) : '';
+          const needsProxy = iconUrl
+            ? await checkResourceAccess(iconUrl)
+            : false;
+
+          onChange({
+            url: newValue,
+            icon: iconUrl,
+            needsProxy,
+          });
+        } catch (e) {
+          // We're allowing to save invalid URLs, however, remove icon in this case.
+          onChange({ url: newValue, icon: '', needsProxy: false });
+          setIsInvalidUrl(true);
+        } finally {
+          setIsFetching(false);
+        }
+      },
+      [
+        checkResourceAccess,
+        getLinkMetadata,
+        onChange,
+        setIsFetching,
+        setIsInvalidUrl,
+      ]
+    ),
+    1200
+  );
+
+  const handleChangeUrl = useCallback(
+    (newValue) => {
+      populateUrlData.cancel();
+
+      _setUrl(newValue);
+      setIsInvalidUrl(false);
+      const urlWithProtocol = withProtocol(newValue.trim());
+      const valid = isValidUrl(urlWithProtocol);
+      if (valid) {
+        populateUrlData(urlWithProtocol);
+      }
+    },
+    [populateUrlData, setIsInvalidUrl]
+  );
+
+  const onBlur = useCallback(() => {
+    debouncedUpdate.cancel();
+    onChange({
+      url: _url?.trim().length ? withProtocol(_url.trim()) : '',
+    });
+  }, [_url, debouncedUpdate, onChange]);
+
+  return (
+    <LinkInput
+      onChange={(newValue) => handleChangeUrl(newValue?.trim())}
+      onBlur={onBlur}
+      onFocus={onFocus}
+      value={_url}
+      clear
+      aria-label={__(
+        'Type an address to add a page attachment link',
+        'web-stories'
+      )}
+      hasError={hasError}
+      hint={hint}
+    />
+  );
+}
+
+LinkUrl.propTypes = {
+  value: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  setIsInvalidUrl: PropTypes.func.isRequired,
+  hasError: PropTypes.bool,
+  setIsFetching: PropTypes.func.isRequired,
+  onFocus: PropTypes.func.isRequired,
+  hint: PropTypes.string,
+};

--- a/packages/story-editor/src/components/panels/design/pageAttachment/shoppingAttachment.js
+++ b/packages/story-editor/src/components/panels/design/pageAttachment/shoppingAttachment.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { __ } from '@googleforcreators/i18n';
+import { Text, THEME_CONSTANTS } from '@googleforcreators/design-system';
+
+/**
+ * Internal dependencies
+ */
+import { Row } from '../../../form';
+import { CallToActionText, Theme } from './shared';
+
+const HelperText = styled(Text).attrs({
+  size: THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL,
+})`
+  color: ${({ theme }) => theme.colors.fg.secondary};
+`;
+
+function ShoppingAttachment({ shoppingAttachment, updateShoppingAttachment }) {
+  const { ctaText, theme } = shoppingAttachment;
+
+  return (
+    <>
+      <Row>
+        <HelperText>
+          {__(
+            'Since there are products on this page, you cannot add a regular page attachment, but only customize the appearance of the shopping call to action.',
+            'web-stories'
+          )}
+        </HelperText>
+      </Row>
+      <CallToActionText
+        value={ctaText}
+        defaultValue={__('Shop Now', 'web-stories')}
+        onChange={updateShoppingAttachment}
+      />
+      <Theme theme={theme} onChange={updateShoppingAttachment} />
+    </>
+  );
+}
+
+ShoppingAttachment.propTypes = {
+  shoppingAttachment: PropTypes.shape({
+    ctaText: PropTypes.string,
+    theme: PropTypes.string,
+  }).isRequired,
+  updateShoppingAttachment: PropTypes.func.isRequired,
+};
+
+export default ShoppingAttachment;


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

There's a couple of conflicts between the page attachment (aka outlink) and the shopping attachment, most notably because right now they use some of the same components.

## Summary

<!-- A brief description of what this PR does. -->

Separate page and shopping attachment configuration so that the CTA text or theme of the one does not affect the other.

## Relevant Technical Choices

<!-- Please describe your changes. -->

Split up the giant component into multiple smaller ones to improve readability. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

* No duplicate CTA on the frontend
* Configuration for page attachment and shopping attachment not mixed

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add a page attachment
2. Change the CTA text
3. Use dark theme
4. See page attachment updated as expected on the canvas and on the preview
5. Now add products to the page
6. See that the CTA text and theme are now different and can be customized as well
7. Preview the story, see that only the shopping page attachment is displayed, not the "regular" one
8. Remove products again from the page
9. See that the previous page attachment CTA text and theme are back


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11704