### PR TITLE
Avoid always loading RTL stylesheets

### DIFF
--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -282,6 +282,7 @@ const templateContent = ({ htmlWebpackPlugin, chunkNames }) => {
 
   const chunkName = htmlWebpackPlugin.options.chunks[0];
   const omitPrimaryChunk = (f) => f !== chunkName;
+  const omitRightToLeftChunk = (f) => !f.endsWith('-rtl');
 
   const js = htmlWebpackPlugin.files.js
     .map((pathname) => {
@@ -295,7 +296,8 @@ const templateContent = ({ htmlWebpackPlugin, chunkNames }) => {
       const f = filenameOf(pathname);
       return f.split('.css')[0];
     })
-    .filter(omitPrimaryChunk);
+    .filter(omitPrimaryChunk)
+    .filter(omitRightToLeftChunk);
 
   // We're only interested in chunks from dynamic imports;
   // ones that are not already in `js` and not primaries.


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

I just noticed that we were loading the RTL variants of our stylesheets all the time, even when viewing the LTR version.

So on LTR, we were loading two stylesheets: first the RTL version, then LTR.

As a user you don't notice it because the LTR one overrides the former.

## Summary

<!-- A brief description of what this PR does. -->

Avoid always loading RTL stylesheets, even on LTR.

Adjusts webpack config to prevent duplicate stylesheets.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Visit dashboard
2. See that only `wp-dashboard-css` is loaded, but `wp-dashboard-rtl-css` is **not**
3. Switch to RTL
4. See that only `wp-dashboard-rtl-css` is loaded


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
