### PR TITLE
Fix story poster meta fallback

### DIFF
--- a/includes/Model/Story.php
+++ b/includes/Model/Story.php
@@ -194,17 +194,17 @@ class Story {
 					$this->poster_srcset = (string) wp_calculate_image_srcset( $size_array, $poster_url, $image_meta, $thumbnail_id );
 				}
 			}
-		}
-
-		/**
-		 * Poster.
-		 *
-		 * @var array{url?:string, width?: int, height?: int}|false $poster
-		 */
-		$poster = get_post_meta( $post->ID, Story_Post_Type::POSTER_META_KEY, true );
-		if ( $poster ) {
-			$this->poster_portrait      = $poster['url'];
-			$this->poster_portrait_size = [ (int) $poster['width'], (int) $poster['height'] ];
+		} else {
+			/**
+			 * Poster.
+			 *
+			 * @var array{url?:string, width?: int, height?: int}|false $poster
+			 */
+			$poster = get_post_meta( $post->ID, Story_Post_Type::POSTER_META_KEY, true );
+			if ( ! empty( $poster ) ) {
+				$this->poster_portrait      = $poster['url'];
+				$this->poster_portrait_size = [ (int) $poster['width'], (int) $poster['height'] ];
+			}
 		}
 
 		/**

--- a/packages/wp-story-editor/src/api/story.js
+++ b/packages/wp-story-editor/src/api/story.js
@@ -121,7 +121,14 @@ export function saveStoryById(config, story) {
   }).then((data) => {
     const { _embedded: embedded = {}, meta, ...rest } = data;
 
-    let featuredMedia = {};
+    let featuredMedia = {
+      id: 0,
+      height: 0,
+      width: 0,
+      url: '',
+      needsProxy: false,
+      isExternal: false,
+    };
 
     const externalPoster = meta['web_stories_poster'];
     const postThumbnail = embedded?.['wp:featuredmedia']?.[0];

--- a/packages/wp-story-editor/src/api/test/story.js
+++ b/packages/wp-story-editor/src/api/test/story.js
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * External dependencies
+ */
+import { bindToCallbacks } from '@web-stories-wp/wp-utils';
+
+/**
+ * Internal dependencies
+ */
+import * as apiCallbacks from '..';
+
+jest.mock('@wordpress/api-fetch');
+
+describe('Story API Callbacks', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('saveStoryById', () => {
+    it('uses featured image', async () => {
+      apiFetch.mockReturnValue(
+        Promise.resolve({
+          id: 123,
+          meta: {},
+          _embedded: {
+            'wp:featuredmedia': [
+              {
+                id: 567,
+                source_url: 'https://example.com/featuredimage.jpg',
+                media_details: {
+                  width: 640,
+                  height: 853,
+                },
+              },
+            ],
+          },
+        })
+      );
+      const { saveStoryById } = bindToCallbacks(apiCallbacks, {
+        api: { stories: '/web-stories/v1/web-story/' },
+      });
+
+      await expect(
+        saveStoryById({
+          storyId: 123,
+          featuredMedia: {},
+          author: {},
+        })
+      ).resolves.toStrictEqual(
+        expect.objectContaining({
+          id: 123,
+          featuredMedia: {
+            id: 567,
+            width: 640,
+            height: 853,
+            isExternal: false,
+            needsProxy: false,
+            url: 'https://example.com/featuredimage.jpg',
+          },
+        })
+      );
+    });
+
+    it('uses hotlinked poster from post meta', async () => {
+      apiFetch.mockReturnValue(
+        Promise.resolve({
+          id: 123,
+          meta: {
+            web_stories_poster: {
+              url: 'https://example.com/hotlinked.jpg',
+              width: 640,
+              height: 853,
+              needsProxy: true,
+            },
+          },
+          _embedded: {
+            'wp:featuredmedia': [],
+          },
+        })
+      );
+      const { saveStoryById } = bindToCallbacks(apiCallbacks, {
+        api: { stories: '/web-stories/v1/web-story/' },
+      });
+
+      await expect(
+        saveStoryById({
+          storyId: 123,
+          featuredMedia: {},
+          author: {},
+        })
+      ).resolves.toStrictEqual(
+        expect.objectContaining({
+          id: 123,
+          featuredMedia: {
+            id: 0,
+            width: 640,
+            height: 853,
+            isExternal: true,
+            needsProxy: true,
+            url: 'https://example.com/hotlinked.jpg',
+          },
+        })
+      );
+    });
+
+    it('uses featured image over hotlinked poster from post meta', async () => {
+      apiFetch.mockReturnValue(
+        Promise.resolve({
+          id: 123,
+          meta: {
+            web_stories_poster: {
+              url: 'https://example.com/hotlinked.jpg',
+              width: 640,
+              height: 853,
+              needsProxy: true,
+            },
+          },
+          _embedded: {
+            'wp:featuredmedia': [
+              {
+                id: 567,
+                source_url: 'https://example.com/featuredimage.jpg',
+                media_details: {
+                  width: 640,
+                  height: 853,
+                },
+              },
+            ],
+          },
+        })
+      );
+      const { saveStoryById } = bindToCallbacks(apiCallbacks, {
+        api: { stories: '/web-stories/v1/web-story/' },
+      });
+
+      await expect(
+        saveStoryById({
+          storyId: 123,
+          featuredMedia: {},
+          author: {},
+        })
+      ).resolves.toStrictEqual(
+        expect.objectContaining({
+          id: 123,
+          featuredMedia: {
+            id: 567,
+            width: 640,
+            height: 853,
+            isExternal: false,
+            needsProxy: false,
+            url: 'https://example.com/featuredimage.jpg',
+          },
+        })
+      );
+    });
+
+    it('returns "empty" object when there is no featured image', async () => {
+      apiFetch.mockReturnValue(
+        Promise.resolve({
+          id: 123,
+          meta: {},
+          _embedded: {
+            'wp:featuredmedia': [],
+          },
+        })
+      );
+      const { saveStoryById } = bindToCallbacks(apiCallbacks, {
+        api: { stories: '/web-stories/v1/web-story/' },
+      });
+
+      await expect(
+        saveStoryById({
+          storyId: 123,
+          featuredMedia: {},
+          author: {},
+        })
+      ).resolves.toStrictEqual(
+        expect.objectContaining({
+          id: 123,
+          featuredMedia: {
+            id: 0,
+            width: 0,
+            height: 0,
+            isExternal: false,
+            needsProxy: false,
+            url: '',
+          },
+        })
+      );
+    });
+  });
+});

--- a/tests/phpunit/integration/tests/Model/Story.php
+++ b/tests/phpunit/integration/tests/Model/Story.php
@@ -85,8 +85,7 @@ class Story extends TestCase {
 
 		$this->assertEquals( $story->get_title(), 'test title' );
 		$this->assertEquals( $story->get_url(), get_permalink( $post ) );
-		$this->assertNotEmpty( $story->get_poster_portrait() );
-		$this->assertIsString( $story->get_poster_portrait() );
+		$this->assertStringContainsString( 'canola.jpg', $story->get_poster_portrait() );
 		$this->assertNotEmpty( $story->get_poster_sizes() );
 		$this->assertIsString( $story->get_poster_sizes() );
 		$this->assertNotEmpty( $story->get_poster_srcset() );
@@ -124,6 +123,52 @@ class Story extends TestCase {
 		$this->assertEquals( 'http://www.example.com/image.png', $story->get_poster_portrait() );
 		$this->assertEqualSets( [ 1000, 1000 ], $story->get_poster_portrait_size() );
 		$this->assertEmpty( $story->get_poster_srcset() );
+	}
+
+	/**
+	 * @covers ::load_from_post
+	 */
+	public function test_load_from_post_with_poster_and_poster_meta(): void {
+		$post = self::factory()->post->create_and_get(
+			[
+				'post_title'   => 'test title',
+				'post_type'    => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
+				'post_content' => '<html><head></head><body><amp-story></amp-story></body></html>',
+			]
+		);
+
+		$poster_attachment_id = self::factory()->attachment->create_object(
+			[
+				'file'           => DIR_TESTDATA . '/images/canola.jpg',
+				'post_parent'    => 0,
+				'post_mime_type' => 'image/jpeg',
+				'post_title'     => 'Test Image',
+			]
+		);
+		wp_maybe_generate_attachment_metadata( get_post( $poster_attachment_id ) );
+		set_post_thumbnail( $post->ID, $poster_attachment_id );
+
+		add_post_meta(
+			$post->ID,
+			\Google\Web_Stories\Story_Post_Type::POSTER_META_KEY,
+			[
+				'url'        => 'http://www.example.com/image.png',
+				'height'     => 1000,
+				'width'      => 1000,
+				'needsProxy' => false,
+			]
+		);
+
+		$story = new \Google\Web_Stories\Model\Story();
+		$story->load_from_post( $post );
+
+		$this->assertEquals( $story->get_title(), 'test title' );
+		$this->assertEquals( $story->get_url(), get_permalink( $post ) );
+		$this->assertStringContainsString( 'canola.jpg', $story->get_poster_portrait() );
+		$this->assertNotEmpty( $story->get_poster_sizes() );
+		$this->assertIsString( $story->get_poster_sizes() );
+		$this->assertNotEmpty( $story->get_poster_srcset() );
+		$this->assertIsString( $story->get_poster_srcset() );
 	}
 
 	/**


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

It was reported that poster images could not be reliably saved anymore, with the 

## Summary

<!-- A brief description of what this PR does. -->

While looking into this bug, I noticed two issues:

1. When adding a poster image using "Upload file" (**not** hotlinking!), I still ended up with the `web_stories_poster` meta field set with the poster URL.
2. Both the Story model and the `saveStoryById` callback override the poster image with the meta value even if there was a legit featured image set

Combined, this led to the reported behavior of the story poster randomly resetting to the previous one.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

This needs tests.

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

No more random poster resets

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add a story poster image
2. Save story
3. Change the story poster
4. Save story
5. Poster should persist


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11980
