### PR TITLE
Add Jest test for custom font selection

### DIFF
--- a/packages/wp-dashboard/src/components/editorSettings/customFonts/test/customFonts.js
+++ b/packages/wp-dashboard/src/components/editorSettings/customFonts/test/customFonts.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import CustomFontsSettings, { TEXT } from '..';
+import { renderWithProviders } from '../../../../testUtils';
+
+describe('Editor Settings: CustomFontsSettings <CustomFontsSettings />', function () {
+    let mockUpdate;
+    let mockDelete;
+
+    beforeEach(() => {
+        mockUpdate = jest.fn(() => { });
+        mockDelete = jest.fn(() => { });
+    });
+
+    afterEach(() => {
+    });
+
+    it('should render CustomFontsSettings input and helper text by default', function () {
+        renderWithProviders(
+            <CustomFontsSettings
+                customFonts={[]}
+                addCustomFont={mockUpdate}
+                deleteCustomFont={mockDelete}
+            />
+        );
+
+        const input = screen.getByRole('textbox');
+        expect(input).toBeInTheDocument();
+        expect(input).toBeEnabled();
+
+        const sectionHeader = screen.getByText(TEXT.SECTION_HEADING);
+        expect(sectionHeader).toBeInTheDocument();
+    });
+});

--- a/packages/wp-dashboard/src/components/editorSettings/customFonts/test/customFonts.js
+++ b/packages/wp-dashboard/src/components/editorSettings/customFonts/test/customFonts.js
@@ -24,20 +24,25 @@ import { fireEvent, screen } from '@testing-library/react';
 import CustomFontsSettings, { TEXT } from '..';
 import { renderWithProviders } from '../../../../testUtils';
 
-describe('Editor Settings: CustomFontsSettings <CustomFontsSettings />', function () {
-  it('should render and select font when clicked', function () {
+describe('Editor Settings: <CustomFontsSettings />', () => {
+  it('should select font when clicked', () => {
     renderWithProviders(
       <CustomFontsSettings
         customFonts={[
           {
-            id: 1,
+            id: 609,
             family: 'Overpass ExtraBold Italic',
             url: 'https://example.com/overpass-extrabold-italic.ttf',
           },
           {
-            id: 2,
+            id: 610,
             family: 'Overpass Regular',
             url: 'https://example.com/overpass-regular.ttf',
+          },
+          {
+            id: 611,
+            family: 'Overpass SemiBold Italic',
+            url: 'https://example.com/overpass-semibold-italic.ttf',
           },
         ]}
         addCustomFont={jest.fn}
@@ -45,9 +50,8 @@ describe('Editor Settings: CustomFontsSettings <CustomFontsSettings />', functio
       />
     );
 
-    const input = screen.getByRole('textbox');
-    expect(input).toBeInTheDocument();
-    expect(input).toBeEnabled();
+    const heading = screen.getByText(TEXT.SECTION_HEADING);
+    expect(heading).toBeInTheDocument();
 
     const textContext = screen.getByText(TEXT.ADD_CONTEXT);
     expect(textContext).toBeInTheDocument();
@@ -55,6 +59,6 @@ describe('Editor Settings: CustomFontsSettings <CustomFontsSettings />', functio
     fireEvent.click(screen.getByText('Overpass Regular'));
 
     const selected = screen.getByRole('option', { selected: true });
-    expect(selected.id).toBe('font-2');
+    expect(selected.id).toBe('font-610');
   });
 });

--- a/packages/wp-dashboard/src/components/editorSettings/customFonts/test/customFonts.js
+++ b/packages/wp-dashboard/src/components/editorSettings/customFonts/test/customFonts.js
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * External dependencies
  */
@@ -10,31 +25,36 @@ import CustomFontsSettings, { TEXT } from '..';
 import { renderWithProviders } from '../../../../testUtils';
 
 describe('Editor Settings: CustomFontsSettings <CustomFontsSettings />', function () {
-    let mockUpdate;
-    let mockDelete;
+  it('should render and select font when clicked', function () {
+    renderWithProviders(
+      <CustomFontsSettings
+        customFonts={[
+          {
+            id: 1,
+            family: 'Overpass ExtraBold Italic',
+            url: 'https://example.com/overpass-extrabold-italic.ttf',
+          },
+          {
+            id: 2,
+            family: 'Overpass Regular',
+            url: 'https://example.com/overpass-regular.ttf',
+          },
+        ]}
+        addCustomFont={jest.fn}
+        deleteCustomFont={jest.fn}
+      />
+    );
 
-    beforeEach(() => {
-        mockUpdate = jest.fn(() => { });
-        mockDelete = jest.fn(() => { });
-    });
+    const input = screen.getByRole('textbox');
+    expect(input).toBeInTheDocument();
+    expect(input).toBeEnabled();
 
-    afterEach(() => {
-    });
+    const textContext = screen.getByText(TEXT.ADD_CONTEXT);
+    expect(textContext).toBeInTheDocument();
 
-    it('should render CustomFontsSettings input and helper text by default', function () {
-        renderWithProviders(
-            <CustomFontsSettings
-                customFonts={[]}
-                addCustomFont={mockUpdate}
-                deleteCustomFont={mockDelete}
-            />
-        );
+    fireEvent.click(screen.getByText('Overpass Regular'));
 
-        const input = screen.getByRole('textbox');
-        expect(input).toBeInTheDocument();
-        expect(input).toBeEnabled();
-
-        const sectionHeader = screen.getByText(TEXT.SECTION_HEADING);
-        expect(sectionHeader).toBeInTheDocument();
-    });
+    const selected = screen.getByRole('option', { selected: true });
+    expect(selected.id).toBe('font-2');
+  });
 });


### PR DESCRIPTION
## Context

This replaces an end to end test that was removed in #11782

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Adds Jest test for font selection

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

No

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

No

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

No

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11929
