### PR TITLE
Editor: Multipage redesign

### DIFF
--- a/packages/story-editor/src/app/layout/useZoomSetting.js
+++ b/packages/story-editor/src/app/layout/useZoomSetting.js
@@ -32,6 +32,7 @@ import {
   ZOOM_SETTING,
   PAGE_NAV_WIDTH,
   PAGE_WIDTH_FACTOR,
+  MAX_EXTRA_PAGES,
 } from '../../constants';
 
 // Beware, that these are slightly magic numbers, that just happens to look good
@@ -167,7 +168,7 @@ function calculateViewportProperties(workspaceSize, zoomSetting, zoomLevel) {
   const extraPageWidth = Math.round(0.9 * pageWidth);
   const hasExtraPages = !hasAnyOverflow && hasPageNavigation && extraSpace > 50;
   const extraPageCount = hasExtraPages
-    ? Math.ceil(extraSpace / extraPageWidth)
+    ? Math.min(MAX_EXTRA_PAGES, Math.ceil(extraSpace / extraPageWidth))
     : 0;
   return {
     pageWidth,

--- a/packages/story-editor/src/components/canvas/extraPages.js
+++ b/packages/story-editor/src/components/canvas/extraPages.js
@@ -45,7 +45,6 @@ const ExtraPageList = styled.ol`
   display: flex;
   flex-direction: ${({ isPrevious }) => (isPrevious ? 'row-reverse' : 'row')};
   width: ${({ listWidth }) => listWidth}px;
-  height: ${({ extraPageHeight }) => extraPageHeight}px;
   margin: 0;
   padding: 0 ${GAP}px;
   gap: ${GAP}px;
@@ -158,7 +157,6 @@ function ExtraPages({ isPrevious = false }) {
                 pageNum + 1
               )}
               width={extraPageWidth - GAP}
-              height={extraPageHeight}
             />
           </ExtraPage>
         ))}

--- a/packages/story-editor/src/components/canvas/extraPages.js
+++ b/packages/story-editor/src/components/canvas/extraPages.js
@@ -23,6 +23,7 @@ import { PAGE_RATIO } from '@googleforcreators/units';
 import PropTypes from 'prop-types';
 import { __, sprintf } from '@googleforcreators/i18n';
 import { useFeature } from 'flagged';
+import { useTransform } from '@googleforcreators/transform';
 
 /**
  * Internal dependencies
@@ -56,11 +57,14 @@ const ExtraPage = styled.li`
   border-radius: 4px;
   background-color: white;
 
-  opacity: 0.5;
+  // First extra page is at 60% opacity, then 45, 30, and 15
+  opacity: ${({ $distance }) => 0.6 - $distance * 0.15};
   transition: opacity 0.2s ease;
   &:hover {
     opacity: 1;
   }
+
+  ${({ $inert }) => $inert && 'pointer-events: none;'}
 `;
 const ExtraPagePreview = styled(PagePreview)`
   cursor: pointer;
@@ -107,6 +111,10 @@ function ExtraPages({ isPrevious = false }) {
       extraPageCount,
     })
   );
+  const isAnythingTransforming = useTransform(
+    ({ state: { isAnythingTransforming } }) => isAnythingTransforming
+  );
+
   const isExtraPagesEnabled = useFeature('extraPages');
   const pageCount = pages?.length;
   if (!pageCount || !isExtraPagesEnabled) {
@@ -134,8 +142,13 @@ function ExtraPages({ isPrevious = false }) {
         listWidth={listWidth}
         extraPageHeight={extraPageHeight}
       >
-        {pagesToShow.map((pageNum) => (
-          <ExtraPage key={pageNum} extraPageWidth={extraPageWidth}>
+        {pagesToShow.map((pageNum, index) => (
+          <ExtraPage
+            key={pageNum}
+            extraPageWidth={extraPageWidth}
+            $inert={isAnythingTransforming}
+            $distance={index}
+          >
             <ExtraPagePreview
               page={pages[pageNum]}
               onClick={clickPage(pages[pageNum].id)}

--- a/packages/story-editor/src/components/footer/carousel/constants.js
+++ b/packages/story-editor/src/components/footer/carousel/constants.js
@@ -32,9 +32,9 @@ export const DRAWER_BUTTON_GAP_COLLAPSED = 2;
 
 // Thumbnail size varies with available carousel size - over or under this limit
 export const WIDE_CAROUSEL_LIMIT = 400;
-export const WIDE_THUMBNAIL_WIDTH = 40;
-export const WIDE_THUMBNAIL_HEIGHT = 60;
+export const WIDE_THUMBNAIL_WIDTH = 45;
+export const WIDE_THUMBNAIL_HEIGHT = 80;
 export const NARROW_THUMBNAIL_WIDTH = 36;
-export const NARROW_THUMBNAIL_HEIGHT = 54;
+export const NARROW_THUMBNAIL_HEIGHT = 64;
 export const THUMBNAIL_MARGIN = 16;
 export const THUMBNAIL_LINE_WIDTH = 4;

--- a/packages/story-editor/src/components/footer/gridview/gridView.js
+++ b/packages/story-editor/src/components/footer/gridview/gridView.js
@@ -26,7 +26,7 @@ import {
   useResizeEffect,
 } from '@googleforcreators/react';
 import { __, sprintf } from '@googleforcreators/i18n';
-import { PAGE_RATIO } from '@googleforcreators/units';
+import { FULLBLEED_RATIO } from '@googleforcreators/units';
 import {
   Slider,
   Button,
@@ -177,7 +177,7 @@ function GridView({ onClose }) {
   const pageGridGap = Math.floor(
     (availableWidth - actualPageWidths) / (pagesPerRow - 1)
   );
-  const pageHeight = pageWidth / PAGE_RATIO;
+  const pageHeight = pageWidth / FULLBLEED_RATIO;
 
   const handleClickPage = (page) => () => setCurrentPage({ pageId: page.id });
 

--- a/packages/story-editor/src/components/footer/pagepreview/index.js
+++ b/packages/story-editor/src/components/footer/pagepreview/index.js
@@ -149,7 +149,12 @@ function PagePreview({ page, label, ...props }) {
         <Page ref={setPageRef} aria-label={label} {...props}>
           <PreviewWrapper background={backgroundColor}>
             {pageImage ? (
-              <Image src={pageImage} alt={label} decoding="async" />
+              <Image
+                draggable="false"
+                src={pageImage}
+                alt={label}
+                decoding="async"
+              />
             ) : (
               page.elements.map((element) => (
                 <DisplayElement

--- a/packages/story-editor/src/components/thumbnail/constants.js
+++ b/packages/story-editor/src/components/thumbnail/constants.js
@@ -19,8 +19,8 @@
 import { __ } from '@googleforcreators/i18n';
 
 export const THUMBNAIL_DIMENSIONS = {
-  WIDTH: 52,
-  HEIGHT: 78,
+  WIDTH: 54,
+  HEIGHT: 96,
   NESTED_ICON: 32,
   THUMBNAIL_SHAPE: 36,
 };

--- a/packages/story-editor/src/constants/index.js
+++ b/packages/story-editor/src/constants/index.js
@@ -46,6 +46,7 @@ export const CAROUSEL_STATE = {
 export const CAROUSEL_TRANSITION_DURATION = 300;
 
 export const PAGE_WIDTH_FACTOR = 12;
+export const MAX_EXTRA_PAGES = 4;
 
 export const DESIGN_SPACE_MARGIN = 48;
 


### PR DESCRIPTION
## Context

This addresses the UX points raised in #11845.

## User-facing changes

| Feature | Before | After |
|-|-|-|
| Pages fading<br><br>Context page proportions<br><br>Carousel page proportions | <img width="1598" alt="Screen Shot 2022-07-19 at 11 41 34" src="https://user-images.githubusercontent.com/637548/179722510-b1f72ae7-794b-46cd-82ca-63a94dcf47f2.png"> | <img width="1598" alt="Screen Shot 2022-07-19 at 11 41 02" src="https://user-images.githubusercontent.com/637548/179722484-e0b68d45-abbc-4ac3-baa2-a7a0a4162e49.png"> |
| Grid view page proportions | <img width="1958" alt="Screen Shot 2022-07-19 at 11 42 03" src="https://user-images.githubusercontent.com/637548/179722629-0269f226-7d8c-41e7-a5c8-c015ed13f073.png"> | <img width="1958" alt="Screen Shot 2022-07-19 at 11 43 35" src="https://user-images.githubusercontent.com/637548/179722646-e23c9f72-329b-42d8-a41e-2b1f48aa64d2.png"> |
| Checklist page proportions | <img width="323" alt="Screen Shot 2022-07-19 at 11 50 31" src="https://user-images.githubusercontent.com/637548/179722687-14757a5c-4297-42e6-bb8a-3a9aaae90faa.png"> | <img width="323" alt="Screen Shot 2022-07-19 at 11 44 29" src="https://user-images.githubusercontent.com/637548/179722700-0c6ba54b-e37b-4566-a02f-84363615a45f.png"> |

## Testing Instructions

This PR can be tested by following these steps:

0. Make sure the "Context pages" experiment is enabled
1. Add content to the top of the first page above the safe zone and at the bottom of the page below the safe zone.
2. Add 5 more pages
3. Observe that the context pages before the current page fade out and only 4 are shown (resize window to show more pages)
4. Go back to the second page and observe the first page in the context and see that the top and bottom content is visible.
5. Observe that the top and bottom content is also visible in the carousel, in the gridview and in the checklist.
6. And any element to the current (second) page
7. Try to drag the current element to the first page and observe that the page does not seem to interact when an element is dragged "over" (or behind) it.
8. Try to resize the current element in the same way so the handle overlaps the previous page and observe that the page does not seem to interact when an element is resized "over" (or behind) it.
9. Try to drag something from the first page and observe that no meaningful interaction happens (a lasso selection starts, which is fine)

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #11845
