### PR TITLE
Editor: Fixed delay before trimming a new recording

### DIFF
--- a/packages/story-editor/src/components/videoTrim/useVideoNode.js
+++ b/packages/story-editor/src/components/videoTrim/useVideoNode.js
@@ -122,7 +122,8 @@ function useVideoNode(videoData) {
     if (isFinite(videoNode.duration) && startOffset === null) {
       onLoadedMetadata({ target: videoNode });
     } else if (!isFinite(videoNode.duration)) {
-      // Video is a blob of unknown length, wait until it finishes
+      // Video is a blob of unknown length, seek to infinity and wait until it's ready
+      videoNode.currentTime = Number.MAX_SAFE_INTEGER;
       videoNode.addEventListener('timeupdate', onLoadedMetadata);
     } else {
       // Video hasn't loaded yet, wait for that

--- a/packages/story-editor/src/components/videoTrim/useVideoNode.js
+++ b/packages/story-editor/src/components/videoTrim/useVideoNode.js
@@ -123,6 +123,7 @@ function useVideoNode(videoData) {
       onLoadedMetadata({ target: videoNode });
     } else if (!isFinite(videoNode.duration)) {
       // Video is a blob of unknown length, seek to infinity and wait until it's ready
+      // @see https://crbug.com/642012
       videoNode.currentTime = Number.MAX_SAFE_INTEGER;
       videoNode.addEventListener('timeupdate', onLoadedMetadata);
     } else {


### PR DESCRIPTION
## Context

This was surprisingly easy to fix by simply seeking to `MAX_SAFE_INTEGER` when trimming is entered with a video node with duration set to infinity (once seeking past the end, the DOM will be updated with the actual video duration).

## Testing Instructions

1. Start a video recording
2. Record at least a minute of video
3. As soon as the recording is stopped, press the scissor icon to go into trimming mode
4. Observe that trimming mode is entered instantly with (almost) no delay
5. Test this in a large combination of OS and browser

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #11987
