### PR TITLE
Editor: Fixed right-click in layer panel

### DIFF
--- a/packages/story-editor/src/components/reorderable/useReordering.js
+++ b/packages/story-editor/src/components/reorderable/useReordering.js
@@ -36,9 +36,10 @@ function useReordering(onPositionChange, numChildren) {
   const handleStartReordering = useCallback(
     ({ position: currentPos, onStartReordering = () => {} }) =>
       (evt) => {
-        // Only allow reordering with non-modified click on non-background element.
+        // Only allow reordering with non-modified left-click on non-background element.
         // Modified (shift+ or meta+) clicks are for selection.
-        if (!evt.shiftKey && !evt.metaKey) {
+        // Right-clicks (button===2) are for context menu
+        if (!evt.shiftKey && !evt.metaKey && evt.button === 0) {
           onStartReordering();
           setCurrentPosition(currentPos);
           setDragTarget(evt.target);

--- a/packages/story-editor/src/components/reorderable/useReordering.js
+++ b/packages/story-editor/src/components/reorderable/useReordering.js
@@ -37,9 +37,12 @@ function useReordering(onPositionChange, numChildren) {
     ({ position: currentPos, onStartReordering = () => {} }) =>
       (evt) => {
         // Only allow reordering with non-modified left-click.
-        // Modified (shift+ or meta+) clicks are for selection.
+        // Modified (shift, meta, alt, ctrl) clicks are for selection.
+        const isModified =
+          evt.shiftKey || evt.metaKey || evt.ctrlKey || evt.altKey;
         // Right-clicks (button===2) are for context menu.
-        if (!evt.shiftKey && !evt.metaKey && evt.button === 0) {
+        const isLeftButton = evt.button === 0;
+        if (!isModified && isLeftButton) {
           onStartReordering();
           setCurrentPosition(currentPos);
           setDragTarget(evt.target);

--- a/packages/story-editor/src/components/reorderable/useReordering.js
+++ b/packages/story-editor/src/components/reorderable/useReordering.js
@@ -36,9 +36,9 @@ function useReordering(onPositionChange, numChildren) {
   const handleStartReordering = useCallback(
     ({ position: currentPos, onStartReordering = () => {} }) =>
       (evt) => {
-        // Only allow reordering with non-modified left-click on non-background element.
+        // Only allow reordering with non-modified left-click.
         // Modified (shift+ or meta+) clicks are for selection.
-        // Right-clicks (button===2) are for context menu
+        // Right-clicks (button===2) are for context menu.
         if (!evt.shiftKey && !evt.metaKey && evt.button === 0) {
           onStartReordering();
           setCurrentPosition(currentPos);


### PR DESCRIPTION
Essentially just had to make sure that the reorderable only looks for regular left-clicks and ignores other mouse button clicks.

## Testing Instructions

This PR can be tested by following these steps:

1. Select multiple elements on stage in any possible way
2. Right-click (without pressing shift or meta at the same time) one of the layers in the layer panel and observe, that all the layers remain selected.

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #11717
