### PR TITLE
Code: Fixed references for `patterns` package

### DIFF
--- a/packages/patterns/tsconfig.json
+++ b/packages/patterns/tsconfig.json
@@ -4,6 +4,6 @@
     "rootDir": "src",
     "declarationDir": "dist-types"
   },
-  "references": [],
+  "references": [{ "path": "../i18n" }],
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Context

Added a TypeScript reference from `patterns` package to `i18n` package to suppress lint errors (and actually fix the type reference).

## Testing Instructions

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #12178
