### PR TITLE
Dashboard: delete auto-draft local autosave when creating new story from template

### DIFF
--- a/packages/dashboard/src/app/api/useStoryApi.js
+++ b/packages/dashboard/src/app/api/useStoryApi.js
@@ -40,8 +40,8 @@ import storyReducer, {
 import { ERRORS } from '../textContent';
 import { useConfig } from '../config';
 
-// See also `getSessionStorageKey` for the key format:
-// https://github.com/GoogleForCreators/web-stories-wp/blob/d62ed358d069b3cd8586bc5f6949f50cdc0a39e6/packages/story-editor/src/utils/getSessionStorageKey.js
+// The format here is taken from the `getSessionStorageKey`.
+// See https://github.com/GoogleForCreators/web-stories-wp/blob/d62ed358d069b3cd8586bc5f6949f50cdc0a39e6/packages/story-editor/src/utils/getSessionStorageKey.js
 const DRAFT_STORAGE_KEY = `${SESSION_STORAGE_PREFIX.LOCAL_AUTOSAVE_PREFIX}_auto-draft`;
 
 const useStoryApi = () => {

--- a/packages/dashboard/src/app/api/useStoryApi.js
+++ b/packages/dashboard/src/app/api/useStoryApi.js
@@ -40,6 +40,8 @@ import storyReducer, {
 import { ERRORS } from '../textContent';
 import { useConfig } from '../config';
 
+// See also `getSessionStorageKey` for the key format:
+// https://github.com/GoogleForCreators/web-stories-wp/blob/d62ed358d069b3cd8586bc5f6949f50cdc0a39e6/packages/story-editor/src/utils/getSessionStorageKey.js
 const DRAFT_STORAGE_KEY = `${SESSION_STORAGE_PREFIX.LOCAL_AUTOSAVE_PREFIX}_auto-draft`;
 
 const useStoryApi = () => {

--- a/packages/dashboard/src/app/api/useStoryApi.js
+++ b/packages/dashboard/src/app/api/useStoryApi.js
@@ -40,7 +40,7 @@ import storyReducer, {
 import { ERRORS } from '../textContent';
 import { useConfig } from '../config';
 
-// The format here is taken from the `getSessionStorageKey`.
+// The format here is taken from the `getSessionStorageKey` util.
 // See https://github.com/GoogleForCreators/web-stories-wp/blob/d62ed358d069b3cd8586bc5f6949f50cdc0a39e6/packages/story-editor/src/utils/getSessionStorageKey.js
 const DRAFT_STORAGE_KEY = `${SESSION_STORAGE_PREFIX.LOCAL_AUTOSAVE_PREFIX}_auto-draft`;
 

--- a/packages/dashboard/src/app/api/useStoryApi.js
+++ b/packages/dashboard/src/app/api/useStoryApi.js
@@ -25,6 +25,10 @@ import {
   useRef,
 } from '@googleforcreators/react';
 import { getTimeTracker } from '@googleforcreators/tracking';
+import {
+  SESSION_STORAGE_PREFIX,
+  sessionStore,
+} from '@googleforcreators/design-system';
 
 /**
  * Internal dependencies
@@ -35,6 +39,8 @@ import storyReducer, {
 } from '../reducer/stories';
 import { ERRORS } from '../textContent';
 import { useConfig } from '../config';
+
+const DRAFT_STORAGE_KEY = `${SESSION_STORAGE_PREFIX.LOCAL_AUTOSAVE_PREFIX}_auto-draft`;
 
 const useStoryApi = () => {
   const isInitialFetch = useRef(true);
@@ -171,7 +177,7 @@ const useStoryApi = () => {
 
       try {
         const response = await apiCallbacks.createStoryFromTemplate(template);
-
+        sessionStore.deleteItemByKey(DRAFT_STORAGE_KEY);
         dispatch({
           type: STORY_ACTION_TYPES.CREATE_STORY_FROM_TEMPLATE_SUCCESS,
         });

--- a/packages/story-editor/src/utils/getSessionStorageKey.js
+++ b/packages/story-editor/src/utils/getSessionStorageKey.js
@@ -19,6 +19,8 @@
  */
 import { SESSION_STORAGE_PREFIX } from '@googleforcreators/design-system';
 
+// Note: this format is also used in the `dashboard` package that should be updated in case of the format changing.
+// See https://github.com/GoogleForCreators/web-stories-wp/pull/12416/files#diff-a314e9df4ccf61e1a84cd3ca5b318a729c086e49e92da545b5a6272da3666b98R43
 export default function getSessionStorageKey(storyId, isNew) {
   return `${SESSION_STORAGE_PREFIX.LOCAL_AUTOSAVE_PREFIX}_${
     isNew ? 'auto-draft' : storyId

--- a/packages/story-editor/src/utils/getSessionStorageKey.js
+++ b/packages/story-editor/src/utils/getSessionStorageKey.js
@@ -19,7 +19,7 @@
  */
 import { SESSION_STORAGE_PREFIX } from '@googleforcreators/design-system';
 
-// Note: this format is also used in the `dashboard` package that should be updated in case of the format changing.
+// Note: this key format is also used in the `dashboard` package which should be updated in case of changes.
 // See https://github.com/GoogleForCreators/web-stories-wp/pull/12416/files#diff-a314e9df4ccf61e1a84cd3ca5b318a729c086e49e92da545b5a6272da3666b98R43
 export default function getSessionStorageKey(storyId, isNew) {
   return `${SESSION_STORAGE_PREFIX.LOCAL_AUTOSAVE_PREFIX}_${


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Deletes `auto-draft` local autosave when creating a new story from a template.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Create new story
2. Wait for local autosave (session storage) -> `wp_stories_autosave_story_auto-draft` gets created
3. Go to dashboard
4. Create new story from a template
5. Get redirected to editor
6. Verify there's no warning about an existing local autosave


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12343 
