### PR TITLE
Sanitization: clone node before importing

### DIFF
--- a/includes/AMP/Traits/Sanitization_Utils.php
+++ b/includes/AMP/Traits/Sanitization_Utils.php
@@ -234,7 +234,8 @@ trait Sanitization_Utils {
 			 *
 			 * @var DOMNode $child Child node.
 			 */
-			$new_node->appendChild( $document->importNode( $child, true ) );
+
+			$new_node->appendChild( $document->importNode( $child->cloneNode( true ), true ) );
 		}
 
 		// Then, copy over all attributes.

--- a/tests/phpunit/unit/tests/AMP/Story_Sanitizer.php
+++ b/tests/phpunit/unit/tests/AMP/Story_Sanitizer.php
@@ -662,4 +662,44 @@ HTML;
 		$this->assertStringContainsString( 'T3B</p>', $actual );
 		$this->assertStringContainsString( 'PB</p>', $actual );
 	}
+
+
+	/**
+	 * @covers \Google\Web_Stories\AMP\Traits\Sanitization_Utils::use_semantic_heading_tags
+	 */
+	public function test_use_semantic_heading_tags_with_newlines_and_nested_spans(): void {
+		$source = <<<'HTML'
+<html><head></head><body><amp-story>
+	<amp-story-page>
+		<amp-story-grid-layer>
+			<p class="fill text-wrapper" style="font-size:.582524em">
+				<span>
+				<span style="font-weight: 700; color: #fff">Title 1</span>
+				</span>
+			</p>
+			<p class="text-wrapper" style="font-size:.582524em"><span><span>Title 1</span></span></p>
+			<p class="text-wrapper" style="font-size:.436893em"><span><span>Title 2</span></span></p>
+			<p class="text-wrapper" style="font-size:.339805em"><span><span>Title 3</span></span></p>
+			<p class="text-wrapper" style="font-size:.291262em"><span><span>Paragraph</span></span></p>
+		</amp-story-grid-layer>
+	</amp-story-page>
+</amp-story></body></html>
+HTML;
+
+		$args = [
+			'publisher_logo' => '',
+			'publisher'      => '',
+			'poster_images'  => [],
+			'video_cache'    => false,
+		];
+
+		$actual = $this->sanitize_and_get( $source, $args );
+
+		$this->assertStringContainsString( "<span class=\"_14af73e\">Title 1</span>\n\t\t\t\t</span>\n\t\t\t</h1>", $actual );
+		$this->assertStringContainsString( 'Title 1</span></span></h2>', $actual );
+		$this->assertStringContainsString( 'Title 2</span></span></h2>', $actual );
+		$this->assertStringContainsString( 'Title 3</span></span></h3>', $actual );
+		$this->assertStringContainsString( 'Paragraph</span></span></p>', $actual );
+	}
+
 }


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

While looking at #12159 I found another issue related to the AMP output sanitization, where some text content was completely missing.

I then realized it was because of the `Sanitization_Utils::change_tag_name()` method (used via `Sanitization_Utils::use_semantic_heading_tags()`. That util uses `DomDocument::importNode()`, which calls `DomDocument::importNode()` on a `DomNodeList`, which is not a simple array but actually an `IteratorAggregate`.

So when importing a node in a loop like that, it directly modifies the list, missing subsequent children

## Summary

<!-- A brief description of what this PR does. -->

This PR addresses this by cloning the child nodes before importing them, making sure the `DomNodeList` traversal works as expected.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

N/A

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
