### PR TITLE
Editor: Fixing border between Editor submenus in sidebar

### DIFF
--- a/packages/story-editor/src/components/library/libraryLayout.js
+++ b/packages/story-editor/src/components/library/libraryLayout.js
@@ -47,7 +47,7 @@ const Layout = styled.section.attrs({
 // @todo Verify that L10N works with the translation happening here.
 const TabsArea = styled.nav.attrs({
   'aria-label': __('Library tabs', 'web-stories'),
-});
+})``;
 
 const LibraryPaneContainer = styled.div`
   height: 100%;

--- a/packages/story-editor/src/components/library/libraryLayout.js
+++ b/packages/story-editor/src/components/library/libraryLayout.js
@@ -47,9 +47,7 @@ const Layout = styled.section.attrs({
 // @todo Verify that L10N works with the translation happening here.
 const TabsArea = styled.nav.attrs({
   'aria-label': __('Library tabs', 'web-stories'),
-})`
-  padding: 0 4px;
-`;
+});
 
 const LibraryPaneContainer = styled.div`
   height: 100%;

--- a/packages/story-editor/src/components/style/styleLayout.js
+++ b/packages/story-editor/src/components/style/styleLayout.js
@@ -48,7 +48,7 @@ const Layout = styled.section.attrs({
 
 const TabsArea = styled.nav.attrs({
   'aria-label': __('Style tabs', 'web-stories'),
-});
+})``;
 
 const UnjustifiedTabView = styled(TabView)`
   justify-content: center;

--- a/packages/story-editor/src/components/style/styleLayout.js
+++ b/packages/story-editor/src/components/style/styleLayout.js
@@ -48,9 +48,7 @@ const Layout = styled.section.attrs({
 
 const TabsArea = styled.nav.attrs({
   'aria-label': __('Style tabs', 'web-stories'),
-})`
-  padding: 0 4px;
-`;
+});
 
 const UnjustifiedTabView = styled(TabView)`
   justify-content: center;


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

To fix #11317, this removes the padding between both the style and library submenus. 

Before (thanks @bmattb for the screenshot):
![Before](https://user-images.githubusercontent.com/58738530/164282756-15273795-07fc-4d98-b3c0-7ee7b881e2e3.png)

After
![After](https://user-images.githubusercontent.com/7110244/175113019-7dc05753-f7fe-4b22-ad02-d60979c25780.png)


## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. In the Editor, check that the Style (when an item is selected) and Library submenus have the border extend from end to end of the sidebar. See the screenshots for examples.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [X] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [X] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11317
