### PR TITLE
Discovery: always print document title

### DIFF
--- a/includes/Discovery.php
+++ b/includes/Discovery.php
@@ -84,6 +84,7 @@ class Discovery extends Service_Base implements HasRequirements {
 	 * @since 1.0.0
 	 */
 	public function register(): void {
+		add_action( 'web_stories_story_head', [ $this, 'print_document_title' ] );
 		add_action( 'web_stories_story_head', [ $this, 'print_metadata' ] );
 		add_action( 'web_stories_story_head', [ $this, 'print_schemaorg_metadata' ] );
 		add_action( 'web_stories_story_head', [ $this, 'print_open_graph_metadata' ] );
@@ -109,7 +110,35 @@ class Discovery extends Service_Base implements HasRequirements {
 	}
 
 	/**
-	 * Prints general metadata on the single story template.
+	 * Prints document title for stories.
+	 *
+	 * Works both for classic themes and block themes without any conditionals.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @link https://github.com/GoogleForCreators/web-stories-wp/issues/12139
+	 * @see _wp_render_title_tag()
+	 * @see _block_template_render_title_tag()
+	 */
+	public function print_document_title(): void {
+		/**
+		 * Filters whether to print the document title.
+		 *
+		 * @since 1.25.0
+		 *
+		 * @param bool $enable_open_graph Whether to print the document title. Default to true.
+		 */
+		$enable_metadata = apply_filters( 'web_stories_enable_document_title', true );
+		if ( ! $enable_metadata ) {
+			return;
+		}
+		?>
+		<title><?php echo esc_html( wp_get_document_title() ); ?></title>
+		<?php
+	}
+
+	/**
+	 * Prints the meta description on the single story template.
 	 *
 	 * Theme support for title tag is implied for stories.
 	 *
@@ -119,18 +148,17 @@ class Discovery extends Service_Base implements HasRequirements {
 	 */
 	public function print_metadata(): void {
 		/**
-		 * Filters filter to enable / disable metadata
+		 * Filters whether to print the meta description.
 		 *
 		 * @since 1.2.0
 		 *
-		 * @param bool $enable_open_graph Enable / disable metadata. Default to true.
+		 * @param bool $enable_open_graph Whether to print the meta description. Default to true.
 		 */
 		$enable_metadata = apply_filters( 'web_stories_enable_metadata', true );
 		if ( ! $enable_metadata ) {
 			return;
 		}
 		?>
-		<title><?php echo esc_html( wp_get_document_title() ); ?></title>
 		<meta name="description" content="<?php echo esc_attr( wp_strip_all_tags( get_the_excerpt() ) ); ?>" />
 		<?php
 	}

--- a/includes/Discovery.php
+++ b/includes/Discovery.php
@@ -114,7 +114,7 @@ class Discovery extends Service_Base implements HasRequirements {
 	 *
 	 * Works both for classic themes and block themes without any conditionals.
 	 *
-	 * @since 1.0.0
+	 * @since 1.25.0
 	 *
 	 * @link https://github.com/GoogleForCreators/web-stories-wp/issues/12139
 	 * @see _wp_render_title_tag()

--- a/tests/phpunit/integration/tests/Discovery.php
+++ b/tests/phpunit/integration/tests/Discovery.php
@@ -113,6 +113,7 @@ class Discovery extends DependencyInjectedTestCase {
 	 */
 	public function test_register(): void {
 		$this->instance->register();
+		$this->assertSame( 10, has_action( 'web_stories_story_head', [ $this->instance, 'print_document_title' ] ) );
 		$this->assertSame( 10, has_action( 'web_stories_story_head', [ $this->instance, 'print_metadata' ] ) );
 		$this->assertSame( 10, has_action( 'web_stories_story_head', [ $this->instance, 'print_schemaorg_metadata' ] ) );
 		$this->assertSame( 10, has_action( 'web_stories_story_head', [ $this->instance, 'print_open_graph_metadata' ] ) );
@@ -126,6 +127,14 @@ class Discovery extends DependencyInjectedTestCase {
 	 */
 	public function test_print_metadata(): void {
 		$output = get_echo( [ $this->instance, 'print_metadata' ] );
+		$this->assertStringContainsString( '<meta', $output );
+	}
+
+	/**
+	 * @covers ::print_metadata
+	 */
+	public function test_print_document_title(): void {
+		$output = get_echo( [ $this->instance, 'print_document_title' ] );
 		$this->assertStringContainsString( '<title>', $output );
 	}
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

It was reported that there was a missing `<title>` tag on stories when using Yoast SEO in combination with a block theme like Twenty Twenty Two

## Summary

<!-- A brief description of what this PR does. -->

Adds a separate function with its own filter for displaying the document title.

Ensures that the document title is always printed when using SEO plugins and a block theme.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

No changes besides the `<title>` tag reappearing.

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Activate Yoast SEO plugin
2. Activate Twenty-Twenty Two theme
3. View a single story
4. Verify the `<title>` tag is added


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12139
