### PR TITLE
Composer: Temporarily disable platform check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,8 @@
     "platform": {
       "php": "7.2.24"
     },
-    "sort-packages": true
+    "sort-packages": true,
+    "platform-check": false
   },
   "extra": {
     "downloads": {

--- a/composer.json
+++ b/composer.json
@@ -78,8 +78,8 @@
     "platform": {
       "php": "7.2.24"
     },
-    "sort-packages": true,
-    "platform-check": false
+    "platform-check": false,
+    "sort-packages": true
   },
   "extra": {
     "downloads": {


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Fix composer install in CI, by setting platform check in composer.

[Context](https://php.watch/articles/composer-platform-check). 

## Relevant Technical Choices

In my testing, composer install / phpunit do not run locally in PHP 7.2/7.3 because of this requirement. 

I believe this bug came around, because the composer vendor cache was empty and build happened in a PHP 7.2 or 7.3 and this resulted in platform check.php file being generated. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12480
