### PR TITLE
Increase admin submenu z-index

### DIFF
--- a/packages/design-system/src/components/index.js
+++ b/packages/design-system/src/components/index.js
@@ -26,7 +26,7 @@ export { Input, BaseInput } from './input';
 export { LoadingBar, LOADING_INDICATOR_CLASS } from './loadingBar';
 export { LoadingSpinner } from './loadingSpinner';
 export { MediaInput, MEDIA_VARIANTS } from './mediaInput';
-export { Modal, ModalGlobalStyle, OVERLAY_CLASS } from './modal';
+export { Modal, ModalGlobalStyle, OVERLAY_CLASS, BODY_CLASS } from './modal';
 export { NumericInput } from './input/numericInput';
 export * from './menu';
 export * from './pill';

--- a/packages/design-system/src/components/modal/index.js
+++ b/packages/design-system/src/components/modal/index.js
@@ -22,6 +22,7 @@ import ReactModal from 'react-modal';
 import PropTypes from 'prop-types';
 import { createGlobalStyle, ThemeContext } from 'styled-components';
 
+export const BODY_CLASS = 'WebStories_ReactModal__Body--open';
 export const CONTENT_CLASS = 'WebStories_ReactModal__Content';
 export const OVERLAY_CLASS = 'WebStories_ReactModal__Overlay';
 
@@ -83,6 +84,7 @@ export function Modal({
       isOpen={isOpen}
       onRequestClose={onClose}
       overlayClassName={OVERLAY_CLASS}
+      bodyOpenClassName={BODY_CLASS}
       style={{
         maxHeight: '100vh',
         ...modalStyles,

--- a/packages/wp-dashboard/src/theme.js
+++ b/packages/wp-dashboard/src/theme.js
@@ -18,7 +18,11 @@
  * External dependencies
  */
 import { createGlobalStyle } from 'styled-components';
-import { themeHelpers, OVERLAY_CLASS } from '@googleforcreators/design-system';
+import {
+  themeHelpers,
+  OVERLAY_CLASS,
+  BODY_CLASS,
+} from '@googleforcreators/design-system';
 
 /**
  * Internal dependencies
@@ -37,5 +41,15 @@ export const GlobalStyle = createGlobalStyle`
 
   body.folded .${OVERLAY_CLASS} {
     left: ${MENU_FOLDED_WIDTH}px !important;
+  }
+
+  /*
+    Increase submenu z-index from 3 to 15 so it's above the modal overlay (z-index 10).
+    See https://github.com/GoogleForCreators/web-stories-wp/pull/12443
+  */
+  body.${BODY_CLASS} {
+    #adminmenuwrap, #adminmenuback {
+      z-index: 15;
+    }
   }
 `;

--- a/packages/wp-story-editor/src/theme.js
+++ b/packages/wp-story-editor/src/theme.js
@@ -17,7 +17,7 @@
  * External dependencies
  */
 import { createGlobalStyle } from 'styled-components';
-import { OVERLAY_CLASS } from '@googleforcreators/design-system';
+import { OVERLAY_CLASS, BODY_CLASS } from '@googleforcreators/design-system';
 
 /**
  * Internal dependencies
@@ -32,5 +32,15 @@ export const GlobalStyle = createGlobalStyle`
 
   body.folded .${OVERLAY_CLASS} {
     left: ${MENU_FOLDED_WIDTH}px !important;
+  }
+
+  /*
+    Increase submenu z-index from 3 to 15 so it's above the modal overlay (z-index 10).
+    See https://github.com/GoogleForCreators/web-stories-wp/pull/12443
+  */
+  body.${BODY_CLASS} {
+    #adminmenuwrap, #adminmenuback {
+      z-index: 15;
+    }
   }
 `;


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

When a dialog (e.g. the “story is locked” dialog) is showing, the dialog grayout is above the main WP menu dropdowns, so you cannot actually use the WP menu while any dialog is showing.

## Summary

<!-- A brief description of what this PR does. -->

Increases the WordPress admin submenu z-index whenever a dialog is open.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Click on Publish button in the top right of the editor to open the publish dialog
2. Verify that the WordPress admin submenu is still accessible


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12433
