### PR TITLE
Editor: Do not show 'Add animation' quick action on first page

### DIFF
--- a/docs/quick-actions.md
+++ b/docs/quick-actions.md
@@ -19,31 +19,33 @@ Quick actions are not limited to just the above functionality. In the future it 
 
 The actions that are displayed dynamically change depending on which element type is selected. These are outlined below:
 
-|Selected Element Type|Available actions|
-|--|--|
-|Nothing selected|- Change background color<br/>- Insert media<br/>- Insert text|
-|Background Image|- Replace background<br/>- Add animation<br/>- Clear filters and animation|
-|Foreground Image|- Replace media<br/>- Add animation<br/>- Add link<br/>- Clear animation|
-|Video|- Replace media<br/>- Add animation<br/>- Add link<br/>- Add captions<br/>- Clear filters and animation|
-|Shape|- Change color<br/>- Add animation<br/>- Add link<br/>- Clear filters and animation|
-|Text|- Change color<br/>- Edit text<br/>- Add animation<br/>- Add link<br/>- Clear animation|
+| Selected Element Type | Available actions                                                                                         |
+|-----------------------|-----------------------------------------------------------------------------------------------------------|
+| Nothing selected      | - Change background color<br/>- Insert media <br/>- Insert text                                           |
+| Background Image      | - Replace background<br/>- Add animation* <br/>- Clear filters and animation                              |
+| Foreground Image      | - Replace media<br/>- Add animation* <br/>- Add link<br/>- Clear animation                                |
+| Video                 | - Replace media<br/>- Add animation* <br/>- Add link<br/>- Add captions<br/>- Clear filters and animation |
+| Shape                 | - Change color<br/>- Add animation* <br/>- Add link<br/>- Clear filters and animation                     |
+| Text                  | - Change color<br/>- Edit text<br/>- Add animation*<br/>- Add link<br/>- Clear animation                  |
 
 ### Action functionality
 
 Reference this table when needing to know what a quick action will do when clicked.
 
-|Quick Action|Result|
-|--|--|
-|Add animation|Open and highlight the `animation` panel in the `design pane`. Focus the effect chooser dropdown.|
-|Add caption|Open and highlight the `captions and subtitles` panel in the `design pane`. Focus the input.|
-|Add link|Open and highlight the `link` panel in the `design pane`. Focus the input.|
-|Change background color|Open and highlight the `page background` panel in the `design pane`. Focus the input.|
-|Clear animation/filters and animation|Remove all filters and/or animations as specified. Display a snackbar to the user indicating that they were removed. The snackbar will contain an action button that when clicked will re-apply the styles that were removed.|
-|Edit text|Open and highlight the `text` panel in the `design pane`. Focus the first input.|
-|Insert media|Open and highlight the `media pane` in the `library`. Focus the media tab button.|
-|Insert text|Open and highlight the `text pane` in the `library`. Focus the text tab button.|
-|Replace background/media|Open and highlight one of the media panes in the `library`. The media pane opened will depend on the type of the element selected. Focus the relevant tab button.|
-|Trim video|Enter video trim mode similar to button in design panel.|
+| Quick Action                          | Result                                                                                                                                                                                                                        |
+|---------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Add animation*                        | Open and highlight the `animation` panel in the `design pane`. Focus the effect chooser dropdown.                                                                                                                             |
+| Add caption                           | Open and highlight the `captions and subtitles` panel in the `design pane`. Focus the input.                                                                                                                                  |
+| Add link                              | Open and highlight the `link` panel in the `design pane`. Focus the input.                                                                                                                                                    |
+| Change background color               | Open and highlight the `page background` panel in the `design pane`. Focus the input.                                                                                                                                         |
+| Clear animation/filters and animation | Remove all filters and/or animations as specified. Display a snackbar to the user indicating that they were removed. The snackbar will contain an action button that when clicked will re-apply the styles that were removed. |
+| Edit text                             | Open and highlight the `text` panel in the `design pane`. Focus the first input.                                                                                                                                              |
+| Insert media                          | Open and highlight the `media pane` in the `library`. Focus the media tab button.                                                                                                                                             |
+| Insert text                           | Open and highlight the `text pane` in the `library`. Focus the text tab button.                                                                                                                                               |
+| Replace background/media              | Open and highlight one of the media panes in the `library`. The media pane opened will depend on the type of the element selected. Focus the relevant tab button.                                                             |
+| Trim video                            | Enter video trim mode similar to button in design panel.                                                                                                                                                                      |
+
+> *_Add animation_ action is not available on the first page of a story.
 
 ### Visibility
 

--- a/packages/story-editor/src/app/highlights/quickActions/test/useQuickActions.js
+++ b/packages/story-editor/src/app/highlights/quickActions/test/useQuickActions.js
@@ -195,11 +195,6 @@ const defaultQuickActions = [
 
 const foregroundCommonActions = [
   expect.objectContaining({
-    label: ACTIONS.ADD_ANIMATION.text,
-    onClick: expect.any(Function),
-    Icon: CircleSpeed,
-  }),
-  expect.objectContaining({
     label: ACTIONS.ADD_LINK.text,
     onClick: expect.any(Function),
     Icon: Link,
@@ -653,12 +648,6 @@ describe('useQuickActions', () => {
       result.current[1].onClick(mockClickEvent);
       expect(highlight).toStrictEqual({
         elementId: IMAGE_ELEMENT.id,
-        highlight: states.ANIMATION,
-      });
-
-      result.current[2].onClick(mockClickEvent);
-      expect(highlight).toStrictEqual({
-        elementId: IMAGE_ELEMENT.id,
         highlight: states.LINK,
       });
     });
@@ -675,13 +664,13 @@ describe('useQuickActions', () => {
 
       const { result } = renderHook(() => useQuickActions());
 
-      expect(result.current[3]).toBeUndefined();
+      expect(result.current[2]).toBeUndefined();
     });
 
     it('clicking `reset element` should update the element', () => {
       const { result } = renderHook(() => useQuickActions());
 
-      result.current[3].onClick(mockClickEvent);
+      result.current[2].onClick(mockClickEvent);
       expect(mockUpdateElementsById).toHaveBeenCalledWith({
         elementIds: [IMAGE_ELEMENT.id],
         properties: expect.any(Function),
@@ -726,12 +715,6 @@ describe('useQuickActions', () => {
       result.current[0].onClick(mockClickEvent);
       expect(highlight).toStrictEqual({
         elementId: SHAPE_ELEMENT.id,
-        highlight: states.ANIMATION,
-      });
-
-      result.current[1].onClick(mockClickEvent);
-      expect(highlight).toStrictEqual({
-        elementId: SHAPE_ELEMENT.id,
         highlight: states.LINK,
       });
     });
@@ -748,13 +731,13 @@ describe('useQuickActions', () => {
 
       const { result } = renderHook(() => useQuickActions());
 
-      expect(result.current[2]).toBeUndefined();
+      expect(result.current[1]).toBeUndefined();
     });
 
     it('clicking `clear animations` should call `updateElementsById`', () => {
       const { result } = renderHook(() => useQuickActions());
 
-      result.current[2].onClick(mockClickEvent);
+      result.current[1].onClick(mockClickEvent);
       expect(mockUpdateElementsById).toHaveBeenCalledWith({
         elementIds: [SHAPE_ELEMENT.id],
         properties: expect.any(Function),
@@ -784,12 +767,6 @@ describe('useQuickActions', () => {
       result.current[1].onClick(mockClickEvent);
       expect(highlight).toStrictEqual({
         elementId: TEXT_ELEMENT.id,
-        highlight: states.ANIMATION,
-      });
-
-      result.current[2].onClick(mockClickEvent);
-      expect(highlight).toStrictEqual({
-        elementId: TEXT_ELEMENT.id,
         highlight: states.LINK,
       });
     });
@@ -806,7 +783,7 @@ describe('useQuickActions', () => {
 
       const { result } = renderHook(() => useQuickActions());
 
-      expect(result.current[3]).toBeUndefined();
+      expect(result.current[2]).toBeUndefined();
     });
 
     it('clicking `reset element` should update the element', () => {
@@ -826,7 +803,7 @@ describe('useQuickActions', () => {
       const { result } = renderHook(() => useQuickActions());
       expect(result.current).toStrictEqual(textQuickActionsWithClear);
 
-      result.current[3].onClick(mockClickEvent);
+      result.current[2].onClick(mockClickEvent);
       expect(mockUpdateElementsById).toHaveBeenCalledWith({
         elementIds: [TEXT_ELEMENT.id],
         properties: expect.any(Function),
@@ -861,16 +838,10 @@ describe('useQuickActions', () => {
       result.current[1].onClick(mockClickEvent);
       expect(highlight).toStrictEqual({
         elementId: VIDEO_ELEMENT.id,
-        highlight: states.ANIMATION,
-      });
-
-      result.current[2].onClick(mockClickEvent);
-      expect(highlight).toStrictEqual({
-        elementId: VIDEO_ELEMENT.id,
         highlight: states.LINK,
       });
 
-      result.current[3].onClick(mockClickEvent);
+      result.current[2].onClick(mockClickEvent);
       expect(highlight).toStrictEqual({
         elementId: VIDEO_ELEMENT.id,
         highlight: states.CAPTIONS,
@@ -895,7 +866,7 @@ describe('useQuickActions', () => {
     it(`should click \`${ACTIONS.RESET_ELEMENT.text} and update the element`, () => {
       const { result } = renderHook(() => useQuickActions());
 
-      result.current[4].onClick(mockClickEvent);
+      result.current[3].onClick(mockClickEvent);
       expect(mockUpdateElementsById).toHaveBeenCalledWith({
         elementIds: [VIDEO_ELEMENT.id],
         properties: expect.any(Function),
@@ -931,12 +902,6 @@ describe('useQuickActions', () => {
       result.current[0].onClick(mockClickEvent);
       expect(highlight).toStrictEqual({
         elementId: STICKER_ELEMENT.id,
-        highlight: states.ANIMATION,
-      });
-
-      result.current[1].onClick(mockClickEvent);
-      expect(highlight).toStrictEqual({
-        elementId: STICKER_ELEMENT.id,
         highlight: states.LINK,
       });
     });
@@ -959,7 +924,7 @@ describe('useQuickActions', () => {
     it('clicking `reset element` should update the element', () => {
       const { result } = renderHook(() => useQuickActions());
 
-      result.current[2].onClick(mockClickEvent);
+      result.current[1].onClick(mockClickEvent);
       expect(mockUpdateElementsById).toHaveBeenCalledWith({
         elementIds: [STICKER_ELEMENT.id],
         properties: expect.any(Function),


### PR DESCRIPTION
## Context

Since animations cannot be applied to elements on the first page of a story, the 'Add animation' button should not be shown in the 'quick actions' button group.

## Summary

The 'Add animation' button will not be rendered on the first page of a story.

## Relevant Technical Choices

The `currentPageNumber` prop was tracked down and added to the dependency array for the function responsible for building the menu for 'common actions' of foreground elements. The logic for building the button group was changed to add buttons in the order they should appear

The logic for building the `foregroundCommonActions` button group was changed to conditionally render the add animation button based on the value of the `currentPageNumber` prop. The logic for rendering the 'reset' button was refactored using the same pattern for consistency.

## To-do

None.

## User-facing changes

Before:
<img width="387" alt="Screen Shot 2022-06-20 at 12 57 59 PM" src="https://user-images.githubusercontent.com/4173034/174656791-a4b92c8a-c6c5-4813-a105-6cbfc52a0856.png">

After:
<img width="424" alt="Screen Shot 2022-06-20 at 12 56 44 PM" src="https://user-images.githubusercontent.com/4173034/174656808-75f9a9da-1bdf-4a88-9b82-73fffc23c63c.png">


## Testing Instructions

Navigate to the first page of a story. Click on an element (that would support animating on the other pages). The 'Add animation' button should not be rendered.

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11602 
