### PR TITLE
Fix preview issues with auto-drafts

### DIFF
--- a/packages/story-editor/src/app/story/actions/useSaveStory.js
+++ b/packages/story-editor/src/app/story/actions/useSaveStory.js
@@ -87,6 +87,8 @@ function useSaveStory({ storyId, pages, story, updateStory }) {
               metadata,
               flags,
             }),
+            // Saving an auto-draft should create a draft by default.
+            status: 'auto-draft' === story.status ? 'draft' : story.status,
             ...props,
           })
         )

--- a/packages/story-editor/src/components/checklist/checks/storyAmpValidationErrors.js
+++ b/packages/story-editor/src/components/checklist/checks/storyAmpValidationErrors.js
@@ -30,11 +30,7 @@ import { useRegisterCheck } from '../countContext';
 
 /** @typedef {import('amphtml-validator').ValidationResult} ValidationResult */
 
-export async function getStoryAmpValidationErrors({ link, status }) {
-  if (!link || !['publish', 'future'].includes(status)) {
-    return false;
-  }
-
+export async function getStoryAmpValidationErrors(link) {
   try {
     const response = await fetch(link);
     const storyMarkup = await response.text();
@@ -69,6 +65,7 @@ export async function getStoryAmpValidationErrors({ link, status }) {
         ) {
           return false;
         }
+
         // Missing video posters
         if ('INVALID_URL_PROTOCOL' === code && params?.[0].startsWith('src')) {
           return false;
@@ -85,10 +82,13 @@ export async function getStoryAmpValidationErrors({ link, status }) {
 const StoryAmpValidationErrors = () => {
   // ampValidationErrorRef is making sure that tracking is only fired once per session.
   const ampValidationErrorsRef = useRef();
-  const { isSaving, link, status } = useStory(({ state }) => ({
+  const { isSaving, link, isPublic } = useStory(({ state }) => ({
     isSaving: state.meta.isSaving,
     link: state.story.link,
-    status: state.story.status,
+    isPublic:
+      ['publish', 'future'].includes(state.story.status) &&
+      state.story.link &&
+      !state.story.password?.length,
   }));
 
   // isRendered is getting set asynchronously based on the returned value of `getStoryAmpValidationErrors`,
@@ -101,7 +101,16 @@ const StoryAmpValidationErrors = () => {
   useEffect(() => {
     let isMounted = true;
     if (!isSaving) {
-      getStoryAmpValidationErrors({ link, status }).then((hasErrors) => {
+      if (!isPublic) {
+        setIsRendered(true);
+        return () => {
+          isMounted = false;
+        };
+      }
+
+      // TODO: Do not call if freshly set to password protected and story has never been saved yet (and thus 404s).
+
+      getStoryAmpValidationErrors(link).then((hasErrors) => {
         if (isMounted) {
           setIsRendered(hasErrors);
           if (hasErrors && !ampValidationErrorsRef?.current) {
@@ -113,7 +122,7 @@ const StoryAmpValidationErrors = () => {
     return () => {
       isMounted = false;
     };
-  }, [link, status, isSaving]);
+  }, [link, isPublic, isSaving]);
 
   useEffect(() => {
     if (isRendered && ampValidationErrorsRef?.current) {


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

While looking into e2e tests I noticed an issue with the new autosaving mechanism and story previews.

When previewing a story without saving it first, you'd get a 404 because the story was still an `auto-draft` and not a regular `draft`.

## Summary

<!-- A brief description of what this PR does. -->

Fixes an issue with stories not being proper `draft`s when previewing and thus seeing 404s.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

- Fix TODOs in follow-up tickets
- Fix and re-enable e2e tests in follow-up tickets

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

No 404s when previewing a story.

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Create a new story and set it as password protected
2. Click on Preview button
3. Verify that you don't get a 404 page


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
