### PR TITLE
3P Media: Enable stickers support by default 

### DIFF
--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -417,6 +417,7 @@ class Experiments extends Service_Base implements HasRequirements {
 				'label'       => __( 'Stickers', 'web-stories' ),
 				'description' => __( 'Enable Tenor stickers support', 'web-stories' ),
 				'group'       => 'editor',
+				'default'     => true,
 			],
 		];
 	}


### PR DESCRIPTION
## Context

We want to enable Tenor stickers support by default in the next release

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Enable Tenor stickers by default

Set default property to `true` for Tenor stickers

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

![Screenshot 2022-07-26 at 14 51 25](https://user-images.githubusercontent.com/841956/181010185-e1cd575a-be11-4284-9d4b-bf21c64097f5.png)


## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Visit the Third-party media tab
2. Note `Stickers` exists without turning on the experiment
3. Verify that searching, filtering, and inserting stickers works as expected
4. Stickers should display properly in all browsers


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11936
