### PR TITLE
Fix issues with uploading and hotlinking story poster

### DIFF
--- a/includes/Admin/Dashboard.php
+++ b/includes/Admin/Dashboard.php
@@ -322,7 +322,7 @@ class Dashboard extends Service_Base {
 					'_embed'                => rawurlencode(
 						implode(
 							',',
-							[ 'wp:lock', 'wp:lockuser', 'author', 'wp:featuredmedia' ]
+							[ 'wp:lock', 'wp:lockuser', 'author' ]
 						)
 					),
 					'context'               => 'edit',
@@ -348,6 +348,7 @@ class Dashboard extends Service_Base {
 								'date_gmt',
 								'modified',
 								'modified_gmt',
+								'story_poster',
 								'link',
 								'preview_link',
 								'edit_link',

--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -655,9 +655,9 @@ class Stories_Controller extends Stories_Base_Controller {
 	 * @since 1.23.2
 	 *
 	 * @param WP_Post $post Post Object.
-	 * @return array{url:string, width: int, height: int, needsProxy: bool, id?: int} Story poster data.
+	 * @return array{url:string, width: int, height: int, needsProxy: bool, id?: int}|null Story poster data.
 	 */
-	private function get_story_poster( WP_Post $post ): array {
+	private function get_story_poster( WP_Post $post ): ?array {
 		$thumbnail_id = (int) get_post_thumbnail_id( $post );
 
 		if ( 0 !== $thumbnail_id ) {

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -238,7 +238,7 @@ class Story_Post_Type extends Post_Type_Base implements HasRequirements, HasMeta
 								'description' => __( 'Poster height', 'web-stories' ),
 							],
 							'url'        => [
-								'description' => __( 'Poster url.', 'web-stories' ),
+								'description' => __( 'Poster URL.', 'web-stories' ),
 								'type'        => 'string',
 								'format'      => 'uri',
 							],
@@ -247,7 +247,6 @@ class Story_Post_Type extends Post_Type_Base implements HasRequirements, HasMeta
 								'type'        => 'integer',
 							],
 						],
-
 					],
 				],
 				'default'      => [],

--- a/includes/templates/admin/edit-story.php
+++ b/includes/templates/admin/edit-story.php
@@ -95,7 +95,7 @@ $story_query_params = [
 	'_embed'  => rawurlencode(
 		implode(
 			',',
-			[ 'wp:featuredmedia', 'wp:lockuser', 'author', 'wp:publisherlogo', 'wp:term' ]
+			[ 'wp:lockuser', 'author', 'wp:publisherlogo', 'wp:term' ]
 		)
 	),
 	'context' => 'edit',
@@ -111,7 +111,7 @@ $story_query_params = [
 				'modified',
 				'excerpt',
 				'link',
-				'meta.web_stories_poster',
+				'story_poster',
 				'story_data',
 				'preview_link',
 				'edit_link',

--- a/packages/story-editor/src/app/story/actions/test/useAutoSave.js
+++ b/packages/story-editor/src/app/story/actions/test/useAutoSave.js
@@ -120,14 +120,10 @@ describe('useAutoSave', () => {
       ...story,
       pages,
       content: 'Hello World!',
-      meta: {
-        web_stories_poster: undefined,
-        web_stories_publisher_logo: 1,
-        web_stories_products: [],
-      },
+      products: [],
     };
-    delete expected.publisherLogo;
     delete expected.taxonomies;
+
     expect(autoSaveById).toHaveBeenCalledWith(expected);
   });
 
@@ -198,19 +194,10 @@ describe('useAutoSave', () => {
       ...story,
       pages,
       content: 'Hello World!',
-      meta: {
-        web_stories_poster: {
-          height: 100,
-          url: 'https://example.com/image.png',
-          width: 100,
-          needsProxy: false,
-        },
-        web_stories_publisher_logo: 1,
-        web_stories_products: [],
-      },
+      products: [],
     };
-    delete expected.publisherLogo;
     delete expected.taxonomies;
+
     expect(autoSaveById).toHaveBeenCalledWith(expected);
   });
 });

--- a/packages/story-editor/src/app/story/utils/getStoryPropsToSave.js
+++ b/packages/story-editor/src/app/story/utils/getStoryPropsToSave.js
@@ -25,7 +25,7 @@ import objectPick from '../../../utils/objectPick';
 import getAllProdcuts from './getAllProducts';
 
 function getStoryPropsToSave({ story, pages, metadata, flags }) {
-  const { terms, featuredMedia, ...propsFromStory } = objectPick(story, [
+  const { terms, ...propsFromStory } = objectPick(story, [
     'title',
     'status',
     'author',
@@ -34,6 +34,7 @@ function getStoryPropsToSave({ story, pages, metadata, flags }) {
     'slug',
     'excerpt',
     'featuredMedia',
+    'publisherLogo',
     'password',
     'currentStoryStyles',
     'globalStoryStyles',
@@ -49,19 +50,7 @@ function getStoryPropsToSave({ story, pages, metadata, flags }) {
     pages,
     ...propsFromStory,
     ...terms,
-    featuredMedia,
-    meta: {
-      web_stories_publisher_logo: story.publisherLogo?.id,
-      web_stories_products: products,
-      web_stories_poster: featuredMedia.isExternal
-        ? {
-            url: featuredMedia.url,
-            width: featuredMedia.width,
-            height: featuredMedia.height,
-            needsProxy: featuredMedia.needsProxy,
-          }
-        : undefined,
-    },
+    products,
   };
 }
 

--- a/packages/story-editor/src/app/story/utils/test/getStoryPropsToSave.js
+++ b/packages/story-editor/src/app/story/utils/test/getStoryPropsToSave.js
@@ -85,13 +85,8 @@ describe('getStoryPropsToSave', () => {
       content: 'Hello World!',
       pages,
       ...neededProps,
-      meta: {
-        web_stories_poster: undefined,
-        web_stories_products: [],
-        web_stories_publisher_logo: 1,
-      },
+      products: [],
     };
-    delete expected.publisherLogo;
     delete expected.taxonomies;
 
     expect(props).toStrictEqual(expected);
@@ -155,18 +150,9 @@ describe('getStoryPropsToSave', () => {
       content: 'Hello World!',
       pages,
       ...neededProps,
-      meta: {
-        web_stories_poster: {
-          height: 100,
-          url: 'https://example.com/image.png',
-          width: 100,
-          needsProxy: false,
-        },
-        web_stories_products: [],
-        web_stories_publisher_logo: 1,
-      },
+      products: [],
     };
-    delete expected.publisherLogo;
+
     delete expected.taxonomies;
 
     expect(props).toStrictEqual(expected);

--- a/packages/story-editor/src/components/canvas/displayLayer.js
+++ b/packages/story-editor/src/components/canvas/displayLayer.js
@@ -184,7 +184,7 @@ function DisplayLayer() {
       isBackgroundSelected: state.selectedElements?.[0]?.isBackground,
       pageAttachment: state.currentPage?.pageAttachment || {},
       shoppingAttachment: state.currentPage?.shoppingAttachment || {},
-      hasProducts: state.currentPage.elements?.some(
+      hasProducts: state.currentPage?.elements?.some(
         ({ type, product }) =>
           type === ELEMENT_TYPES.PRODUCT && product?.productId
       ),

--- a/packages/wp-dashboard/src/api/constants/index.js
+++ b/packages/wp-dashboard/src/api/constants/index.js
@@ -21,8 +21,8 @@ export const STORY_FIELDS = [
   'date_gmt',
   'modified',
   'modified_gmt',
+  'story_poster',
   'link',
-  'meta.web_stories_poster',
   'preview_link',
   'edit_link',
   // _web_stories_envelope will add these fields, we need them too.
@@ -34,7 +34,7 @@ export const STORY_FIELDS = [
 export const SEARCH_PAGES_FIELDS = ['id', 'title'];
 export const GET_PAGE_FIELDS = ['title', 'link'];
 
-export const STORY_EMBED = 'wp:lock,wp:lockuser,author,wp:featuredmedia';
+export const STORY_EMBED = 'wp:lock,wp:lockuser,author';
 
 export const REST_LINKS = {
   EDIT: 'wp:action-edit',

--- a/packages/wp-dashboard/src/api/utils/reshapeStoryObject.js
+++ b/packages/wp-dashboard/src/api/utils/reshapeStoryObject.js
@@ -31,10 +31,9 @@ export default function reshapeStoryObject(originalStoryData) {
     link,
     preview_link: previewLink,
     edit_link: editStoryLink,
-    meta: { web_stories_poster: poster = {} },
+    story_poster: storyPoster,
     _embedded: {
       author = [{ name: '', id: 0 }],
-      'wp:featuredmedia': featuredMedia = [{ source_url: '' }],
       'wp:lock': lock = [{ locked: false }],
       'wp:lockuser': lockUser = [{ id: 0, name: '' }],
     } = {},
@@ -43,7 +42,6 @@ export default function reshapeStoryObject(originalStoryData) {
   if (!id) {
     return null;
   }
-  const { source_url: featuredMediaUrl } = featuredMedia[0];
   const capabilities = {
     hasEditAction: Object.prototype.hasOwnProperty.call(links, REST_LINKS.EDIT),
     hasDeleteAction: Object.prototype.hasOwnProperty.call(
@@ -71,11 +69,10 @@ export default function reshapeStoryObject(originalStoryData) {
       avatar: lockUser[0]?.avatar_urls?.['96'] || null,
     },
     bottomTargetAction: editStoryLink,
-    featuredMediaUrl: poster?.url || featuredMediaUrl,
+    featuredMediaUrl: storyPoster?.url,
     editStoryLink,
     previewLink,
     link,
     capabilities,
-    poster,
   };
 }

--- a/packages/wp-dashboard/src/api/utils/test/reshapeStoryObject.js
+++ b/packages/wp-dashboard/src/api/utils/test/reshapeStoryObject.js
@@ -42,16 +42,14 @@ describe('reshapeStoryObject', () => {
       template: '',
       categories: [],
       tags: [],
-      meta: {
-        web_stories_poster: {},
+      story_poster: {
+        id: 33,
+        url: 'http://localhost:8899/wp-content/uploads/poster.jpg',
+        width: 640,
+        height: 853,
+        needsProxy: false,
       },
       _embedded: {
-        'wp:featuredmedia': [
-          {
-            id: 33,
-            source_url: 'http://localhost:8899/wp-content/uploads/poster.jpg',
-          },
-        ],
         author: [{ id: 1, name: 'admin' }],
         'wp:lock': [{ locked: true, time: '1628506372', user: 1 }],
         'wp:lockuser': [
@@ -120,16 +118,14 @@ describe('reshapeStoryObject', () => {
       template: '',
       categories: [],
       tags: [],
-      meta: {
-        web_stories_poster: {},
+      story_poster: {
+        id: 33,
+        url: 'http://localhost:8899/wp-content/uploads/poster.jpg',
+        width: 640,
+        height: 853,
+        needsProxy: false,
       },
       _embedded: {
-        'wp:featuredmedia': [
-          {
-            id: 33,
-            source_url: 'http://localhost:8899/wp-content/uploads/poster.jpg',
-          },
-        ],
         author: [{ id: 1, name: 'admin' }],
         'wp:lock': [{ locked: true, time: '1628506372', user: 1 }],
         'wp:lockuser': [

--- a/packages/wp-story-editor/src/api/constants/index.js
+++ b/packages/wp-story-editor/src/api/constants/index.js
@@ -24,7 +24,7 @@ export const STORY_FIELDS = [
   'modified',
   'excerpt',
   'link',
-  'meta.web_stories_poster',
+  'story_poster',
   'story_data',
   'preview_link',
   'edit_link',
@@ -34,8 +34,7 @@ export const STORY_FIELDS = [
   'password',
 ].join(',');
 
-export const STORY_EMBED =
-  'wp:featuredmedia,wp:lockuser,author,wp:publisherlogo,wp:term';
+export const STORY_EMBED = 'wp:lockuser,author,wp:publisherlogo,wp:term';
 
 export const MEDIA_FIELDS = [
   'id',

--- a/packages/wp-story-editor/src/api/story.js
+++ b/packages/wp-story-editor/src/api/story.js
@@ -79,7 +79,7 @@ const getStorySaveData = (
             height: featuredMedia.height,
             needsProxy: featuredMedia.needsProxy,
           }
-        : undefined,
+        : null, // null ensures the meta value will be deleted.
     },
     publisher_logo: publisherLogo,
     content: encodeMarkup ? base64Encode(content) : content,

--- a/packages/wp-story-editor/src/api/story.js
+++ b/packages/wp-story-editor/src/api/story.js
@@ -109,7 +109,7 @@ export function saveStoryById(config, story) {
       'preview_link',
       'edit_link',
       'embed_post_link',
-      'meta.web_stories_poster',
+      'story_poster',
     ].join(','),
     _embed: STORY_EMBED,
   });
@@ -119,39 +119,21 @@ export function saveStoryById(config, story) {
     data: storySaveData,
     method: 'POST',
   }).then((data) => {
-    const { _embedded: embedded = {}, meta, ...rest } = data;
+    const { story_poster: storyPoster, ...rest } = data;
 
-    let featuredMedia = {
-      id: 0,
-      height: 0,
-      width: 0,
-      url: '',
-      needsProxy: false,
-      isExternal: false,
-    };
-
-    const externalPoster = meta['web_stories_poster'];
-    const postThumbnail = embedded?.['wp:featuredmedia']?.[0];
-
-    if (postThumbnail?.id) {
-      featuredMedia = {
-        id: postThumbnail.id,
-        height: postThumbnail.media_details?.height || 0,
-        width: postThumbnail.media_details?.width || 0,
-        url: postThumbnail.source_url || '',
-        needsProxy: false,
-        isExternal: false,
-      };
-    } else if (externalPoster?.url) {
-      featuredMedia = {
-        id: 0,
-        height: externalPoster.height || 0,
-        width: externalPoster.width || 0,
-        url: externalPoster.url,
-        needsProxy: Boolean(externalPoster.needsProxy),
-        isExternal: true,
-      };
-    }
+    const featuredMedia = storyPoster
+      ? {
+          ...storyPoster,
+          isExternal: !storyPoster.id,
+        }
+      : {
+          id: 0,
+          height: 0,
+          width: 0,
+          url: '',
+          needsProxy: false,
+          isExternal: false,
+        };
 
     return {
       ...snakeToCamelCaseObjectKeys(rest),

--- a/packages/wp-story-editor/src/api/test/story.js
+++ b/packages/wp-story-editor/src/api/test/story.js
@@ -37,22 +37,17 @@ describe('Story API Callbacks', () => {
   });
 
   describe('saveStoryById', () => {
-    it('uses featured image', async () => {
+    it('uses provided story poster', async () => {
       apiFetch.mockReturnValue(
         Promise.resolve({
           id: 123,
           meta: {},
-          _embedded: {
-            'wp:featuredmedia': [
-              {
-                id: 567,
-                source_url: 'https://example.com/featuredimage.jpg',
-                media_details: {
-                  width: 640,
-                  height: 853,
-                },
-              },
-            ],
+          story_poster: {
+            id: 567,
+            url: 'https://example.com/featuredimage.jpg',
+            width: 640,
+            height: 853,
+            needsProxy: false,
           },
         })
       );
@@ -71,30 +66,25 @@ describe('Story API Callbacks', () => {
           id: 123,
           featuredMedia: {
             id: 567,
+            url: 'https://example.com/featuredimage.jpg',
             width: 640,
             height: 853,
-            isExternal: false,
             needsProxy: false,
-            url: 'https://example.com/featuredimage.jpg',
+            isExternal: false,
           },
         })
       );
     });
 
-    it('uses hotlinked poster from post meta', async () => {
+    it('sets isExternal for hotlinked poster', async () => {
       apiFetch.mockReturnValue(
         Promise.resolve({
           id: 123,
-          meta: {
-            web_stories_poster: {
-              url: 'https://example.com/hotlinked.jpg',
-              width: 640,
-              height: 853,
-              needsProxy: true,
-            },
-          },
-          _embedded: {
-            'wp:featuredmedia': [],
+          story_poster: {
+            url: 'https://example.com/hotlinked.jpg',
+            width: 640,
+            height: 853,
+            needsProxy: true,
           },
         })
       );
@@ -112,7 +102,6 @@ describe('Story API Callbacks', () => {
         expect.objectContaining({
           id: 123,
           featuredMedia: {
-            id: 0,
             width: 640,
             height: 853,
             isExternal: true,
@@ -123,65 +112,11 @@ describe('Story API Callbacks', () => {
       );
     });
 
-    it('uses featured image over hotlinked poster from post meta', async () => {
-      apiFetch.mockReturnValue(
-        Promise.resolve({
-          id: 123,
-          meta: {
-            web_stories_poster: {
-              url: 'https://example.com/hotlinked.jpg',
-              width: 640,
-              height: 853,
-              needsProxy: true,
-            },
-          },
-          _embedded: {
-            'wp:featuredmedia': [
-              {
-                id: 567,
-                source_url: 'https://example.com/featuredimage.jpg',
-                media_details: {
-                  width: 640,
-                  height: 853,
-                },
-              },
-            ],
-          },
-        })
-      );
-      const { saveStoryById } = bindToCallbacks(apiCallbacks, {
-        api: { stories: '/web-stories/v1/web-story/' },
-      });
-
-      await expect(
-        saveStoryById({
-          storyId: 123,
-          featuredMedia: {},
-          author: {},
-        })
-      ).resolves.toStrictEqual(
-        expect.objectContaining({
-          id: 123,
-          featuredMedia: {
-            id: 567,
-            width: 640,
-            height: 853,
-            isExternal: false,
-            needsProxy: false,
-            url: 'https://example.com/featuredimage.jpg',
-          },
-        })
-      );
-    });
-
     it('returns "empty" object when there is no featured image', async () => {
       apiFetch.mockReturnValue(
         Promise.resolve({
           id: 123,
-          meta: {},
-          _embedded: {
-            'wp:featuredmedia': [],
-          },
+          story_poster: null,
         })
       );
       const { saveStoryById } = bindToCallbacks(apiCallbacks, {

--- a/packages/wp-story-editor/src/api/utils/transformStoryResponse.js
+++ b/packages/wp-story-editor/src/api/utils/transformStoryResponse.js
@@ -18,12 +18,14 @@
  */
 import { snakeToCamelCaseObjectKeys } from '@web-stories-wp/wp-utils';
 
-// eslint-disable-next-line complexity -- Transform function is complex.
 function transformStoryResponse(post) {
-  const { _embedded: embedded = {}, meta, _links: links = {}, ...rest } = post;
+  const {
+    _embedded: embedded = {},
+    story_poster: storyPoster,
+    _links: links = {},
+    ...rest
+  } = post;
 
-  const poster = meta['web_stories_poster'];
-  const featuredmedia = embedded?.['wp:featuredmedia']?.[0];
   // TODO: Make author, lockUser, etc. null if absent, instead of these "empty" objects.
   const story = {
     ...snakeToCamelCaseObjectKeys(rest, ['story_data']),
@@ -39,14 +41,19 @@ function transformStoryResponse(post) {
         avatar: embedded?.['wp:lockuser']?.[0].avatar_urls?.['96'] || '',
       },
     },
-    featuredMedia: {
-      id: featuredmedia?.id || 0,
-      height: poster?.height || featuredmedia?.media_details?.height || 0,
-      width: poster?.width || featuredmedia?.media_details?.width || 0,
-      url: poster?.url || featuredmedia?.source_url || '',
-      needsProxy: poster?.needsProxy || false,
-      isExternal: Boolean(poster),
-    },
+    featuredMedia: storyPoster
+      ? {
+          ...storyPoster,
+          isExternal: !storyPoster.id,
+        }
+      : {
+          id: 0,
+          height: 0,
+          width: 0,
+          url: '',
+          needsProxy: false,
+          isExternal: false,
+        },
     publisherLogo: {
       id: embedded?.['wp:publisherlogo']?.[0].id || 0,
       height: embedded?.['wp:publisherlogo']?.[0]?.media_details?.height || 0,

--- a/tests/phpunit/integration/tests/REST_API/Stories_Controller.php
+++ b/tests/phpunit/integration/tests/REST_API/Stories_Controller.php
@@ -18,6 +18,7 @@
 namespace Google\Web_Stories\Tests\Integration\REST_API;
 
 use DateTime;
+use Google\Web_Stories\Media\Image_Sizes;
 use Google\Web_Stories\Story_Post_Type;
 use Google\Web_Stories\Tests\Integration\DependencyInjectedRestTestCase;
 use Google\Web_Stories\Tests\Integration\Fixture\DummyTaxonomy;
@@ -486,6 +487,172 @@ class Stories_Controller extends DependencyInjectedRestTestCase {
 
 		$this->assertSame( '3', $data['headers']['X-WP-Total'] );
 	}
+
+	/**
+	 * @covers ::get_item
+	 * @covers ::get_story_poster
+	 * @covers \Google\Web_Stories\REST_API\Stories_Base_Controller::prepare_links
+	 */
+	public function test_get_item_with_no_poster(): void {
+		$this->controller->register_routes();
+
+		wp_set_current_user( self::$user_id );
+
+		$story = self::factory()->post->create(
+			[
+				'post_type'   => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
+				'post_status' => 'future',
+				'post_date'   => ( new DateTime( '+1day' ) )->format( 'Y-m-d H:i:s' ),
+				'post_author' => self::$user_id,
+			]
+		);
+
+		$request  = new WP_REST_Request( \WP_REST_Server::READABLE, '/web-stories/v1/web-story/' . $story );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertArrayNotHasKey( 'story_poster', $data );
+	}
+
+	/**
+	 * @covers ::get_item
+	 * @covers ::get_story_poster
+	 * @covers \Google\Web_Stories\REST_API\Stories_Base_Controller::prepare_links
+	 */
+	public function test_get_item_with_featured_image(): void {
+		$this->controller->register_routes();
+
+		wp_set_current_user( self::$user_id );
+
+		$story = self::factory()->post->create(
+			[
+				'post_type'   => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
+				'post_status' => 'future',
+				'post_date'   => ( new DateTime( '+1day' ) )->format( 'Y-m-d H:i:s' ),
+				'post_author' => self::$user_id,
+			]
+		);
+
+		$attachment_id = self::factory()->attachment->create_upload_object( WEB_STORIES_TEST_DATA_DIR . '/attachment.jpg', 0 );
+		set_post_thumbnail( $story, $attachment_id );
+
+		$attachment_src = wp_get_attachment_image_src( $attachment_id, Image_Sizes::POSTER_PORTRAIT_IMAGE_SIZE );
+
+		$request  = new WP_REST_Request( \WP_REST_Server::READABLE, '/web-stories/v1/web-story/' . $story );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertArrayHasKey( 'story_poster', $data );
+		$this->assertEqualSetsWithIndex(
+			[
+				'id'         => $attachment_id,
+				'url'        => $attachment_src[0],
+				'height'     => $attachment_src[1],
+				'width'      => $attachment_src[2],
+				'needsProxy' => false,
+			],
+			$data['story_poster']
+		);
+	}
+
+	/**
+	 * @covers ::get_item
+	 * @covers ::get_story_poster
+	 * @covers \Google\Web_Stories\REST_API\Stories_Base_Controller::prepare_links
+	 */
+	public function test_get_item_with_hotlinked_poster(): void {
+		$this->controller->register_routes();
+
+		wp_set_current_user( self::$user_id );
+
+		$story = self::factory()->post->create(
+			[
+				'post_type'   => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
+				'post_status' => 'future',
+				'post_date'   => ( new DateTime( '+1day' ) )->format( 'Y-m-d H:i:s' ),
+				'post_author' => self::$user_id,
+			]
+		);
+
+		add_post_meta(
+			$story,
+			\Google\Web_Stories\Story_Post_Type::POSTER_META_KEY,
+			[
+				'url'        => 'http://www.example.com/image.png',
+				'height'     => 1000,
+				'width'      => 1000,
+				'needsProxy' => false,
+			]
+		);
+
+		$request  = new WP_REST_Request( \WP_REST_Server::READABLE, '/web-stories/v1/web-story/' . $story );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertArrayHasKey( 'story_poster', $data );
+		$this->assertEqualSetsWithIndex(
+			[
+				'url'        => 'http://www.example.com/image.png',
+				'height'     => 1000,
+				'width'      => 1000,
+				'needsProxy' => false,
+			],
+			$data['story_poster']
+		);
+	}
+
+	/**
+	 * @covers ::get_item
+	 * @covers ::get_story_poster
+	 * @covers \Google\Web_Stories\REST_API\Stories_Base_Controller::prepare_links
+	 */
+	public function test_get_item_with_featured_image_and_hotlinked_poster(): void {
+		$this->controller->register_routes();
+
+		wp_set_current_user( self::$user_id );
+
+		$story = self::factory()->post->create(
+			[
+				'post_type'   => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
+				'post_status' => 'future',
+				'post_date'   => ( new DateTime( '+1day' ) )->format( 'Y-m-d H:i:s' ),
+				'post_author' => self::$user_id,
+			]
+		);
+
+		$attachment_id = self::factory()->attachment->create_upload_object( WEB_STORIES_TEST_DATA_DIR . '/attachment.jpg', 0 );
+		set_post_thumbnail( $story, $attachment_id );
+
+		$attachment_src = wp_get_attachment_image_src( $attachment_id, Image_Sizes::POSTER_PORTRAIT_IMAGE_SIZE );
+
+		add_post_meta(
+			$story,
+			\Google\Web_Stories\Story_Post_Type::POSTER_META_KEY,
+			[
+				'url'        => 'http://www.example.com/image.png',
+				'height'     => 1000,
+				'width'      => 1000,
+				'needsProxy' => false,
+			]
+		);
+
+		$request  = new WP_REST_Request( \WP_REST_Server::READABLE, '/web-stories/v1/web-story/' . $story );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertArrayHasKey( 'story_poster', $data );
+		$this->assertEqualSetsWithIndex(
+			[
+				'id'         => $attachment_id,
+				'url'        => $attachment_src[0],
+				'height'     => $attachment_src[1],
+				'width'      => $attachment_src[2],
+				'needsProxy' => false,
+			],
+			$data['story_poster']
+		);
+	}
+
 
 	/**
 	 * @covers ::get_item_schema


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

Apparently #11982 / v1.23.1 didn't completely fix all issues with story posters, see #12029

## Summary

<!-- A brief description of what this PR does. -->

This PR attempts to consolidate logic for (hotlinked) story posters to ensure expected behavior is met.

## Relevant Technical Choices

<!-- Please describe your changes. -->

Move the relevant logic to the REST controller so that the JS code does not have to deal with it. Adds a new `story_poster` field to the API response.

Updates `getStoryPropsToSave` in `story-editor` to not return any `meta` object. `getStorySaveData` in `wp-story-editor` already handles that.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

* [x] Add tests
* [x] Check that REST API preloading still works

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Create a new story
2. Add a new poster image from the media library, publish.
3. Save story
4. Refresh editor (or go to dashboard), see new poster image reflected in both editor and dashboard
5. Repeat with a hotlinked image
6. In general, saving should still work as expected

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12029
