### PR TITLE
Panels: fix excessive tracking events

### DIFF
--- a/packages/story-editor/src/components/panels/panel/panel.js
+++ b/packages/story-editor/src/components/panels/panel/panel.js
@@ -126,12 +126,20 @@ function Panel({
     if (resizable) {
       setHeight(0);
     }
+  }, [resizable, canCollapse, setHeight]);
+
+  const onCollapse = useCallback(() => {
+    if (!canCollapse) {
+      return;
+    }
+
+    collapse();
 
     trackEvent('panel_toggled', {
       name: name,
       status: 'collapsed',
     });
-  }, [resizable, canCollapse, name, setHeight]);
+  }, [canCollapse, collapse, name]);
 
   const expand = useCallback(
     (restoreHeight = true) => {
@@ -140,13 +148,20 @@ function Panel({
       if (restoreHeight && resizable) {
         setHeight(expandToHeight);
       }
+    },
+    [resizable, expandToHeight, setHeight]
+  );
+
+  const onExpand = useCallback(
+    (restoreHeight = true) => {
+      expand(restoreHeight);
 
       trackEvent('panel_toggled', {
         name: name,
         status: 'expanded',
       });
     },
-    [resizable, expandToHeight, name, setHeight]
+    [expand, name]
   );
 
   // Expand panel on first mount/on selection change if it can't be persisted.
@@ -262,8 +277,8 @@ function Panel({
     actions: {
       setHeight: manuallySetHeight,
       setExpandToHeight,
-      collapse,
-      expand,
+      collapse: onCollapse,
+      expand: onExpand,
       resetHeight,
       confirmTitle,
     },


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

I noticed that there were tons of `panel_toggled` tracking events being fired because the `collapse` and `expand` callbacks were fired within effects.

Whenever you selected an element, the events fired.

## Summary

<!-- A brief description of what this PR does. -->

This PR fixes the excessive firing of these events by splitting up these callbacks so that the tracking events are only fired on actual user interaction.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

n/a

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ 
-[x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
