### PR TITLE
Fix Karma test: `should allow user to edit and reset poster image using keyboard`

### DIFF
--- a/packages/story-editor/src/components/panels/design/videoAccessibility/karma/videoPoster.karma.js
+++ b/packages/story-editor/src/components/panels/design/videoAccessibility/karma/videoPoster.karma.js
@@ -77,9 +77,7 @@ describe('Video Accessibility Panel', () => {
       expect(vaPanel.posterImage.src).toBe(originalPoster);
     });
 
-    // TODO: https://github.com/GoogleForCreators/web-stories-wp/issues/12141
-    // eslint-disable-next-line jasmine/no-disabled-tests
-    xit('should allow user to edit and reset poster image using keyboard', async () => {
+    it('should allow user to edit and reset poster image using keyboard', async () => {
       // Remember original poster image
       const originalPoster = vaPanel.posterImage.src;
 
@@ -99,7 +97,9 @@ describe('Video Accessibility Panel', () => {
       expect(vaPanel.posterMenuEdit).toBeDefined();
       await fixture.snapshot('Menu open');
 
-      // And click on edit
+      // The third option is for editing, press down and click to edit.
+      await fixture.events.keyboard.press('down');
+      await fixture.events.keyboard.press('down');
       expect(vaPanel.posterMenuEdit).toHaveFocus();
       await fixture.events.keyboard.press('Enter');
 
@@ -110,6 +110,7 @@ describe('Video Accessibility Panel', () => {
       await focusOnTitle();
       await fixture.events.keyboard.press('tab');
       await fixture.events.keyboard.press('Enter');
+      await fixture.events.keyboard.press('down');
       await fixture.events.keyboard.press('down');
       await fixture.events.keyboard.press('down');
       expect(vaPanel.posterMenuReset).toHaveFocus();

--- a/packages/story-editor/src/karma/fixture/containers/designPanel/videoPoster.js
+++ b/packages/story-editor/src/karma/fixture/containers/designPanel/videoPoster.js
@@ -39,7 +39,7 @@ export class VideoPoster extends AbstractPanel {
 
   get posterMenuEdit() {
     return this.getByRoleIn(this.node.ownerDocument, 'menuitem', {
-      name: /upload a file/i,
+      name: /edit/i,
     });
   }
 


### PR DESCRIPTION
## Context
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Fixes and re-enables the Karma test `should allow user to edit and reset poster image using keyboard`
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
N/A
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12141 
