### PR TITLE
Code Quality: Move `prepare_links()` to its own method in taxonomies controller

### DIFF
--- a/includes/REST_API/Stories_Taxonomies_Controller.php
+++ b/includes/REST_API/Stories_Taxonomies_Controller.php
@@ -37,6 +37,8 @@ use WP_Taxonomy;
 
 /**
  * Stories_Taxonomies_Controller class.
+ *
+ * @phpstan-import-type Links from \Google\Web_Stories\REST_API\Stories_Base_Controller
  */
 class Stories_Taxonomies_Controller extends WP_REST_Taxonomies_Controller implements Service, Delayed, Registerable {
 	/**
@@ -81,21 +83,23 @@ class Stories_Taxonomies_Controller extends WP_REST_Taxonomies_Controller implem
 	 *
 	 * @param WP_Taxonomy $taxonomy The taxonomy.
 	 * @return array Links for the given taxonomy.
+	 *
+	 * @phpstan-return Links
 	 */
-	protected function prepare_links( $taxonomy ) {
+	protected function prepare_links( WP_Taxonomy $taxonomy ): array {
 		$controller = $taxonomy->get_rest_controller();
 		// TODO: Remove get_namespace when WP 5.9, min requirements.
-		$namespace  = method_exists( $controller, 'get_namespace' ) ? $controller->get_namespace() : 'wp/v2';
-		$base       = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
+		$namespace = $controller && method_exists( $controller, 'get_namespace' ) ? $controller->get_namespace() : 'wp/v2';
+		$base      = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
 
-		return array(
-			'collection'              => array(
+		return [
+			'collection'              => [
 				'href' => rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ),
-			),
-			'https://api.w.org/items' => array(
+			],
+			'https://api.w.org/items' => [
 				'href' => rest_url( sprintf( '%s/%s', $namespace, $base ) ),
-			),
-		);
+			],
+		];
 	}
 
 	/**

--- a/includes/REST_API/Stories_Taxonomies_Controller.php
+++ b/includes/REST_API/Stories_Taxonomies_Controller.php
@@ -63,7 +63,10 @@ class Stories_Taxonomies_Controller extends WP_REST_Taxonomies_Controller implem
 	 * @return WP_REST_Response Response object.
 	 */
 	public function prepare_item_for_response( $taxonomy, $request ): WP_REST_Response {
-		$response   = parent::prepare_item_for_response( $taxonomy, $request );
+		$old_response   = parent::prepare_item_for_response( $taxonomy, $request );
+
+		// Wrap the data in a response object.
+		$response = rest_ensure_response( $old_response->get_data() );
 		$response->add_links( $this->prepare_links( $taxonomy ) );
 
 		/** This filter is documented in wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php */

--- a/includes/REST_API/Stories_Taxonomies_Controller.php
+++ b/includes/REST_API/Stories_Taxonomies_Controller.php
@@ -63,10 +63,20 @@ class Stories_Taxonomies_Controller extends WP_REST_Taxonomies_Controller implem
 	 * @return WP_REST_Response Response object.
 	 */
 	public function prepare_item_for_response( $taxonomy, $request ): WP_REST_Response {
-		$old_response   = parent::prepare_item_for_response( $taxonomy, $request );
+		$old_response = parent::prepare_item_for_response( $taxonomy, $request );
 
-		// Wrap the data in a response object.
-		$response = rest_ensure_response( $old_response->get_data() );
+		/**
+		 * Response data.
+		 *
+		 * @var array<string,mixed> $data
+		 */
+		$data = $old_response->get_data();
+		/**
+		 * Response object.
+		 *
+		 * @var WP_REST_Response $response
+		 */
+		$response = rest_ensure_response( $data );
 		$response->add_links( $this->prepare_links( $taxonomy ) );
 
 		/** This filter is documented in wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php */

--- a/includes/REST_API/Stories_Taxonomies_Controller.php
+++ b/includes/REST_API/Stories_Taxonomies_Controller.php
@@ -64,12 +64,6 @@ class Stories_Taxonomies_Controller extends WP_REST_Taxonomies_Controller implem
 	 */
 	public function prepare_item_for_response( $taxonomy, $request ): WP_REST_Response {
 		$response   = parent::prepare_item_for_response( $taxonomy, $request );
-		$controller = $taxonomy->get_rest_controller();
-
-		if ( ! $controller ) {
-			return $response;
-		}
-
 		$response->add_links( $this->prepare_links( $taxonomy ) );
 
 		/** This filter is documented in wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php */
@@ -86,7 +80,7 @@ class Stories_Taxonomies_Controller extends WP_REST_Taxonomies_Controller implem
 	 *
 	 * @phpstan-return Links
 	 */
-	protected function prepare_links( WP_Taxonomy $taxonomy ): array {
+	protected function prepare_links( $taxonomy ): array {
 		$controller = $taxonomy->get_rest_controller();
 		// TODO: Remove get_namespace when WP 5.9, min requirements.
 		$namespace = $controller && method_exists( $controller, 'get_namespace' ) ? $controller->get_namespace() : 'wp/v2';


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Added in https://github.com/WordPress/wordpress-develop/commit/eaad35de6b4b12bf3c8581df5fc1aa9aba501531, the taxonomy endpoint now has it's own prepare links method. Bring our endpoint inline with core. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
