### PR TITLE
Code Quality: Remove `tenorStickers` feature flag code 

### DIFF
--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -291,18 +291,6 @@ class Experiments extends Service_Base implements HasRequirements {
 				'default'     => true,
 			],
 			/**
-			 * Author: @swissspidy
-			 * Issue: #11878
-			 * Creation date: 2022-07-06
-			 */
-			[
-				'name'        => 'tenorStickers',
-				'label'       => __( 'Stickers', 'web-stories' ),
-				'description' => __( 'Enable Tenor stickers support', 'web-stories' ),
-				'group'       => 'editor',
-				'default'     => true,
-			],
-			/**
 			 * Author: @timarney
 			 * Issue: #12094
 			 * Creation date: 2022-08-11

--- a/packages/story-editor/src/app/media/media3p/providerConfiguration.js
+++ b/packages/story-editor/src/app/media/media3p/providerConfiguration.js
@@ -108,6 +108,5 @@ export const PROVIDERS = {
       __('Error loading media from %s', 'web-stories'),
       'Tenor'
     ),
-    featureName: 'tenorStickers',
   },
 };


### PR DESCRIPTION
## Context

Now that this has been enabled by default in https://github.com/GoogleForCreators/web-stories-wp/pull/12019 in the last release we can remove the relevant code bits.

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Removes tenorStickers flag

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Visit the Third-party media tab
2. Note Stickers exists without turning on the experiment
3. Verify that searching, filtering, and inserting stickers works as expected


## Reviews

### Does this PR have a security-related impact?

No

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

No

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

No

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12306
