### PR TITLE
Do not print title tags for classic themes

### DIFF
--- a/includes/Discovery.php
+++ b/includes/Discovery.php
@@ -101,23 +101,26 @@ class Discovery extends Service_Base implements HasRequirements {
 	/**
 	 * Prints document title for stories.
 	 *
-	 * Works both for classic themes and block themes without any conditionals.
+	 * Works both for classic themes and block themes.
 	 *
 	 * @since 1.25.0
 	 *
 	 * @link https://github.com/GoogleForCreators/web-stories-wp/issues/12139
+	 * @link https://github.com/GoogleForCreators/web-stories-wp/issues/12487
 	 * @see _wp_render_title_tag()
 	 * @see _block_template_render_title_tag()
 	 */
 	public function print_document_title(): void {
+		$enable_metadata = function_exists( 'wp_is_block_theme' ) && wp_is_block_theme();
+
 		/**
 		 * Filters whether to print the document title.
 		 *
 		 * @since 1.25.0
 		 *
-		 * @param bool $enable_open_graph Whether to print the document title. Default to true.
+		 * @param bool $enable_open_graph Whether to print the document title. Defaults to true for block themes, false otherwise.
 		 */
-		$enable_metadata = apply_filters( 'web_stories_enable_document_title', true );
+		$enable_metadata = apply_filters( 'web_stories_enable_document_title', $enable_metadata );
 		if ( ! $enable_metadata ) {
 			return;
 		}

--- a/tests/phpunit/integration/tests/Discovery.php
+++ b/tests/phpunit/integration/tests/Discovery.php
@@ -119,7 +119,6 @@ class Discovery extends DependencyInjectedTestCase {
 		$this->assertSame( 10, has_action( 'web_stories_story_head', [ $this->instance, 'print_open_graph_metadata' ] ) );
 		$this->assertSame( 10, has_action( 'web_stories_story_head', [ $this->instance, 'print_twitter_metadata' ] ) );
 		$this->assertSame( 4, has_action( 'web_stories_story_head', [ $this->instance, 'print_feed_link' ] ) );
-
 	}
 
 	/**
@@ -134,6 +133,32 @@ class Discovery extends DependencyInjectedTestCase {
 	 * @covers ::print_metadata
 	 */
 	public function test_print_document_title(): void {
+		$output = get_echo( [ $this->instance, 'print_document_title' ] );
+		$this->assertStringNotContainsString( '<title>', $output );
+	}
+
+	/**
+	 * @covers ::print_metadata
+	 */
+	public function test_print_document_title_block_theme(): void {
+		if ( ! is_wp_version_compatible( '5.9.0' ) ) {
+			$this->markTestSkipped( 'This test requires WordPress 5.9.' );
+		}
+
+		$block_theme = 'twentytwentytwo';
+
+		// Skip if the block theme is not available.
+		if ( ! wp_get_theme( $block_theme )->exists() ) {
+			$this->markTestSkipped( "$block_theme must be available." );
+		}
+
+		switch_theme( $block_theme );
+
+		// Skip if we could not switch to the block theme.
+		if ( wp_get_theme()->stylesheet !== $block_theme ) {
+			$this->markTestSkipped( "Could not switch to $block_theme." );
+		}
+
 		$output = get_echo( [ $this->instance, 'print_document_title' ] );
 		$this->assertStringContainsString( '<title>', $output );
 	}

--- a/tests/phpunit/integration/tests/REST_API/Stories_Users_Controller.php
+++ b/tests/phpunit/integration/tests/REST_API/Stories_Users_Controller.php
@@ -75,7 +75,7 @@ class Stories_Users_Controller extends DependencyInjectedRestTestCase {
 	 * @covers ::filter_user_query
 	 */
 	public function test_filter_user_query_pre_wp_59(): void {
-		if ( is_wp_version_compatible( '5.9-beta' ) ) {
+		if ( is_wp_version_compatible( '5.9.0' ) ) {
 			$this->markTestSkipped( 'This test requires WordPress < 5.9.' );
 		}
 
@@ -93,7 +93,7 @@ class Stories_Users_Controller extends DependencyInjectedRestTestCase {
 	 * @covers ::filter_user_query
 	 */
 	public function test_filter_user_query_wp_59(): void {
-		if ( ! is_wp_version_compatible( '5.9-beta' ) ) {
+		if ( ! is_wp_version_compatible( '5.9.0' ) ) {
 			$this->markTestSkipped( 'This test requires WordPress 5.9.' );
 		}
 
@@ -141,7 +141,7 @@ class Stories_Users_Controller extends DependencyInjectedRestTestCase {
 	 * @covers ::filter_user_query
 	 */
 	public function test_filter_user_query_wp_59_existing_query(): void {
-		if ( version_compare( get_bloginfo( 'version' ), '5.9.0-beta', '<' ) ) {
+		if ( version_compare( get_bloginfo( 'version' ), '5.9.0', '<' ) ) {
 			$this->markTestSkipped( 'This test requires WordPress 5.9.' );
 		}
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

Stories can end up having duplicate title tags under some conditions.

## Summary

<!-- A brief description of what this PR does. -->

Disables default title tag output for classic themes

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

- [x] Tests

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Activate Yoast SEO plugin
2. Activate a theme like Astra, OceanWP, GeneratePress, etc.
3. View a single story
4. Verify there is only one `<title>` tag in the source code
5. Activate a theme like Twenty Twenty Two
6. Verify there is  _still_ only one `<title>` tag in the source code

Repeat with a plugin like Rank Math SEO

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12487
