### PR TITLE
Enable autosaves for non-drafts

### DIFF
--- a/packages/story-editor/src/components/autoSaveHandler/index.js
+++ b/packages/story-editor/src/components/autoSaveHandler/index.js
@@ -32,18 +32,11 @@ function AutoSaveHandler() {
   const {
     state: { hasNewChanges },
   } = useHistory();
-  const { status, saveStory, autoSave } = useStory(
-    ({
-      state: {
-        story: { status },
-      },
-      actions: { autoSave, saveStory },
-    }) => ({
-      status,
-      autoSave,
-      saveStory,
-    })
-  );
+  const { status, saveStory, autoSave } = useStory(({ state, actions }) => ({
+    autoSave: actions.autoSave,
+    saveStory: actions.saveStory,
+    isDraft: state.status,
+  }));
   const isUploading = useIsUploadingToStory();
 
   const isDraft = 'draft' === status || !status;
@@ -57,9 +50,13 @@ function AutoSaveHandler() {
   }, [save]);
 
   useEffect(() => {
-    // @todo The isDraft check is temporary to ensure only draft gets auto-saved,
-    // until the logic for other statuses has been decided.
-    if (!isDraft || !hasNewChanges || !autoSaveInterval || isUploading) {
+    // TODO: Remove isDraft check when improvedAutosaves gets enabled by default.
+    if (
+      (!isDraft && !improvedAutosaves) ||
+      !hasNewChanges ||
+      !autoSaveInterval ||
+      isUploading
+    ) {
       return undefined;
     }
     // This is only a timeout (and not an interval), as `hasNewChanges` will come
@@ -71,7 +68,13 @@ function AutoSaveHandler() {
     );
 
     return () => clearTimeout(timeout);
-  }, [autoSaveInterval, isDraft, hasNewChanges, isUploading]);
+  }, [
+    autoSaveInterval,
+    isDraft,
+    improvedAutosaves,
+    hasNewChanges,
+    isUploading,
+  ]);
 
   return null;
 }

--- a/packages/story-editor/src/components/autoSaveHandler/index.js
+++ b/packages/story-editor/src/components/autoSaveHandler/index.js
@@ -32,14 +32,14 @@ function AutoSaveHandler() {
   const {
     state: { hasNewChanges },
   } = useHistory();
-  const { status, saveStory, autoSave } = useStory(({ state, actions }) => ({
-    autoSave: actions.autoSave,
-    saveStory: actions.saveStory,
-    isDraft: state.status,
-  }));
+  const { isDraft, saveStory, autoSave } = useStory(
+    ({ state: { story }, actions }) => ({
+      autoSave: actions.autoSave,
+      saveStory: actions.saveStory,
+      isDraft: 'draft' === story.status || !story.status,
+    })
+  );
   const isUploading = useIsUploadingToStory();
-
-  const isDraft = 'draft' === status || !status;
 
   const save = improvedAutosaves ? autoSave : saveStory;
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

See #1402 / #9859 for context.

## Summary

<!-- A brief description of what this PR does. -->

This change removes\* the `isDraft` check for the autosave handler, causing autosaves to work even if the story is private, scheduled, or published. For published stories, it will create a new revision.

We'll add a link for users to manage revisions soon, see #12197.

\* It does not actually remove the check, just disable it if the autosave experiment is on.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

No visual change.

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

0. Enable autosave experiment
1. Publish a story
2. Make some changes
3. Wait a minute or so
4. Observe network tab, see that an autosave happened


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

See #1402
