### PR TITLE
Disallow closing story takeover dialog

### DIFF
--- a/packages/wp-story-editor/src/components/postLock/postLockDialog.js
+++ b/packages/wp-story-editor/src/components/postLock/postLockDialog.js
@@ -71,6 +71,8 @@ function PostLockDialog({
     <Dialog
       isOpen={isOpen}
       onClose={onClose}
+      shouldCloseOnEsc={false}
+      shouldCloseOnOverlayClick={false}
       title={dialogTile}
       contentLabel={dialogTile}
       actions={

--- a/packages/wp-story-editor/src/components/postLock/postTakeOverDialog.js
+++ b/packages/wp-story-editor/src/components/postLock/postTakeOverDialog.js
@@ -59,6 +59,8 @@ function PostTakeOverDialog({ isOpen, user, dashboardLink, onClose }) {
       title={dialogTile}
       contentLabel={dialogTile}
       onClose={onClose}
+      shouldCloseOnEsc={false}
+      shouldCloseOnOverlayClick={false}
       actions={
         <Button
           type={BUTTON_TYPES.QUATERNARY}


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

Found during bug bash

## Summary

<!-- A brief description of what this PR does. -->

Prevent closing the takeover dialog in any way.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

**Post Locking:**

1. Open a locked story
2. Try to close the story locking dialog by pressing ESC or by clicking outside the dialog
3. It should not be possible

**Post Takeover:**

1. Wait for your story to be taken over by someone else
2. Try to close the takeover dialog by pressing ESC or by clicking outside the dialog
3. It should not be possible


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12430
