### PR TITLE
Slug: allow unicode characters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47682,6 +47682,7 @@
         "react-photo-album": "^1.15.0",
         "react-transition-group": "^4.4.5",
         "react-virtual": "^2.10.4",
+        "remove-accents": "^0.4.3",
         "sat": "^0.9.0",
         "styled-components": "^5.3.6",
         "stylis-plugin-rtl": "^1.0.0",
@@ -47744,6 +47745,11 @@
         "blurhash": "^2.0.3",
         "react": ">=15"
       }
+    },
+    "packages/story-editor/node_modules/remove-accents": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.3.tgz",
+      "integrity": "sha512-bwzzFccF6RgWWt+KrcEpCDMw9uCwz5GCdyo+r4p2hu6PhqtlEMOXEO0uPAw6XmVYAnODxHaqLanhUY1lqmsNFw=="
     },
     "packages/story-editor/node_modules/uuid": {
       "version": "9.0.0",
@@ -50260,6 +50266,7 @@
         "react-photo-album": "^1.15.0",
         "react-transition-group": "^4.4.5",
         "react-virtual": "^2.10.4",
+        "remove-accents": "^0.4.3",
         "sat": "^0.9.0",
         "styled-components": "^5.3.6",
         "stylis-plugin-rtl": "^1.0.0",
@@ -50292,6 +50299,11 @@
           "resolved": "https://registry.npmjs.org/react-blurhash/-/react-blurhash-0.2.0.tgz",
           "integrity": "sha512-MfhPLfFTNCX3MCJ8nM5t+T5qAixBUv8QHVcHORs5iVaqdpg+IW/e4lpOphc0bm6AvKz//4MuHESIeKKoxi3wnA==",
           "requires": {}
+        },
+        "remove-accents": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.3.tgz",
+          "integrity": "sha512-bwzzFccF6RgWWt+KrcEpCDMw9uCwz5GCdyo+r4p2hu6PhqtlEMOXEO0uPAw6XmVYAnODxHaqLanhUY1lqmsNFw=="
         },
         "uuid": {
           "version": "9.0.0",

--- a/packages/story-editor/package.json
+++ b/packages/story-editor/package.json
@@ -84,6 +84,7 @@
     "react-photo-album": "^1.15.0",
     "react-transition-group": "^4.4.5",
     "react-virtual": "^2.10.4",
+    "remove-accents": "^0.4.3",
     "sat": "^0.9.0",
     "styled-components": "^5.3.6",
     "stylis-plugin-rtl": "^1.0.0",

--- a/packages/story-editor/src/components/panels/document/slug/slug.js
+++ b/packages/story-editor/src/components/panels/document/slug/slug.js
@@ -22,6 +22,7 @@ import { useCallback, useEffect, useState } from '@googleforcreators/react';
 import styled from 'styled-components';
 import { __ } from '@googleforcreators/i18n';
 import { Input, Link, THEME_CONSTANTS } from '@googleforcreators/design-system';
+import { safeDecodeURIComponent } from '@googleforcreators/url';
 
 /**
  * Internal dependencies
@@ -70,7 +71,12 @@ function SlugPanel({ nameOverride }) {
         story: { slug = '', link, permalinkConfig },
       },
       actions: { updateStory },
-    }) => ({ slug, link, permalinkConfig, updateStory })
+    }) => ({
+      slug: safeDecodeURIComponent(slug),
+      link,
+      permalinkConfig,
+      updateStory,
+    })
   );
   const [slug, setSlug] = useState(savedSlug);
 

--- a/packages/story-editor/src/utils/cleanForSlug.js
+++ b/packages/story-editor/src/utils/cleanForSlug.js
@@ -48,10 +48,10 @@ export default function cleanForSlug(string, isEditing = false) {
       .map((s) => s.replace(/[\s./_]/g, '-'))
       // If not editing, remove hyphens from the beginning and ending.
       .map((s) => (isEditing ? s : s.replace(/^-+|-+$/g, '')))
-      .map((s) => (isEditing ? s : s.replace(/--+/g, '-')))
       .map((s) => s.normalize('NFC'))
       // Remove anything that's not a letter, number, underscore or hyphen.
       .map((s) => (isEditing ? s : s.replace(/[^\p{L}\p{N}_-]+/gu, '')))
+      .map((s) => (isEditing ? s : s.replace(/--+/g, '-')))
       .map((s) => s.toLowerCase())
       .pop()
   );

--- a/packages/story-editor/src/utils/test/cleanForSlug.js
+++ b/packages/story-editor/src/utils/test/cleanForSlug.js
@@ -62,23 +62,17 @@ describe('cleanForSlug', () => {
     expect(result).toBe('hello-world');
   });
 
-  it('should allow using unicode characters', () => {
-    // Telugu
-    const result = cleanForSlug('హల-వరలడ');
-    expect(result).toBe('హల-వరలడ');
-
-    // Chinese (traditional)
-    const result2 = cleanForSlug('你好世界');
-    expect(result2).toBe('你好世界');
-
-    // Greek
-    const result3 = cleanForSlug('Γειά σου Κόσμε');
-    expect(result3).toBe('γειά-σου-κόσμε');
-
-    // Farsi
-    const result4 = cleanForSlug('سلام دنیا');
-    expect(result4).toBe('سلام-دنیا');
-  });
+  it.each([
+    ['హల-వరలడ', 'హల-వరలడ'],
+    ['你好世界', '你好世界'],
+    ['Γειά σου Κόσμε', 'γειά-σου-κόσμε'],
+    ['سلام دنیا', 'سلام-دنیا'],
+  ])(
+    'should properly generate slug from %s and return %s',
+    (original, expected) => {
+      expect(cleanForSlug(original)).toBe(expected);
+    }
+  );
 
   // eslint-disable-next-line jest/no-disabled-tests -- not implemented yet.
   it.skip('should replace umlauts if locale is de-*', () => {

--- a/packages/story-editor/src/utils/test/cleanForSlug.js
+++ b/packages/story-editor/src/utils/test/cleanForSlug.js
@@ -43,7 +43,7 @@ describe('cleanForSlug', () => {
   });
 
   it('should collapse multiple whitespace and dashes', () => {
-    const result = cleanForSlug('Hello   cruel-- world');
+    const result = cleanForSlug('Hello   cruel- world');
     expect(result).toBe('hello-cruel-world');
   });
 

--- a/packages/story-editor/src/utils/test/cleanForSlug.js
+++ b/packages/story-editor/src/utils/test/cleanForSlug.js
@@ -62,6 +62,11 @@ describe('cleanForSlug', () => {
     expect(result).toBe('hello-world');
   });
 
+  it('should allow using unicode characters', () => {
+    const result = cleanForSlug('హల-వరలడ');
+    expect(result).toBe('హల-వరలడ');
+  });
+
   // eslint-disable-next-line jest/no-disabled-tests -- not implemented yet.
   it.skip('should replace umlauts if locale is de-*', () => {
     expect(cleanForSlug('Übergrössengeschäft')).toBe('uebergroessengeschaeft');

--- a/packages/story-editor/src/utils/test/cleanForSlug.js
+++ b/packages/story-editor/src/utils/test/cleanForSlug.js
@@ -43,7 +43,7 @@ describe('cleanForSlug', () => {
   });
 
   it('should collapse multiple whitespace and dashes', () => {
-    const result = cleanForSlug('Hello   cruel- world');
+    const result = cleanForSlug('Hello   cruel-- world');
     expect(result).toBe('hello-cruel-world');
   });
 
@@ -58,7 +58,7 @@ describe('cleanForSlug', () => {
   });
 
   it('should remove all illegal characters', () => {
-    const result = cleanForSlug('Hello-?,:;!"World');
+    const result = cleanForSlug('Hello-?-,:;!"World');
     expect(result).toBe('hello-world');
   });
 

--- a/packages/story-editor/src/utils/test/cleanForSlug.js
+++ b/packages/story-editor/src/utils/test/cleanForSlug.js
@@ -63,8 +63,21 @@ describe('cleanForSlug', () => {
   });
 
   it('should allow using unicode characters', () => {
+    // Telugu
     const result = cleanForSlug('హల-వరలడ');
     expect(result).toBe('హల-వరలడ');
+
+    // Chinese (traditional)
+    const result2 = cleanForSlug('你好世界');
+    expect(result2).toBe('你好世界');
+
+    // Greek
+    const result3 = cleanForSlug('Γειά σου Κόσμε');
+    expect(result3).toBe('γειά-σου-κόσμε');
+
+    // Farsi
+    const result4 = cleanForSlug('سلام دنیا');
+    expect(result4).toBe('سلام-دنیا');
   });
 
   // eslint-disable-next-line jest/no-disabled-tests -- not implemented yet.

--- a/packages/url/src/safeDecodeUriComponent.ts
+++ b/packages/url/src/safeDecodeUriComponent.ts
@@ -14,6 +14,17 @@
  * limitations under the License.
  */
 
-export * from './url';
-export { default as addQueryArgs } from './addQueryArgs';
-export { default as safeDecodeURIComponent } from './safeDecodeUriComponent';
+/**
+ * Safely decodes a URI component with `decodeURIComponent`. Returns the URI component unmodified if
+ * `decodeURIComponent` throws an error.
+ *
+ * @param uriComponent URI component to decode.
+ * @return Decoded URI component if possible.
+ */
+export default function safeDecodeURIComponent(uriComponent: string) {
+  try {
+    return decodeURIComponent(uriComponent);
+  } catch (uriComponentError) {
+    return uriComponent;
+  }
+}

--- a/packages/url/src/test/safeDecodeUriComponent.js
+++ b/packages/url/src/test/safeDecodeUriComponent.js
@@ -20,18 +20,14 @@
 import safeDecodeURIComponent from '../safeDecodeUriComponent';
 
 describe('safeDecodeURIComponent', () => {
-  it('should decode the URI correctly', () => {
-    let url = 'kanji-漢字';
-    expect(safeDecodeURIComponent('kanji-%e6%bc%a2%e5%ad%97')).toBe(url);
-
-    url = 'Χαίρετε';
-    expect(
-      safeDecodeURIComponent('%CE%A7%CE%B1%CE%AF%CF%81%CE%B5%CF%84%CE%B5')
-    ).toBe(url);
-
-    url = '你好世界';
-    expect(safeDecodeURIComponent('%E4%BD%A0%E5%A5%BD%E4%B8%96%E7%95%8C')).toBe(
-      url
-    );
-  });
+  it.each([
+    ['kanji-%e6%bc%a2%e5%ad%97', 'kanji-漢字'],
+    ['%CE%A7%CE%B1%CE%AF%CF%81%CE%B5%CF%84%CE%B5', 'Χαίρετε'],
+    ['%E4%BD%A0%E5%A5%BD%E4%B8%96%E7%95%8C', '你好世界'],
+  ])(
+    'should decode the URI %s correctly and return %s',
+    (original, expected) => {
+      expect(safeDecodeURIComponent(original)).toBe(expected);
+    }
+  );
 });

--- a/packages/url/src/test/safeDecodeUriComponent.js
+++ b/packages/url/src/test/safeDecodeUriComponent.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import safeDecodeURIComponent from '../safeDecodeUriComponent';
+
+describe('safeDecodeURIComponent', () => {
+  it('should decode the URI correctly', () => {
+    let url = 'kanji-漢字';
+    expect(safeDecodeURIComponent('kanji-%e6%bc%a2%e5%ad%97')).toBe(url);
+
+    url = 'Χαίρετε';
+    expect(
+      safeDecodeURIComponent('%CE%A7%CE%B1%CE%AF%CF%81%CE%B5%CF%84%CE%B5')
+    ).toBe(url);
+
+    url = '你好世界';
+    expect(safeDecodeURIComponent('%E4%BD%A0%E5%A5%BD%E4%B8%96%E7%95%8C')).toBe(
+      url
+    );
+  });
+});


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Allows unicode characters in the slug. Also, adds using `remove-accents` package.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Open the editor Document panel and go to the Permalink section
2. Paste in a unicode slug, for example హల-వరలడ or Γειά σου Κόσμε
3. Verify a slug is created and characters not removed.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12546
