### PR TITLE
Correctly use registered option defaults

### DIFF
--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -398,12 +398,24 @@ class Settings implements Service, Registerable, PluginUninstallAware {
 	 * @return string|array<int|string,mixed>|bool Setting value.
 	 */
 	public function get_setting( string $key, $default = false ) {
+		// Distinguish between `false` as a default, and not passing one, just like WordPress.
+		$passed_default = \func_num_args() > 1;
+
+		if ( $passed_default ) {
+			/**
+			 * Setting value.
+			 *
+			 * @var string|array<int|string,mixed>|bool
+			 */
+			return get_option( $key, $default );
+		}
+
 		/**
 		 * Setting value.
 		 *
 		 * @var string|array<int|string,mixed>|bool
 		 */
-		return get_option( $key, $default );
+		return get_option( $key );
 	}
 
 	/**

--- a/tests/phpunit/integration/tests/Admin/Editor.php
+++ b/tests/phpunit/integration/tests/Admin/Editor.php
@@ -247,6 +247,17 @@ class Editor extends DependencyInjectedTestCase {
 	}
 
 	/**
+	 * @link https://github.com/GoogleForCreators/web-stories-wp/issues/12601
+	 *
+	 * @covers ::get_editor_settings
+	 */
+	public function test_get_editor_settings_uses_correct_default_value(): void {
+		$results = $this->instance->get_editor_settings();
+
+		$this->assertTrue( $results['globalAutoAdvance'] );
+	}
+
+	/**
 	 * @covers ::setup_lock
 	 */
 	public function test_setup_lock_admin(): void {

--- a/tests/phpunit/integration/tests/Settings.php
+++ b/tests/phpunit/integration/tests/Settings.php
@@ -95,4 +95,27 @@ class Settings extends DependencyInjectedTestCase {
 		$this->assertTrue( get_option( $this->instance::SETTING_NAME_AUTO_ADVANCE ) );
 		$this->assertSame( 7, get_option( $this->instance::SETTING_NAME_DEFAULT_PAGE_DURATION ) );
 	}
+
+	/**
+	 * @covers ::get_setting
+	 */
+	public function test_get_setting_uses_saved_option(): void {
+		add_option( $this->instance::SETTING_NAME_AUTO_ADVANCE, false );
+		$this->assertFalse( $this->instance->get_setting( $this->instance::SETTING_NAME_AUTO_ADVANCE, true ) );
+	}
+
+	/**
+	 * @covers ::get_setting
+	 */
+	public function test_get_setting_uses_registered_default(): void {
+		$this->assertTrue( $this->instance->get_setting( $this->instance::SETTING_NAME_AUTO_ADVANCE ) );
+	}
+
+	/**
+	 * @covers ::get_setting
+	 */
+	public function test_get_setting_uses_explicit_default(): void {
+		$this->assertFalse( $this->instance->get_setting( $this->instance::SETTING_NAME_AUTO_ADVANCE, false ) );
+		$this->assertSame( 'foo', $this->instance->get_setting( $this->instance::SETTING_NAME_AUTO_ADVANCE, 'foo' ) );
+	}
 }


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

I noticed this in #12601 when testing the new page advancement setting on the settings page.

## Summary

<!-- A brief description of what this PR does. -->

Fixes an issue where the registered option default values were never used because we always explicitly passed `false` as a second parameter to `get_option()`.

So even if the default value was something else, when the option didn't exist yet, `get_setting()` returned `false`.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Delete the `web_stories_auto_advance` option from the database or set up a new test environment where this option does not exist yet
2. Create a new story
3. Verify that the "Document" tab shows the same page advancement settings as on the Settings page


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12601
