### PR TITLE
Code: Removed unused feature flags

### DIFF
--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -234,17 +234,6 @@ class Experiments extends Service_Base implements HasRequirements {
 	public function get_experiments(): array {
 		return [
 			/**
-			 * Author: @littlemilkstudio
-			 * Issue: 6379
-			 * Creation date: 2021-03-09
-			 */
-			[
-				'name'        => 'enableExperimentalAnimationEffects',
-				'label'       => __( 'Experimental animations', 'web-stories' ),
-				'description' => __( 'Enable any animation effects that are currently experimental', 'web-stories' ),
-				'group'       => 'editor',
-			],
-			/**
 			 * Author: @brittanyirl
 			 * Issue: 2381
 			 * Creation date: 2020-06-11

--- a/packages/story-editor/src/components/checklist/karma/checklist.karma.js
+++ b/packages/story-editor/src/components/checklist/karma/checklist.karma.js
@@ -524,7 +524,6 @@ describe('Checklist integration - Card visibility', () => {
             }),
         },
       });
-      fixture.setFlags({ enableChecklistCompanion: true });
 
       fixture.setConfig({ capabilities: { hasUploadMediaAction: false } });
       await fixture.render();

--- a/packages/story-editor/src/components/mediaRecording/karma/mediaRecording.karma.js
+++ b/packages/story-editor/src/components/mediaRecording/karma/mediaRecording.karma.js
@@ -81,9 +81,6 @@ describe('Media Recording', () => {
     spyOnProperty(window, 'crossOriginIsolated', 'get').and.returnValue(true);
 
     fixture = new Fixture();
-    fixture.setFlags({
-      mediaRecording: true,
-    });
 
     await fixture.render();
     await fixture.collapseHelpCenter();

--- a/packages/story-editor/src/components/panels/design/animation/effectChooserDropdown/dropdownConstants.js
+++ b/packages/story-editor/src/components/panels/design/animation/effectChooserDropdown/dropdownConstants.js
@@ -70,11 +70,6 @@ export const GRID_SIZING = {
 };
 
 /**
- * Effects that are behind feature flag
- */
-export const experimentalEffects = [];
-
-/**
  * Some effects are more complicated or have just 1 prebaked option in the effect drop down.
  * For these we want to make sure we're mapping the appropriate value to the drop down selectedValue
  * which means ignoring direction which `getDirectionalEffect` ties into to give 1 effect several

--- a/packages/story-editor/src/components/panels/design/animation/effectChooserDropdown/effectChooserDropdown.js
+++ b/packages/story-editor/src/components/panels/design/animation/effectChooserDropdown/effectChooserDropdown.js
@@ -20,7 +20,6 @@
 import { forwardRef, useCallback, useMemo } from '@googleforcreators/react';
 import PropTypes from 'prop-types';
 import { __, _x } from '@googleforcreators/i18n';
-import { useFeatures } from 'flagged';
 import { css } from 'styled-components';
 import { DropDown, PLACEMENT } from '@googleforcreators/design-system';
 
@@ -32,7 +31,6 @@ import {
   backgroundEffectOptions,
   NO_ANIMATION,
   foregroundEffectOptions,
-  experimentalEffects,
   getDirectionalEffect,
 } from './dropdownConstants';
 import { ANIMATION_DIRECTION_PROP_TYPE } from './types';
@@ -57,8 +55,6 @@ const EffectChooserDropdown = forwardRef(function EffectChooserDropdown(
   },
   ref
 ) {
-  const { enableExperimentalAnimationEffects } = useFeatures();
-
   const selectedValue = useMemo(
     () => getDirectionalEffect(selectedEffectType, direction),
     [selectedEffectType, direction]
@@ -83,15 +79,9 @@ const EffectChooserDropdown = forwardRef(function EffectChooserDropdown(
     ? backgroundEffectOptions
     : foregroundEffectOptions;
 
-  // remove experiments if needed
   const availableAnimationOptions = useMemo(
-    () =>
-      enableExperimentalAnimationEffects
-        ? Object.values(animationOptionsObject)
-        : Object.values(animationOptionsObject).filter(({ value }) => {
-            return experimentalEffects.indexOf(value) === -1;
-          }),
-    [animationOptionsObject, enableExperimentalAnimationEffects]
+    () => Object.values(animationOptionsObject),
+    [animationOptionsObject]
   );
 
   const assembledOptions = useMemo(

--- a/packages/story-editor/src/components/panels/design/animation/effectChooserDropdown/effectChooserDropdown.js
+++ b/packages/story-editor/src/components/panels/design/animation/effectChooserDropdown/effectChooserDropdown.js
@@ -79,10 +79,7 @@ const EffectChooserDropdown = forwardRef(function EffectChooserDropdown(
     ? backgroundEffectOptions
     : foregroundEffectOptions;
 
-  const availableAnimationOptions = useMemo(
-    () => Object.values(animationOptionsObject),
-    [animationOptionsObject]
-  );
+  const availableAnimationOptions = Object.values(animationOptionsObject);
 
   const assembledOptions = useMemo(
     () =>

--- a/packages/story-editor/src/components/panels/design/textStyle/karma/textStyle.other.karma.js
+++ b/packages/story-editor/src/components/panels/design/textStyle/karma/textStyle.other.karma.js
@@ -31,7 +31,6 @@ describe('Text Style Panel', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     localStorage.clear();
-    fixture.setFlags({ customFonts: true });
     await fixture.render();
     await fixture.collapseHelpCenter();
   });


### PR DESCRIPTION
## Context

This removes an unused feature flag for experimental animations (no such exist and haven't for a long time).

Furthermore, this also removes other unused flags from test code, that sets these flags for no reason.

## Testing Instructions

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #11965
