### PR TITLE
Code: Removed enabled feature flag for new layer features

### DIFF
--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -291,42 +291,6 @@ class Experiments extends Service_Base implements HasRequirements {
 			],
 			/**
 			 * Author: @barklund
-			 * Issue: #7332
-			 * Creation date: 2022-04-19
-			 */
-			[
-				'name'        => 'layerLocking',
-				'label'       => __( 'Layer locking', 'web-stories' ),
-				'description' => __( 'Enable layer locking', 'web-stories' ),
-				'group'       => 'editor',
-				'default'     => true,
-			],
-			/**
-			 * Author: @merapi
-			 * Issue: #9244
-			 * Creation date: 2022-05-04
-			 */
-			[
-				'name'        => 'layerGrouping',
-				'label'       => __( 'Layer grouping', 'web-stories' ),
-				'description' => __( 'Enable layer grouping', 'web-stories' ),
-				'group'       => 'editor',
-				'default'     => true,
-			],
-			/**
-			 * Author: @mariana-k
-			 * Issue: #9248
-			 * Creation date: 2022-05-12
-			 */
-			[
-				'name'        => 'layerNaming',
-				'label'       => __( 'Layer naming', 'web-stories' ),
-				'description' => __( 'Enable layer naming', 'web-stories' ),
-				'group'       => 'editor',
-				'default'     => true,
-			],
-			/**
-			 * Author: @barklund
 			 * Issue: #9643
 			 * Creation date: 2022-06-21
 			 */

--- a/packages/story-editor/src/app/rightClickMenu/items/layerLock.js
+++ b/packages/story-editor/src/app/rightClickMenu/items/layerLock.js
@@ -19,7 +19,6 @@
  */
 import { ContextMenuComponents } from '@googleforcreators/design-system';
 import { useCallback } from '@googleforcreators/react';
-import { useFeature } from 'flagged';
 
 /**
  * Internal dependencies
@@ -41,12 +40,6 @@ function LayerLock() {
       }),
     [updateSelectedElements]
   );
-
-  const isLayerLockingEnabled = useFeature('layerLocking');
-
-  if (!isLayerLockingEnabled) {
-    return null;
-  }
 
   return (
     <ContextMenuComponents.MenuButton onClick={toggleLayerLock}>

--- a/packages/story-editor/src/app/rightClickMenu/items/layerName.js
+++ b/packages/story-editor/src/app/rightClickMenu/items/layerName.js
@@ -19,7 +19,6 @@
  */
 import { ContextMenuComponents } from '@googleforcreators/design-system';
 import { useCallback } from '@googleforcreators/react';
-import { useFeature } from 'flagged';
 
 /**
  * Internal dependencies
@@ -40,12 +39,6 @@ function LayerName() {
       elementId: selectedElementIds[0],
     });
   }, [setRenamableLayer, selectedElementIds]);
-
-  const isLayerNamingEnabled = useFeature('layerNaming');
-
-  if (!isLayerNamingEnabled) {
-    return null;
-  }
 
   return (
     <>

--- a/packages/story-editor/src/app/rightClickMenu/items/layerUngroup.js
+++ b/packages/story-editor/src/app/rightClickMenu/items/layerUngroup.js
@@ -19,7 +19,6 @@
  */
 import { ContextMenuComponents } from '@googleforcreators/design-system';
 import { useCallback } from '@googleforcreators/react';
-import { useFeature } from 'flagged';
 
 /**
  * Internal dependencies
@@ -41,10 +40,9 @@ function LayerUngroup() {
     });
   }, [selectedElements, removeElementFromGroup]);
 
-  const isLayerGroupingEnabled = useFeature('layerGrouping');
   const isLayerInGroup = selectedElements.some((el) => el.groupId);
 
-  if (!isLayerGroupingEnabled || !isLayerInGroup) {
+  if (!isLayerInGroup) {
     return null;
   }
 

--- a/packages/story-editor/src/app/rightClickMenu/menus/groupMenu.js
+++ b/packages/story-editor/src/app/rightClickMenu/menus/groupMenu.js
@@ -18,7 +18,6 @@
  * External dependencies
  */
 import { ContextMenuComponents } from '@googleforcreators/design-system';
-import { useFeature } from 'flagged';
 
 /**
  * Internal dependencies
@@ -33,7 +32,6 @@ function GroupMenu() {
     //handleGroupSelectedElements,
     handleUngroupSelectedElements,
   } = useElementActions();
-  const isLayerGroupingEnabled = useFeature('layerGrouping');
   const { selectedElements } = useStory(({ state }) => ({
     selectedElements: state.selectedElements,
   }));
@@ -49,7 +47,7 @@ function GroupMenu() {
       >
         {RIGHT_CLICK_MENU_LABELS.DUPLICATE_ELEMENTS(2)}
       </ContextMenuComponents.MenuButton>
-      {isLayerGroupingEnabled && isGroupSelected && (
+      {isGroupSelected && (
         <ContextMenuComponents.MenuButton
           onClick={handleUngroupSelectedElements}
         >

--- a/packages/story-editor/src/app/rightClickMenu/menus/multipleElementsMenu.js
+++ b/packages/story-editor/src/app/rightClickMenu/menus/multipleElementsMenu.js
@@ -18,7 +18,6 @@
  * External dependencies
  */
 import { ContextMenuComponents } from '@googleforcreators/design-system';
-import { useFeature } from 'flagged';
 
 /**
  * Internal dependencies
@@ -35,7 +34,6 @@ function MultipleElementsMenu() {
     handleUngroupSelectedElements,
   } = useElementActions();
   const { canMergeIntoMask, mergeIntoMask } = useShapeMaskElements();
-  const isLayerGroupingEnabled = useFeature('layerGrouping');
   const { selectedElements } = useStory(({ state }) => ({
     selectedElements: state.selectedElements,
   }));
@@ -57,12 +55,12 @@ function MultipleElementsMenu() {
           {RIGHT_CLICK_MENU_LABELS.USE_SHAPE_AS_MASK}
         </ContextMenuComponents.MenuButton>
       )}
-      {isLayerGroupingEnabled && !isOnlyGroupSelected && (
+      {!isOnlyGroupSelected && (
         <ContextMenuComponents.MenuButton onClick={handleGroupSelectedElements}>
           {RIGHT_CLICK_MENU_LABELS.GROUP_LAYERS}
         </ContextMenuComponents.MenuButton>
       )}
-      {isLayerGroupingEnabled && isGroupSelected && (
+      {isGroupSelected && (
         <ContextMenuComponents.MenuButton
           onClick={handleUngroupSelectedElements}
         >

--- a/packages/story-editor/src/components/canvas/karma/selection.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/selection.karma.js
@@ -31,7 +31,6 @@ describe('CUJ: Creator can Transform an Element: Selection integration', () => {
 
   beforeEach(async () => {
     fixture = new Fixture();
-    fixture.setFlags({ layerLocking: true });
     await fixture.render();
     await fixture.collapseHelpCenter();
 

--- a/packages/story-editor/src/components/panels/layer/elementLayer.js
+++ b/packages/story-editor/src/components/panels/layer/elementLayer.js
@@ -25,7 +25,6 @@ import {
   getDefinitionForType,
   getLayerName,
 } from '@googleforcreators/elements';
-import { useFeature } from 'flagged';
 
 /**
  * Internal dependencies
@@ -59,7 +58,6 @@ const LayerIconWrapper = styled.div`
 
 function ElementLayer({ element }) {
   const layerName = getLayerName(element);
-  const isLayerLockingEnabled = useFeature('layerLocking');
   const { LayerIcon } = getDefinitionForType(element.type);
   const { isSelected, handleClick } = useLayerSelection(element);
   const { id, isDefaultBackground, isBackground, type } = element;
@@ -93,9 +91,7 @@ function ElementLayer({ element }) {
     [currentPageBackgroundColor, element, getProxiedUrl]
   );
 
-  const hasLayerLockIcon = Boolean(
-    isBackground || (element.isLocked && isLayerLockingEnabled)
-  );
+  const hasLayerLockIcon = Boolean(isBackground || element.isLocked);
   const LayerLockIcon = useCallback(
     () =>
       isBackground || isNested ? (

--- a/packages/story-editor/src/components/panels/layer/elementLayerActions.js
+++ b/packages/story-editor/src/components/panels/layer/elementLayerActions.js
@@ -21,7 +21,6 @@ import { __ } from '@googleforcreators/i18n';
 import { Icons } from '@googleforcreators/design-system';
 import { memo, useMemo, useCallback } from '@googleforcreators/react';
 import { getDefinitionForType } from '@googleforcreators/elements';
-import { useFeature } from 'flagged';
 
 /**
  * Internal dependencies
@@ -33,7 +32,6 @@ import useShapeMask from '../../../utils/useShapeMask';
 import LayerAction from './layerAction';
 
 function ElementLayerActions({ element }) {
-  const isLayerLockingEnabled = useFeature('layerLocking');
   const { hasDuplicateMenu } = getDefinitionForType(element.type);
 
   const { duplicateElementsById, updateElementById, deleteElementById } =
@@ -109,7 +107,6 @@ function ElementLayerActions({ element }) {
         <Icons.PagePlus />
       </LayerAction>
       <LayerAction
-        isActive={isLayerLockingEnabled}
         label={lockTitle}
         disabled={isNested}
         handleClick={handleLockElement}

--- a/packages/story-editor/src/components/panels/layer/groupLayer.js
+++ b/packages/story-editor/src/components/panels/layer/groupLayer.js
@@ -20,7 +20,6 @@
 import styled from 'styled-components';
 import { Icons } from '@googleforcreators/design-system';
 import { memo, useCallback } from '@googleforcreators/react';
-import { useFeature } from 'flagged';
 
 /**
  * Internal dependencies
@@ -69,7 +68,6 @@ const ChevronRight = styled(Icons.ChevronDown)`
 `;
 
 function GroupLayer({ groupId }) {
-  const isLayerLockingEnabled = useFeature('layerLocking');
   const { groups, updateGroupById } = useStory(({ actions, state }) => ({
     groups: state.currentPage.groups,
     updateGroupById: actions.updateGroupById,
@@ -115,7 +113,7 @@ function GroupLayer({ groupId }) {
       handleClick={handleClick}
       isSelected={isSelected}
       LayerIcon={GroupLayerIcon}
-      hasLayerLockIcon={isLocked && isLayerLockingEnabled}
+      hasLayerLockIcon={isLocked}
       LayerLockIcon={Icons.LockClosed}
       actions={<GroupLayerActions groupId={groupId} />}
     />

--- a/packages/story-editor/src/components/panels/layer/groupLayerActions.js
+++ b/packages/story-editor/src/components/panels/layer/groupLayerActions.js
@@ -20,7 +20,6 @@
 import { __ } from '@googleforcreators/i18n';
 import { Icons } from '@googleforcreators/design-system';
 import { memo, useCallback } from '@googleforcreators/react';
-import { useFeature } from 'flagged';
 
 /**
  * Internal dependencies
@@ -32,7 +31,6 @@ import generateGroupName from '../../../utils/generateGroupName';
 import LayerAction from './layerAction';
 
 function GroupLayerActions({ groupId }) {
-  const isLayerLockingEnabled = useFeature('layerLocking');
   const {
     groups,
     updateGroupById,
@@ -103,11 +101,7 @@ function GroupLayerActions({ groupId }) {
         <Icons.PagePlus />
       </LayerAction>
 
-      <LayerAction
-        isActive={isLayerLockingEnabled}
-        label={lockTitle}
-        handleClick={handleLockGroup}
-      >
+      <LayerAction label={lockTitle} handleClick={handleLockGroup}>
         {isLocked ? <Icons.LockClosed /> : <Icons.LockOpen />}
       </LayerAction>
     </>

--- a/packages/story-editor/src/components/panels/layer/karma/layer.karma.js
+++ b/packages/story-editor/src/components/panels/layer/karma/layer.karma.js
@@ -33,7 +33,6 @@ describe('Layer Panel', () => {
 
   beforeEach(async () => {
     fixture = new Fixture();
-    fixture.setFlags({ layerLocking: true, layerNaming: true });
     await fixture.render();
     await fixture.collapseHelpCenter();
     layerPanel = fixture.editor.footer.layerPanel;

--- a/packages/story-editor/src/components/panels/layer/layer.js
+++ b/packages/story-editor/src/components/panels/layer/layer.js
@@ -19,7 +19,6 @@
  */
 import PropTypes from 'prop-types';
 import { useRef, memo } from '@googleforcreators/react';
-import { useFeature } from 'flagged';
 
 /**
  * Internal dependencies
@@ -62,8 +61,6 @@ function Layer({
     eventData: trackingData,
   });
 
-  const isLayerNamingEnabled = useFeature('layerNaming');
-
   if (skipLayer) {
     return null;
   }
@@ -73,7 +70,7 @@ function Layer({
 
   return (
     <LayerContainer>
-      {isRenameable && isLayerNamingEnabled ? (
+      {isRenameable ? (
         <LayerInputWrapper isNested={isNested}>
           <LayerIcon />
           <LayerForm


### PR DESCRIPTION
## Context

This removes long-enabled feature flags for layer manipulation including flags, naming, grouping, and locking.

## Testing Instructions

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #11796
