### PR TITLE
Editor: fix incorrect poster dimensions being returned

### DIFF
--- a/includes/Admin/Editor.php
+++ b/includes/Admin/Editor.php
@@ -486,41 +486,80 @@ class Editor extends Service_Base implements HasRequirements {
 	 *
 	 * @since 1.26.0
 	 *
-	 * @param int[] $max_size {
-	 *     An array of width and height values.
+	 * @param int[]        $max_size {
+	 *            An array of width and height values.
 	 *
 	 *     @type int $0 The maximum width in pixels.
 	 *     @type int $1 The maximum height in pixels.
 	 * }
 	 * @param string|int[] $size     Requested image size. Can be any registered image size name, or
 	 *                               an array of width and height values in pixels (in that order).
-	 *
-	 * @return array
+	 * @return array<int, int>
 	 */
-	public function editor_max_image_size( $max_size, $size ) {
+	public function editor_max_image_size( $max_size, $size ): array {
 		$_wp_additional_image_sizes = wp_get_additional_image_sizes();
 
-		if ( is_array( $size ) ) {
+		if ( \is_array( $size ) ) {
 			$max_width  = $size[0];
 			$max_height = $size[1];
 		} elseif ( 'thumb' === $size || 'thumbnail' === $size ) {
-			$max_width  = (int) get_option( 'thumbnail_size_w' );
-			$max_height = (int) get_option( 'thumbnail_size_h' );
+			/**
+			 * Thumbnail size width.
+			 *
+			 * @var int $max_width
+			 */
+			$max_width = get_option( 'thumbnail_size_w' );
+			/**
+			 * Thumbnail size height.
+			 *
+			 * @var int $max_height
+			 */
+			$max_height = get_option( 'thumbnail_size_h' );
 			// Last chance thumbnail size defaults.
 			if ( ! $max_width && ! $max_height ) {
 				$max_width  = 128;
 				$max_height = 96;
 			}
 		} elseif ( 'medium' === $size ) {
-			$max_width  = (int) get_option( 'medium_size_w' );
-			$max_height = (int) get_option( 'medium_size_h' );
+			/**
+			 * Thumbnail size width.
+			 *
+			 * @var int $max_width
+			 */
+			$max_width = get_option( 'medium_size_w' );
+			/**
+			 * Thumbnail size height.
+			 *
+			 * @var int $max_height
+			 */
+			$max_height = get_option( 'medium_size_h' );
 		} elseif ( 'medium_large' === $size ) {
-			$max_width  = (int) get_option( 'medium_large_size_w' );
-			$max_height = (int) get_option( 'medium_large_size_h' );
+			/**
+			 * Medium large size width.
+			 *
+			 * @var int $max_width
+			 */
+			$max_width = get_option( 'medium_large_size_w' );
+			/**
+			 * Medium large size height.
+			 *
+			 * @var int $max_height
+			 */
+			$max_height = get_option( 'medium_large_size_h' );
 		} elseif ( 'large' === $size ) {
-			$max_width  = (int) get_option( 'large_size_w' );
-			$max_height = (int) get_option( 'large_size_h' );
-		} elseif ( ! empty( $_wp_additional_image_sizes ) && array_key_exists( $size, $_wp_additional_image_sizes ) ) {
+			/**
+			 * Large size width.
+			 *
+			 * @var int $max_width
+			 */
+			$max_width = get_option( 'large_size_w' );
+			/**
+			 * Large size height.
+			 *
+			 * @var int $max_height
+			 */
+			$max_height = get_option( 'large_size_h' );
+		} elseif ( ! empty( $_wp_additional_image_sizes ) && \array_key_exists( $size, $_wp_additional_image_sizes ) ) {
 			$max_width  = (int) $_wp_additional_image_sizes[ $size ]['width'];
 			$max_height = (int) $_wp_additional_image_sizes[ $size ]['height'];
 		} else { // $size === 'full' has no constraint.
@@ -528,6 +567,6 @@ class Editor extends Service_Base implements HasRequirements {
 			$max_height = $max_size[1];
 		}
 
-		return [ $max_width, $max_height ];
+		return [ (int) $max_width, (int) $max_height ];
 	}
 }

--- a/tests/phpunit/integration/tests/Admin/Editor.php
+++ b/tests/phpunit/integration/tests/Admin/Editor.php
@@ -307,51 +307,51 @@ class Editor extends DependencyInjectedTestCase {
 	 */
 	public function data_editor_max_image_size(): array {
 		return [
-			'thumb'        => [
+			'thumb'                      => [
 				'max_size' => [],
 				'size'     => 'thumb',
 				'expected' => [ 150, 150 ],
 			],
-			'thumbnail'    => [
+			'thumbnail'                  => [
 				'max_size' => [],
 				'size'     => 'thumbnail',
 				'expected' => [ 150, 150 ],
 			],
-			'medium'       => [
+			'medium'                     => [
 				'max_size' => [],
 				'size'     => 'medium',
 				'expected' => [ 300, 300 ],
 			],
-			'medium_large' => [
+			'medium_large'               => [
 				'max_size' => [],
 				'size'     => 'medium_large',
 				'expected' => [ 0, 768 ],
 			],
-			'large'        => [
+			'large'                      => [
 				'max_size' => [],
 				'size'     => 'large',
 				'expected' => [ 1024, 1024 ],
 			],
-			'full'         => [
+			'full'                       => [
 				'max_size' => [ 888, 888 ],
 				'size'     => 'full',
 				'expected' => [ 888, 888 ],
 			],
-			'web-stories-publisher-logo'         => [
+			'web-stories-publisher-logo' => [
 				'max_size' => [],
 				'size'     => 'web-stories-publisher-logo',
 				'expected' => [ 96, 96 ],
 			],
-			'web-stories-thumbnail'         => [
+			'web-stories-thumbnail'      => [
 				'max_size' => [],
 				'size'     => 'web-stories-thumbnail',
 				'expected' => [ 150, 9999 ],
 			],
-			'custom_size'         => [
+			'custom_size'                => [
 				'max_size' => [],
 				'size'     => [ 777, 777 ],
 				'expected' => [ 777, 777 ],
-			]
+			],
 		];
 	}
 }

--- a/tests/phpunit/integration/tests/Admin/Editor.php
+++ b/tests/phpunit/integration/tests/Admin/Editor.php
@@ -176,6 +176,9 @@ class Editor extends DependencyInjectedTestCase {
 		);
 
 		$this->add_caps_to_roles();
+
+		$image_size = $this->injector->make( \Google\Web_Stories\Media\Image_Sizes::class );
+		$image_size->register();
 	}
 
 	public function tear_down(): void {
@@ -288,4 +291,67 @@ class Editor extends DependencyInjectedTestCase {
 		$this->assertFalse( $use_block_editor );
 	}
 
+	/**
+	 * @covers ::parse_link
+	 * @dataProvider data_editor_max_image_size
+	 */
+	public function test_editor_max_image_size( $max_size, $size, $expected ): void {
+		$result = $this->instance->editor_max_image_size( $max_size, $size );
+		$this->assertSameSets( $expected, $result );
+	}
+
+	/**
+	 * Data provider for test_editor_max_image_size.
+	 *
+	 * @return array[]
+	 */
+	public function data_editor_max_image_size(): array {
+		return [
+			'thumb'        => [
+				'max_size' => [],
+				'size'     => 'thumb',
+				'expected' => [ 150, 150 ],
+			],
+			'thumbnail'    => [
+				'max_size' => [],
+				'size'     => 'thumbnail',
+				'expected' => [ 150, 150 ],
+			],
+			'medium'       => [
+				'max_size' => [],
+				'size'     => 'medium',
+				'expected' => [ 300, 300 ],
+			],
+			'medium_large' => [
+				'max_size' => [],
+				'size'     => 'medium_large',
+				'expected' => [ 0, 768 ],
+			],
+			'large'        => [
+				'max_size' => [],
+				'size'     => 'large',
+				'expected' => [ 1024, 1024 ],
+			],
+			'full'         => [
+				'max_size' => [ 888, 888 ],
+				'size'     => 'full',
+				'expected' => [ 888, 888 ],
+			],
+			'web-stories-publisher-logo'         => [
+				'max_size' => [],
+				'size'     => 'web-stories-publisher-logo',
+				'expected' => [ 96, 96 ],
+			],
+			'web-stories-thumbnail'         => [
+				'max_size' => [],
+				'size'     => 'web-stories-thumbnail',
+				'expected' => [ 150, 9999 ],
+			],
+			'custom_size'         => [
+				'max_size' => [],
+				'size'     => [ 777, 777 ],
+				'expected' => [ 777, 777 ],
+			]
+		];
+	}
 }


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Fix incorrect image sizes in editor by filtering `editor_max_image_size` only in our editor. 

## Relevant Technical Choices

Copy the logic `image_constrain_size_for_editor`and using same logic without content_width checks. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12354
