### PR TITLE
 AMP Sanitization: use `wp_replace_insecure_home_url` function

### DIFF
--- a/includes/Renderer/Story/HTML.php
+++ b/includes/Renderer/Story/HTML.php
@@ -69,7 +69,7 @@ class HTML {
 		$markup = $this->story->get_markup();
 		$markup = $this->fix_malformed_script_link_tags( $markup );
 		$markup = $this->replace_html_head( $markup );
-		$markup = $this->replace_url_scheme( $markup );
+		$markup = wp_replace_insecure_home_url( $markup );
 		$markup = $this->print_analytics( $markup );
 		$markup = $this->print_social_share( $markup );
 
@@ -193,24 +193,6 @@ class HTML {
 		}
 
 		return $content;
-	}
-
-	/**
-	 * Force home urls to http / https based on context.
-	 *
-	 * @since 1.1.0
-	 *
-	 * @param string $content String to replace.
-	 */
-	protected function replace_url_scheme( string $content ): string {
-		if ( is_ssl() ) {
-			$search  = home_url( '', 'http' );
-			$replace = home_url( '', 'https' );
-			$content = str_replace( $search, $replace, $content );
-		}
-
-		return $content;
-
 	}
 
 	/**

--- a/tests/phpunit/integration/tests/Renderer/Story/HTML.php
+++ b/tests/phpunit/integration/tests/Renderer/Story/HTML.php
@@ -141,39 +141,6 @@ class HTML extends TestCase {
 	}
 
 	/**
-	 * @covers ::replace_url_scheme
-	 */
-	public function test_replace_url_scheme(): void {
-		$_SERVER['HTTPS'] = 'on';
-
-		$link = get_home_url( null, 'web-storires/test' );
-		$link = set_url_scheme( $link, 'http' );
-
-		$link_https = set_url_scheme( $link, 'https' );
-
-		$story    = new Story();
-		$renderer = new \Google\Web_Stories\Renderer\Story\HTML( $story );
-
-		$result = $this->call_private_method( $renderer, 'replace_url_scheme', [ $link ] );
-		$this->assertEquals( $result, $link_https );
-	}
-
-
-	/**
-	 * @covers ::replace_url_scheme
-	 */
-	public function test_replace_url_scheme_different_host(): void {
-		$_SERVER['HTTPS'] = 'on';
-		$link             = 'https://www.google.com';
-
-		$story    = new Story();
-		$renderer = new \Google\Web_Stories\Renderer\Story\HTML( $story );
-
-		$result = $this->call_private_method( $renderer, 'replace_url_scheme', [ $link ] );
-		$this->assertEquals( $result, $link );
-	}
-
-	/**
 	 * @covers ::print_analytics
 	 */
 	public function test_print_analytics(): void {


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Use`wp_replace_insecure_home_url` function that is present in WordPress 5.7.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11444
