### PR TITLE
Design Tab: Make Corners field full width

### DIFF
--- a/packages/story-editor/src/components/form/stackable/stackableGroup.js
+++ b/packages/story-editor/src/components/form/stackable/stackableGroup.js
@@ -45,11 +45,22 @@ const StackableContainer = styled.div`
       border-bottom-right-radius: 4px;
     }
   }
+
+  ${({ $stackableGroupStyleOverride }) => $stackableGroupStyleOverride}
 `;
 
-function StackableGroup({ children, locked, className }) {
+function StackableGroup({
+  children,
+  locked,
+  className,
+  stackableGroupStyleOverride,
+}) {
   return (
-    <StackableContainer locked={locked} className={className}>
+    <StackableContainer
+      $stackableGroupStyleOverride={stackableGroupStyleOverride}
+      locked={locked}
+      className={className}
+    >
       {children}
     </StackableContainer>
   );
@@ -59,6 +70,7 @@ StackableGroup.propTypes = {
   children: PropTypes.node,
   locked: PropTypes.bool,
   className: PropTypes.string,
+  stackableGroupStyleOverride: PropTypes.array,
 };
 
 export default StackableGroup;

--- a/packages/story-editor/src/components/panels/design/sizePosition/radius.js
+++ b/packages/story-editor/src/components/panels/design/sizePosition/radius.js
@@ -69,7 +69,11 @@ const BottomRight = styled(Icons.Corner)`
   transform: rotate(270deg);
 `;
 
-function RadiusControls({ selectedElements, pushUpdateForObject }) {
+function RadiusControls({
+  selectedElements,
+  pushUpdateForObject,
+  stackableGroupStyleOverride,
+}) {
   const borderRadius = useCommonObjectValue(
     selectedElements,
     'borderRadius',
@@ -137,7 +141,10 @@ function RadiusControls({ selectedElements, pushUpdateForObject }) {
 
   return (
     <FlexContainer>
-      <StackableGroup locked={lockRadius}>
+      <StackableGroup
+        stackableGroupStyleOverride={stackableGroupStyleOverride}
+        locked={lockRadius}
+      >
         <StackableInput
           suffix={<TopLeft />}
           value={
@@ -228,6 +235,7 @@ function RadiusControls({ selectedElements, pushUpdateForObject }) {
 RadiusControls.propTypes = {
   selectedElements: PropTypes.array.isRequired,
   pushUpdateForObject: PropTypes.func.isRequired,
+  stackableGroupStyleOverride: PropTypes.array,
 };
 
 export default RadiusControls;

--- a/packages/story-editor/src/components/panels/design/sizePosition/sizePosition.js
+++ b/packages/story-editor/src/components/panels/design/sizePosition/sizePosition.js
@@ -62,6 +62,10 @@ const StyledLockToggle = styled(LockToggle)`
   ${focusStyle};
 `;
 
+const stackableGroupStyleOverride = css`
+  max-width: none;
+`;
+
 function getStickerAspectRatio(element) {
   return stickers?.[element?.sticker?.type].aspectRatio || 1;
 }
@@ -397,7 +401,10 @@ function SizePositionPanel(props) {
           <OpacityControls {...props} />
         </Area>
         <Area area="c">
-          <RadiusControls {...props} />
+          <RadiusControls
+            stackableGroupStyleOverride={stackableGroupStyleOverride}
+            {...props}
+          />
         </Area>
       </Grid>
     </SimplePanel>


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
The 'corner radius' input field within the Style panel is not expanding the full width, making the gird look asymmetric. 

## Summary

<!-- A brief description of what this PR does. -->
Added a style override prop to StackableGroup to allow for override styles - in this case max-width.

## Relevant Technical Choices

<!-- Please describe your changes. -->
Used this approach to allow for other StackableGroups to not be affected unless they opt into using the style override 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->
Before:
![Before field](https://user-images.githubusercontent.com/14057928/175655679-c2e12e10-92b4-4c83-9470-d55ef8e62bdb.png)

After:
![After field](https://user-images.githubusercontent.com/14057928/175655702-57d6eb94-8b68-414c-9028-46436eb27caf.png)

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Go to Story Editor
2. Insert a element that has 'corner radius' (Image, Shape, etc)
3. Click on the element and Go to Style Panel

On Staging:
- Notice 'corner radius' input field does not span the full width like the other fields in that section

On Branch:
- Notice 'corner radius' input field does span the full width like the other fields in that section


## Reviews

### Does this PR have a security-related impact?
No
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
No
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
No
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11318 
