### PR TITLE
Custom Fonts: Remove posts on uninstall

### DIFF
--- a/includes/uninstall.php
+++ b/includes/uninstall.php
@@ -159,6 +159,7 @@ function delete_posts(): void {
 			'post_status'      => 'any',
 			'post_type'        => [
 				Story_Post_Type::POST_TYPE_SLUG,
+				Font_Post_Type::POST_TYPE_SLUG,
 				Page_Template_Post_Type::POST_TYPE_SLUG,
 			],
 			'posts_per_page'   => - 1,

--- a/tests/phpunit/integration/tests/Uninstall.php
+++ b/tests/phpunit/integration/tests/Uninstall.php
@@ -46,6 +46,7 @@ class Uninstall extends DependencyInjectedTestCase {
 			wp_set_object_terms( $attachment_id, $terms_ids, $source_taxonomy->get_taxonomy_slug() );
 		}
 
+		self::factory()->post->create_many( 5, [ 'post_type' => \Google\Web_Stories\Font_Post_Type::POST_TYPE_SLUG ] );
 		self::factory()->post->create_many( 5, [ 'post_type' => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG ] );
 		self::factory()->post->create_many( 5, [ 'post_type' => \Google\Web_Stories\Page_Template_Post_Type::POST_TYPE_SLUG ] );
 
@@ -101,6 +102,7 @@ class Uninstall extends DependencyInjectedTestCase {
 				'fields'           => 'ids',
 				'suppress_filters' => false,
 				'post_type'        => [
+					\Google\Web_Stories\Font_Post_Type::POST_TYPE_SLUG,
 					\Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
 					\Google\Web_Stories\Page_Template_Post_Type::POST_TYPE_SLUG,
 				],


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Remove font post when uninstalling plugin.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Activate plugin. 
2. create a couple of custom fonts. 
3. Save. 
4. Click, Uninstall data on install. 
5. Save. 
6. Uninstall plugin. 
7. Install / activate plugin. 
8. See list of fonts is empty. 


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12360
