### PR TITLE
CI: Update GitHub token permissions for templates workflow

### DIFF
--- a/.github/workflows/update-templates.yml
+++ b/.github/workflows/update-templates.yml
@@ -11,6 +11,9 @@ env:
   GIT_COMMITTER_EMAIL: 94923726+googleforcreators-bot@users.noreply.github.com
   GIT_COMMITTER_NAME: googleforcreators-bot
 
+permissions:
+  contents: read
+
 jobs:
   update-template:
     name: Migrate templates and text sets


### PR DESCRIPTION
### Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using https://github.com/step-security/secure-workflows.

The GitHub Actions workflow has a GITHUB_TOKEN with write access to multiple scopes.
Here is an example of the permissions in one of the workflow runs:
https://github.com/GoogleForCreators/web-stories-wp/runs/8188010407?check_suite_focus=true#step:1:19

After this change, the scopes will be reduced to the minimum needed for the following workflow:

- update-templates.yml

The following workflow files already have the least privileged token permission set:

- add-milestone.yml
- codeql-analysis.yml
- lint-i18n.yml
- plugin-release.yml
- tests-karma-dashboard.yml
- tests-unit-php.yml
- update-product-schema.yml
- build-and-deploy.yml
- deploy-storybook.yml
- lint-php.yml
- scorecards.yml
- tests-karma-editor.yml
- update-browserslist.yml
- cleanup-pr-assets.yml
- lint-css-js-md.yml
- npm-release.yml
- tests-e2e.yml
- tests-unit-js.yml
- update-google-fonts.yml

### Motivation and Context

- This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced.
- GitHub recommends defining minimum GITHUB_TOKEN permissions.
  https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository.

Signed-off-by: Ashish Kurmi <akurmi@stepsecurity.io>

