### PR TITLE
Background Audio: fix types and link conflict

### DIFF
--- a/packages/e2e-tests/src/specs/editor/backgroundAudio.js
+++ b/packages/e2e-tests/src/specs/editor/backgroundAudio.js
@@ -114,6 +114,10 @@ describe('Background Audio', () => {
       await expect(page).toMatch(fileName);
 
       await expect(page).toMatchElement('button[aria-label="Play"]');
+
+      await expect(page).toMatchElement('label', {
+        text: 'Loop',
+      });
     });
 
     it('should allow adding background audio with captions', async () => {

--- a/packages/media/src/createResource.ts
+++ b/packages/media/src/createResource.ts
@@ -22,6 +22,7 @@ import {
   Resource,
   ResourceType,
   VideoResource,
+  AudioResource,
 } from '@googleforcreators/types';
 
 /**
@@ -55,7 +56,7 @@ function createResource({
   trimData,
   needsProxy = false,
   ...rest
-}: ResourceInput): Resource | VideoResource | GifResource {
+}: ResourceInput): Resource | VideoResource | GifResource | AudioResource {
   type = type || getTypeFromMime(mimeType);
   const resource: Resource = {
     type,
@@ -89,6 +90,13 @@ function createResource({
       ...sequenceProps,
       output,
     } as GifResource;
+  }
+  if (type === ResourceType.Audio) {
+    return {
+      ...resource,
+      length,
+      lengthFormatted,
+    } as AudioResource;
   }
   return resource;
 }

--- a/packages/output/src/page.js
+++ b/packages/output/src/page.js
@@ -168,6 +168,10 @@ function OutputPage({
           </amp-story-grid-layer>
         )}
 
+        {backgroundAudioSrc && needsEnhancedBackgroundAudio && (
+          <BackgroundAudio backgroundAudio={backgroundAudio} id={id} />
+        )}
+
         <amp-story-grid-layer
           template="vertical"
           aspect-ratio={ASPECT_RATIO}
@@ -186,10 +190,6 @@ function OutputPage({
           </div>
         </amp-story-grid-layer>
       </StoryAnimation.Provider>
-
-      {backgroundAudioSrc && needsEnhancedBackgroundAudio && (
-        <BackgroundAudio backgroundAudio={backgroundAudio} id={id} />
-      )}
 
       {videoCaptions.length > 0 && (
         <amp-story-grid-layer

--- a/packages/story-editor/src/components/panels/shared/media/backgroundAudioPanelContent.js
+++ b/packages/story-editor/src/components/panels/shared/media/backgroundAudioPanelContent.js
@@ -116,6 +116,9 @@ function BackgroundAudioPanelContent({
   );
 
   const onSelect = useCallback(
+    /**
+     * @param {import('@googleforcreators/types').AudioResource} resource Audio resource.
+     */
     ({ src, id, mimeType, needsProxy, length, lengthFormatted }) => {
       const updatedBackgroundAudio = {
         resource: {

--- a/packages/types/src/resource/audioResource.ts
+++ b/packages/types/src/resource/audioResource.ts
@@ -14,9 +14,16 @@
  * limitations under the License.
  */
 
-export enum ResourceType {
-  Image = 'image',
-  Video = 'video',
-  Gif = 'gif',
-  Audio = 'audio',
+/**
+ * Internal dependencies
+ */
+import type { ResourceType } from './resourceType';
+import type { Resource } from './resource';
+
+export interface AudioResource extends Resource {
+  type: ResourceType.Audio;
+  /** Length in seconds. */
+  length: number;
+  /** The formatted length, e.g. "01:17". */
+  lengthFormatted: string;
 }

--- a/packages/types/src/resource/index.ts
+++ b/packages/types/src/resource/index.ts
@@ -18,3 +18,4 @@ export * from './gifResource';
 export * from './resource';
 export * from './resourceType';
 export * from './videoResource';
+export * from './audioResource';

--- a/packages/wp-story-editor/src/components/mediaUpload/mediaPicker/utils/getResourceFromMediaPicker.js
+++ b/packages/wp-story-editor/src/components/mediaUpload/mediaPicker/utils/getResourceFromMediaPicker.js
@@ -24,7 +24,7 @@ import { snakeToCamelCaseObjectKeys } from '@web-stories-wp/wp-utils';
  * Generates a resource object from a WordPress media picker object.
  *
  * @param {Object} mediaPickerEl WP Media Picker object.
- * @return {import('@googleforcreators/media').Resource} Resource object.
+ * @return {import('@googleforcreators/types').Resource} Resource object.
  */
 const getResourceFromMediaPicker = (mediaPickerEl) => {
   const {


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

Non-looping background audio clashed with link elements on a page.

Also, because of a type bug, the `length` was not passed when saving background audio, causing the "Loop" control to not be displayed.

## Summary

<!-- A brief description of what this PR does. -->

1. Fixes the "Loop" checkbox not being shown anymore for page background audio
2. Fixes an issue where the bg audio's hidden `<amp-video>` element was overlaying any links, making links not clickable.

## Relevant Technical Choices

<!-- Please describe your changes. -->

Extended e2e test to cover the "Loop" control

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add background audio on a given page
3. Disable Looping for audio
4. Add an element with a link to a page
5. Preview story
6. Verify that link is clickable and music is playing (non-looping)


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12384
