### PR TITLE
Fix missing images in Safari

### DIFF
--- a/patches/html-to-image+1.10.8.patch
+++ b/patches/html-to-image+1.10.8.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/html-to-image/es/util.js b/node_modules/html-to-image/es/util.js
+index d3f734b..1f5e9c6 100644
+--- a/node_modules/html-to-image/es/util.js
++++ b/node_modules/html-to-image/es/util.js
+@@ -136,7 +136,7 @@ export function canvasToBlob(canvas, options = {}) {
+ export function createImage(url) {
+     return new Promise((resolve, reject) => {
+         const img = new Image();
+-        img.onload = () => resolve(img);
++        img.decode = () => resolve(img);
+         img.onerror = reject;
+         img.crossOrigin = 'anonymous';
+         img.decoding = 'sync';

--- a/patches/html-to-image+1.10.8.patch
+++ b/patches/html-to-image+1.10.8.patch
@@ -1,5 +1,18 @@
+diff --git a/node_modules/html-to-image/es/embed-images.js b/node_modules/html-to-image/es/embed-images.js
+index 70e8468..c8db1a5 100644
+--- a/node_modules/html-to-image/es/embed-images.js
++++ b/node_modules/html-to-image/es/embed-images.js
+@@ -21,7 +21,7 @@ async function embedImageNode(clonedNode, options) {
+         : clonedNode.href.baseVal;
+     const dataURL = await resourceToDataURL(url, getMimeType(url), options);
+     await new Promise((resolve, reject) => {
+-        clonedNode.onload = resolve;
++        clonedNode.decode = resolve;
+         clonedNode.onerror = reject;
+         if (clonedNode instanceof HTMLImageElement) {
+             clonedNode.srcset = '';
 diff --git a/node_modules/html-to-image/es/util.js b/node_modules/html-to-image/es/util.js
-index d3f734b..1f5e9c6 100644
+index d3f734b..e3667ef 100644
 --- a/node_modules/html-to-image/es/util.js
 +++ b/node_modules/html-to-image/es/util.js
 @@ -136,7 +136,7 @@ export function canvasToBlob(canvas, options = {}) {


### PR DESCRIPTION
## Summary

This bug was pretty inconsistent, some images worked, some not, sometimes those which worked didn't work and so on.
I noticed that external pictures were not working more often.

The issue occurs somewhere between SVG and PNG generation:
SVG:
![image](https://user-images.githubusercontent.com/21036224/195119327-732e5da5-b6f4-4c92-a479-a5abe25b810f.png)
PNG:
![image](https://user-images.githubusercontent.com/21036224/195119372-8e707508-369d-4227-a1a0-a53d9108dd36.png)

Last time we fixed the Safari pictures by setting `decoding=sync` on images.
The current issue can be replicated in even a very old version (from January) so apparently we didn't fix all of the Safari issues last time.

I did a full circle and I'm back to image decoding.
I'm testing if explicit `Image.decode()` will fix the issue (it looks like so far).
https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-decode

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Use different versions of Safari
2. A a few images (local and external)
3. Check if prev/next canvas and thumbnails work as expected.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12432 
