### PR TITLE
Output: optimize `fix_malformed_script_link_tags()` regex

### DIFF
--- a/includes/Renderer/Story/HTML.php
+++ b/includes/Renderer/Story/HTML.php
@@ -116,10 +116,10 @@ class HTML {
 	 * @return string Filtered content
 	 */
 	protected function fix_malformed_script_link_tags( string $content ): string {
-		$content = (string) preg_replace_callback(
-			'/(?P<link><a[^>]+href=\"(?P<href>.*?)\"[^>]*>(?P<content>.*?)<\/a>)/ms',
+		$replaced_content = preg_replace_callback(
+			'/<a[^>]+href="(?P<href>[^"]+)"[^>]*>\1<\/a>/m',
 			static function( $matches ) {
-				if ( $matches['href'] === $matches['content'] && 0 === strpos( $matches['href'], 'https://cdn.ampproject.org/' ) ) {
+				if ( 0 === strpos( $matches['href'], 'https://cdn.ampproject.org/' ) ) {
 					$script_url = $matches['href'];
 
 					// Turns `<a href="https://cdn.ampproject.org/v0.js">https://cdn.ampproject.org/v0.js</a>`
@@ -143,7 +143,8 @@ class HTML {
 			$content
 		);
 
-		return $content;
+		// On errors the return value of preg_replace_callback() is null.
+		return $replaced_content ?: $content;
 	}
 
 	/**

--- a/includes/Renderer/Story/HTML.php
+++ b/includes/Renderer/Story/HTML.php
@@ -77,19 +77,6 @@ class HTML {
 	}
 
 	/**
-	 * Get story meta images.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return string[] Images.
-	 */
-	protected function get_poster_images(): array {
-		return [
-			'poster-portrait-src' => $this->story->get_poster_portrait(),
-		];
-	}
-
-	/**
 	 * Fix malformed <a> tags in the <head>.
 	 *
 	 * On certain environments like WordPress.com VIP, there is additional KSES


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

See #12158.

This error with a blank screen can happen when the `preg_replace_callback()` call in `HTML::fix_malformed_script_link_tags()` errored and thus an empty content was returned.

In my testing this all happened because 

1. The existing regex was very inefficient and had catastrophic backtracking
2. We simply overrode `$content` even if there was an error

## Summary

<!-- A brief description of what this PR does. -->

This PR optimizes the `preg_replace_callback` usage in `fix_malformed_script_link_tags()` in two ways:

1. Use optimized regex that is simpler to read (using a back reference) and has better performance
2. Return original `$content` if there was an error with the regex replacement

## Relevant Technical Choices

<!-- Please describe your changes. -->

Removed some dead code

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

N/A

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12158
