### PR TITLE
Media: Remove media frame on close

### DIFF
--- a/packages/wp-story-editor/src/components/mediaUpload/mediaPicker/useMediaPicker.js
+++ b/packages/wp-story-editor/src/components/mediaUpload/mediaPicker/useMediaPicker.js
@@ -140,16 +140,11 @@ function useMediaPicker({
         onSelect(getResourceFromMediaPicker(mediaPickerEl));
       });
 
-      if (onClose) {
-        fileFrame.once('close', onClose);
-      }
-
-      fileFrame.once('content:activate:browse', () => {
-        // Force-refresh media modal contents every time it's opened
-        // to avoid stale data due to media items being upload & updated
-        // through the editor in the meantime.
-        fileFrame.content?.get()?.collection?._requery(true);
-        fileFrame.content?.get()?.options?.selection?.reset();
+      fileFrame.once('close', () => {
+        if (onClose) {
+          onClose();
+        }
+        fileFrame.remove();
       });
 
       // Finally, open the modal
@@ -272,15 +267,11 @@ function useMediaPicker({
         }
       });
 
-      if (onClose) {
-        fileFrame.once('close', onClose);
-      }
-
-      fileFrame.once('content:activate:browse', () => {
-        // Force-refresh media modal contents every time
-        // to avoid stale data.
-        fileFrame.content?.get()?.collection?._requery(true);
-        fileFrame.content?.get()?.options?.selection?.reset();
+      fileFrame.once('close', () => {
+        if (onClose) {
+          onClose();
+        }
+        fileFrame.remove();
       });
 
       // Finally, open the modal


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

While working on https://github.com/GoogleForCreators/web-stories-wp/pull/11941. I discovered that wp media instance when the wp media instance is closed. This instance may use memory in the browser and requires resetting. Just use remove method. 

See

https://github.com/WordPress/gutenberg/blob/67a652439c3d2f7dd8623d24b0bd12b5aff053f5/packages/media-utils/src/components/media-upload/index.js#L342-L344

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
