### PR TITLE
Media Library: Fix media reducer

### DIFF
--- a/packages/story-editor/src/app/media/pagination/reducer.js
+++ b/packages/story-editor/src/app/media/pagination/reducer.js
@@ -54,7 +54,7 @@ function reducer(state = INITIAL_STATE, { type, payload }) {
       return {
         ...state,
         // If a pageToken is present, append the results.
-        media: pageToken > 1 ? [...state.media, ...media] : media,
+        media: pageToken ? [...state.media, ...media] : media,
         nextPageToken,
         totalPages,
         hasMore: Boolean(nextPageToken),


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

This is a follow-up to #12123, where I inadvertently broke pagination of the media3p library.

Karma tests like `Media3pPane fetching should render the second media provider` were not passing anymore.

## Summary

<!-- A brief description of what this PR does. -->

Restores previous functionality in the media reducer for `FETCH_MEDIA_SUCCESS` to restore proper pagination.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Pagination in the 3p media library should work again


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
