### PR TITLE
Code: Removed enabled feature flag for design menu

### DIFF
--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -279,18 +279,6 @@ class Experiments extends Service_Base implements HasRequirements {
 			],
 			/**
 			 * Author: @barklund
-			 * Issue: #10112
-			 * Creation date: 2022-01-27
-			 */
-			[
-				'name'        => 'floatingMenu',
-				'label'       => __( 'Floating Menu', 'web-stories' ),
-				'description' => __( 'Enable the new floating design menu', 'web-stories' ),
-				'group'       => 'editor',
-				'default'     => true,
-			],
-			/**
-			 * Author: @barklund
 			 * Issue: #7332
 			 * Creation date: 2022-04-19
 			 */

--- a/packages/story-editor/src/components/canvas/canvasLayout.js
+++ b/packages/story-editor/src/components/canvas/canvasLayout.js
@@ -21,7 +21,6 @@ import styled, { StyleSheetManager } from 'styled-components';
 import { memo, useRef, useCombinedRefs } from '@googleforcreators/react';
 import { __ } from '@googleforcreators/i18n';
 import PropTypes from 'prop-types';
-import { useFeature } from 'flagged';
 
 /**
  * Internal dependencies
@@ -90,8 +89,6 @@ function CanvasLayout({ header, footer }) {
     ({ state: { isInRecordingMode } }) => ({ isInRecordingMode })
   );
 
-  const isFloatingMenuEnabled = useFeature('floatingMenu');
-
   // If we don't have proper canvas dimensions yet, don't bother rendering element layers.
   const hasDimensions = pageWidth !== 0 && pageHeight !== 0;
 
@@ -115,7 +112,7 @@ function CanvasLayout({ header, footer }) {
                 <>
                   <EyedropperLayer />
                   <EmptyStateLayer />
-                  {isFloatingMenuEnabled && <FloatingMenuLayer />}
+                  <FloatingMenuLayer />
                 </>
               )}
               {isInRecordingMode && <MediaRecordingLayer />}

--- a/packages/story-editor/src/components/canvas/karma/elementKeyboardNavigation.js
+++ b/packages/story-editor/src/components/canvas/karma/elementKeyboardNavigation.js
@@ -30,7 +30,6 @@ describe('Canvas Element - keyboard navigation', () => {
 
   beforeEach(async () => {
     fixture = new Fixture();
-    fixture.setFlags({ floatingMenu: true });
 
     await fixture.render();
     await fixture.collapseHelpCenter();

--- a/packages/story-editor/src/components/floatingMenu/elements/karma/border.karma.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/karma/border.karma.js
@@ -30,7 +30,6 @@ describe('Design Menu: Border width & color', () => {
 
   beforeEach(async () => {
     fixture = new Fixture();
-    fixture.setFlags({ floatingMenu: true });
     try {
       await fixture.render();
     } catch {

--- a/packages/story-editor/src/components/floatingMenu/elements/karma/borderRadius.karma.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/karma/borderRadius.karma.js
@@ -30,7 +30,6 @@ describe('Design Menu: Border radius', () => {
 
   beforeEach(async () => {
     fixture = new Fixture();
-    fixture.setFlags({ floatingMenu: true });
     await fixture.render();
 
     await fixture.collapseHelpCenter();

--- a/packages/story-editor/src/components/floatingMenu/elements/karma/flip.karma.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/karma/flip.karma.js
@@ -25,7 +25,6 @@ describe('Design Menu: Flip toggles', () => {
 
   beforeEach(async () => {
     fixture = new Fixture();
-    fixture.setFlags({ floatingMenu: true });
     await fixture.render();
 
     await fixture.collapseHelpCenter();

--- a/packages/story-editor/src/components/floatingMenu/elements/karma/loop.karma.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/karma/loop.karma.js
@@ -25,7 +25,6 @@ describe('Design Menu: Video loop toggle', () => {
 
   beforeEach(async () => {
     fixture = new Fixture();
-    fixture.setFlags({ floatingMenu: true });
     try {
       await fixture.render();
     } catch {

--- a/packages/story-editor/src/components/floatingMenu/elements/karma/more.karma.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/karma/more.karma.js
@@ -30,7 +30,6 @@ describe('More button', () => {
 
   beforeEach(async () => {
     fixture = new Fixture();
-    fixture.setFlags({ floatingMenu: true });
 
     await fixture.render();
     await fixture.collapseHelpCenter();

--- a/packages/story-editor/src/components/floatingMenu/elements/karma/opacity.karma.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/karma/opacity.karma.js
@@ -24,7 +24,6 @@ describe('Design Menu: Opacity Input', () => {
 
   beforeEach(async () => {
     fixture = new Fixture();
-    fixture.setFlags({ floatingMenu: true });
 
     await fixture.render();
     await fixture.collapseHelpCenter();

--- a/packages/story-editor/src/components/floatingMenu/elements/karma/shopping.karma.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/karma/shopping.karma.js
@@ -52,7 +52,6 @@ describe('Shopping integration', () => {
 
   beforeEach(async () => {
     fixture = new Fixture();
-    fixture.setFlags({ floatingMenu: true });
     await fixture.render();
     await fixture.collapseHelpCenter();
   });

--- a/packages/story-editor/src/components/floatingMenu/elements/karma/text.karma.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/karma/text.karma.js
@@ -32,7 +32,6 @@ describe('Design Menu: Text Styles', () => {
 
   beforeEach(async () => {
     fixture = new Fixture();
-    fixture.setFlags({ floatingMenu: true });
     await fixture.render();
 
     await fixture.collapseHelpCenter();

--- a/packages/story-editor/src/components/floatingMenu/elements/karma/textAlign.karma.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/karma/textAlign.karma.js
@@ -25,7 +25,6 @@ describe('Design Menu: Text alignment', () => {
 
   beforeEach(async () => {
     fixture = new Fixture();
-    fixture.setFlags({ floatingMenu: true });
     await fixture.render();
 
     await fixture.collapseHelpCenter();

--- a/packages/story-editor/src/components/floatingMenu/karma/floatingMenu.karma.js
+++ b/packages/story-editor/src/components/floatingMenu/karma/floatingMenu.karma.js
@@ -31,7 +31,6 @@ describe('Design Menu: Keyboard Navigation', () => {
 
   beforeEach(async () => {
     fixture = new Fixture();
-    fixture.setFlags({ floatingMenu: true });
     await fixture.render();
     await fixture.collapseHelpCenter();
   });

--- a/packages/story-editor/src/components/floatingMenu/karma/image.karma.js
+++ b/packages/story-editor/src/components/floatingMenu/karma/image.karma.js
@@ -26,7 +26,6 @@ describe('Image Design Menu: Keyboard Navigation', () => {
 
   beforeEach(async () => {
     fixture = new Fixture();
-    fixture.setFlags({ floatingMenu: true });
     await fixture.render();
     await fixture.collapseHelpCenter();
 

--- a/packages/story-editor/src/components/floatingMenu/karma/shape.karma.js
+++ b/packages/story-editor/src/components/floatingMenu/karma/shape.karma.js
@@ -32,7 +32,6 @@ describe('Shape Design Menu: Keyboard Navigation', () => {
 
   beforeEach(async () => {
     fixture = new Fixture();
-    fixture.setFlags({ floatingMenu: true });
     await fixture.render();
     await fixture.collapseHelpCenter();
 

--- a/packages/story-editor/src/components/floatingMenu/karma/sticker.karma.js
+++ b/packages/story-editor/src/components/floatingMenu/karma/sticker.karma.js
@@ -33,7 +33,6 @@ describe('Sticker Design Menu: Keyboard Navigation', () => {
 
   beforeEach(async () => {
     fixture = new Fixture();
-    fixture.setFlags({ floatingMenu: true });
     await fixture.render();
     await fixture.collapseHelpCenter();
 

--- a/packages/story-editor/src/components/floatingMenu/karma/text.karma.js
+++ b/packages/story-editor/src/components/floatingMenu/karma/text.karma.js
@@ -26,7 +26,6 @@ describe('Text Design Menu: Keyboard Navigation', () => {
 
   beforeEach(async () => {
     fixture = new Fixture();
-    fixture.setFlags({ floatingMenu: true });
     await fixture.render();
     await fixture.collapseHelpCenter();
 

--- a/packages/story-editor/src/components/floatingMenu/karma/video.karma.js
+++ b/packages/story-editor/src/components/floatingMenu/karma/video.karma.js
@@ -26,7 +26,6 @@ describe('Video Design Menu: Keyboard Navigation', () => {
 
   beforeEach(async () => {
     fixture = new Fixture();
-    fixture.setFlags({ floatingMenu: true });
     await fixture.render();
     await fixture.collapseHelpCenter();
 

--- a/packages/story-editor/src/components/library/panes/shopping/karma/shopping.karma.js
+++ b/packages/story-editor/src/components/library/panes/shopping/karma/shopping.karma.js
@@ -70,7 +70,6 @@ describe('Shopping integration', () => {
 
   beforeEach(async () => {
     fixture = new Fixture();
-    fixture.setFlags({ floatingMenu: true });
     await fixture.render();
     await fixture.collapseHelpCenter();
   });


### PR DESCRIPTION
## Context

This removes a feature flag for a long-enabled feature: the floating design menu.

## Testing Instructions

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #11130
