### PR TITLE
Design System: Ensure WP toolbar access when dialogs are open

### DIFF
--- a/packages/wp-story-editor/src/style.css
+++ b/packages/wp-story-editor/src/style.css
@@ -27,7 +27,7 @@
 }
 
 body.js.edit-story #wpcontent {
-  position: relative;
+  position: fixed;
   width: calc(100% - 160px);
 }
 
@@ -38,6 +38,11 @@ body.js.edit-story.folded #adminmenuback {
 body.js.edit-story #wpcontent,
 body.js.edit-story #wpbody-content {
   padding: 0;
+}
+
+/* issue #12545 */
+body.js.edit-story.WebStories_ReactModal__Body--open #wpcontent {
+  position: relative;
 }
 
 body.edit-story .web-stories-wp {

--- a/packages/wp-story-editor/src/style.css
+++ b/packages/wp-story-editor/src/style.css
@@ -27,7 +27,7 @@
 }
 
 body.js.edit-story #wpcontent {
-  position: fixed;
+  position: relative;
   width: calc(100% - 160px);
 }
 


### PR DESCRIPTION
## Context

This is like https://github.com/GoogleForCreators/web-stories-wp/issues/12433, but for the admin toolbar

When a dialog (e.g. the pre-publish modal) is being displayed, its overlay covers the admin toolbar submenu items.

## Summary

Updates css to use `relative` vs `fixed` for `#wpcontent`

Not sure what the previous history of setting this `#wpcontent` to `fixed` was but... with that set admin was sitting under the dialog regardless of the z-index being set.

See change in action here:
👉 https://www.youtube.com/watch?v=BaqO8QjniAs



## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Create a new story
2. Press publish 
3. Resize the browser to ensure the admin bar / submenu overlaps with the publish dialog
4. Note your able to access the sub menu


## Reviews

### Does this PR have a security-related impact?

No

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

No

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

No

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12479
