### PR TITLE
Lightbox: ensure story player always has dimensions

### DIFF
--- a/packages/stories-block/src/css/lightbox.css
+++ b/packages/stories-block/src/css/lightbox.css
@@ -15,7 +15,6 @@
   height: 100%;
   opacity: 0;
   transform: translate(0, -100vh);
-  display: none;
 }
 
 /* amp-lightbox needs to have z-index to render on top of other elements in the page. */
@@ -27,7 +26,6 @@
 .web-stories-list__lightbox.show {
   transform: translate(0, 0);
   opacity: 1;
-  display: block;
 }
 
 .web-stories-list__lightbox amp-story-player {


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

See #12363

## Summary

<!-- A brief description of what this PR does. -->

The solution for this story player bug is to ensure that it always has dimensions

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

Player in lightbox should load right away

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add new Web Stories carousel block to site, ideally far down in the footer
2. View website
3. Click on stories in carousel
4. Verify that the player loads right away


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12363
