### PR TITLE
Story Locking: Change interval to 60 seconds

### DIFF
--- a/includes/Admin/Editor.php
+++ b/includes/Admin/Editor.php
@@ -352,9 +352,7 @@ class Editor extends Service_Base implements HasRequirements {
 			admin_url( 'edit.php' )
 		);
 
-		/** This filter is documented in wp-admin/includes/ajax-actions.php */
-		$time_window = apply_filters( 'wp_check_post_lock_window', 150 );
-		$user        = wp_get_current_user();
+		$user = wp_get_current_user();
 
 		/** This filter is documented in wp-admin/includes/post.php */
 		$show_locked_dialog = apply_filters( 'show_post_locked_dialog', true, $post, $user );
@@ -426,7 +424,7 @@ class Editor extends Service_Base implements HasRequirements {
 				'publisher' => $publisher_name,
 			],
 			'postLock'                => [
-				'interval'         => $time_window,
+				'interval'         => 60,
 				'showLockedDialog' => $show_locked_dialog,
 			],
 			'canViewDefaultTemplates' => true,


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Now that the internal of when post locking is checked, down to 60 seconds over 150 seconds. This will improve when take over dialog is shown. 

60 seconds brings this inline with WordPress cores heartbeat api. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Enable post locking take over. 
2. Create a story. 
3. Add title. 
4. Save draft. 
5. In another window. Login as another user. 
6. Edit draft story. 
7. Take over story. 
8. return to original Window. 
9. Wait 60 seconds for dialog to show. 


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12435
