### PR TITLE
Saved Templates: Add missing `crossorigin` attribute

### DIFF
--- a/packages/story-editor/src/components/library/panes/pageTemplates/savedPageTemplate.js
+++ b/packages/story-editor/src/components/library/panes/pageTemplates/savedPageTemplate.js
@@ -212,6 +212,7 @@ function SavedPageTemplate(
           <TemplateImage
             alt={page.image?.alt || __('Saved Page Template', 'web-stories')}
             src={imageUrl}
+            crossOrigin="anonymous"
             height={page.image?.height}
             width={page.image?.height}
             draggable={false}


### PR DESCRIPTION
## Context

In the `DefaultPageTemplate` component we add `crossorigin="anonymous"` to images, but the same attribute is missing for the images in `SavedPageTemplate`.

This causes CORS issues when images are loaded from another origin.

## Summary

Adds `crossorigin="anonymous"` to images `SavedPageTemplate`

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?
No

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

No

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
No

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12512
