### PR TITLE
Refined tests for element rearrange

### DIFF
--- a/packages/story-editor/src/app/story/useStoryReducer/reducers/arrangeElement.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/reducers/arrangeElement.js
@@ -103,19 +103,26 @@ export const arrangeElement = (
 
   // Update group id on current element
   if (groupId) {
+    // Can only change groups to a group that exists
+    if (!page.groups[groupId]) {
+      return;
+    }
     page.elements[currentPosition].groupId = groupId;
   } else if (groupId === undefined || groupId === null) {
     delete page.elements[currentPosition].groupId;
-    // If there are no elements left in this group, remove the group as well.
-    const groupHasElements = page.elements.find(
-      ({ groupId: elGroupId }) => elGroupId === currentGroupId
+  }
+
+  // If there are no elements left in the group, remove the group as well.
+  if (currentGroupId) {
+    const groupHasElements = page.elements.some(
+      (e) => e.groupId === currentGroupId
     );
     if (!groupHasElements) {
-      delete page.groups?.[currentGroupId];
+      delete page.groups[currentGroupId];
     }
   }
 
-  // Then reorder
+  // Then reorder if relevant
   page.elements = moveArrayElement(page.elements, currentPosition, newPosition);
 };
 

--- a/packages/story-editor/src/app/story/useStoryReducer/test/arrangeElement.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/test/arrangeElement.js
@@ -73,6 +73,9 @@ describe('arrangeElement', () => {
             { id: '234', groupId: 'g1' },
             { id: '345' },
           ],
+          groups: {
+            g1: { name: 'Group 1' },
+          },
         },
       ],
       current: '111',
@@ -95,26 +98,101 @@ describe('arrangeElement', () => {
         {
           id: '111',
           elements: [
-            { id: '123', isBackground: true },
-            { id: '234', groupId: 'g1' },
-            { id: '345' },
+            { id: 'e1', isBackground: true },
+            { id: 'e2', groupId: 'g1' },
+            { id: 'e3', groupId: 'g1' },
+            { id: 'e4', groupId: 'g2' },
           ],
+          groups: {
+            g1: { name: 'Group 1' },
+            g2: { name: 'Group 2' },
+          },
         },
       ],
       current: '111',
     });
 
     const result = arrangeElement({
-      elementId: '234',
+      elementId: 'e3',
+      position: 2,
+      groupId: 'g2',
+    });
+
+    expect(result.pages[0].elements).toStrictEqual([
+      { id: 'e1', isBackground: true },
+      { id: 'e2', groupId: 'g1' },
+      { id: 'e3', groupId: 'g2' },
+      { id: 'e4', groupId: 'g2' },
+    ]);
+  });
+
+  it('should remove group if changing group and the old group is empty', () => {
+    const { restore, arrangeElement } = setupReducer();
+
+    restore({
+      pages: [
+        {
+          id: '111',
+          elements: [
+            { id: 'e1', isBackground: true },
+            { id: 'e2', groupId: 'g1' },
+            { id: 'e3', groupId: 'g2' },
+            { id: 'e4', groupId: 'g2' },
+          ],
+          groups: {
+            g1: { name: 'Group 1' },
+            g2: { name: 'Group 2' },
+          },
+        },
+      ],
+      current: '111',
+    });
+
+    const result = arrangeElement({
+      elementId: 'e2',
       position: 1,
       groupId: 'g2',
     });
 
     expect(result.pages[0].elements).toStrictEqual([
-      { id: '123', isBackground: true },
-      { id: '234', groupId: 'g2' },
-      { id: '345' },
+      { id: 'e1', isBackground: true },
+      { id: 'e2', groupId: 'g2' },
+      { id: 'e3', groupId: 'g2' },
+      { id: 'e4', groupId: 'g2' },
     ]);
+
+    expect(result.pages[0].groups).toStrictEqual({
+      g2: { name: 'Group 2' },
+    });
+  });
+
+  it('should not be able to change group to a group that does not exist', () => {
+    const { restore, arrangeElement } = setupReducer();
+
+    const initialState = restore({
+      pages: [
+        {
+          id: '111',
+          elements: [
+            { id: 'e1', isBackground: true },
+            { id: 'e2', groupId: 'g1' },
+            { id: 'e3', groupId: 'g1' },
+          ],
+          groups: {
+            g1: { name: 'Group 1' },
+          },
+        },
+      ],
+      current: '111',
+    });
+
+    const result = arrangeElement({
+      elementId: 'e2',
+      position: 1,
+      groupId: 'g2',
+    });
+
+    expect(result).toBe(initialState);
   });
 
   it('should remove group if already in the right place, but explicitly without group', () => {
@@ -127,8 +205,11 @@ describe('arrangeElement', () => {
           elements: [
             { id: '123', isBackground: true },
             { id: '234', groupId: 'g1' },
-            { id: '345' },
+            { id: '345', groupId: 'g1' },
           ],
+          groups: {
+            g1: { name: 'Group 1' },
+          },
         },
       ],
       current: '111',
@@ -143,7 +224,7 @@ describe('arrangeElement', () => {
     expect(result.pages[0].elements).toStrictEqual([
       { id: '123', isBackground: true },
       { id: '234' },
-      { id: '345' },
+      { id: '345', groupId: 'g1' },
     ]);
   });
 


### PR DESCRIPTION
## Context

Refining tests to ensure 100% coverage (and adding a case for moving an element from one group to another leaving the old group empty).

## Testing Instructions

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---
Partially addresses #11784