### PR TITLE
Remove scaling properties from non-media elements

### DIFF
--- a/packages/migration/src/migrate.ts
+++ b/packages/migration/src/migrate.ts
@@ -68,6 +68,7 @@ import removeTrackName from './migrations/v0042_removeTrackName';
 import removeTagNames from './migrations/v0043_removeTagNames';
 import unusedProperties from './migrations/v0044_unusedProperties';
 import globalPageAdvancement from './migrations/v0045_globalPageAdvancement';
+import removeRedundantScalingProperties from './migrations/v0046_removeRedundantScalingProperties';
 
 type MigrationFn<T, S> = (storyData: T) => S;
 
@@ -119,6 +120,7 @@ const MIGRATIONS: Record<number, MigrationFn<any, any>[]> = { // eslint-disable-
   43: [removeTagNames],
   44: [unusedProperties],
   45: [globalPageAdvancement],
+  46: [removeRedundantScalingProperties],
 };
 
 export const DATA_VERSION = Math.max.apply(

--- a/packages/migration/src/migrations/test/v0046_removeRedundantScalingProperties.js
+++ b/packages/migration/src/migrations/test/v0046_removeRedundantScalingProperties.js
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import removeRedundantScalingProperties from '../v0046_removeRedundantScalingProperties';
+
+describe('unusedProperties', () => {
+  it('should remove scaling properties from non-media elements', () => {
+    expect(
+      removeRedundantScalingProperties({
+        pages: [
+          {
+            elements: [
+              {
+                id: '1',
+                type: 'text',
+                scale: 400,
+                focalX: 10,
+                focalY: 30,
+              },
+              {
+                id: '2',
+                type: 'image',
+                resource: {},
+                scale: 100,
+                focalX: 0,
+                focalY: 0,
+              },
+              {
+                id: '3',
+                type: 'shape',
+                scale: 10,
+                focalX: 10,
+                focalY: 10,
+              },
+            ],
+          },
+          {
+            elements: [
+              {
+                id: '4',
+                type: 'text',
+              },
+            ],
+          },
+        ],
+      })
+    ).toStrictEqual({
+      pages: [
+        {
+          elements: [
+            {
+              id: '1',
+              type: 'text',
+            },
+            {
+              id: '2',
+              type: 'image',
+              resource: {},
+              scale: 100,
+              focalX: 0,
+              focalY: 0,
+            },
+            {
+              id: '3',
+              type: 'shape',
+            },
+          ],
+        },
+        {
+          elements: [
+            {
+              id: '4',
+              type: 'text',
+            },
+          ],
+        },
+      ],
+    });
+  });
+});

--- a/packages/migration/src/migrations/v0045_globalPageAdvancement.ts
+++ b/packages/migration/src/migrations/v0045_globalPageAdvancement.ts
@@ -26,6 +26,9 @@ import type {
   StoryV44,
   TextElementV44,
   VideoElementV44,
+  GifResourceV44,
+  ImageResourceV44,
+  VideoResourceV44,
 } from './v0044_unusedProperties';
 
 export type TextElementV45 = TextElementV44;
@@ -34,6 +37,10 @@ export type ShapeElementV45 = ShapeElementV44;
 export type ImageElementV45 = ImageElementV44;
 export type VideoElementV45 = VideoElementV44;
 export type GifElementV45 = GifElementV44;
+
+export type ImageResourceV45 = ImageResourceV44;
+export type VideoResourceV45 = VideoResourceV44;
+export type GifResourceV45 = GifResourceV44;
 
 export type UnionElementV45 =
   | ShapeElementV45

--- a/packages/migration/src/migrations/v0046_removeRedundantScalingProperties.ts
+++ b/packages/migration/src/migrations/v0046_removeRedundantScalingProperties.ts
@@ -68,7 +68,7 @@ export interface PageV46 extends Omit<PageV45, 'elements'> {
   elements: UnionElementV46[];
 }
 
-function unusedProperties({ pages, ...rest }: StoryV45): StoryV46 {
+function removeRedundantScalingProperties({ pages, ...rest }: StoryV45): StoryV46 {
   return {
     pages: pages.map(reducePage),
     ...rest,
@@ -91,4 +91,4 @@ function updateElement(element: UnionElementV45): UnionElementV46 {
   return element;
 }
 
-export default unusedProperties;
+export default removeRedundantScalingProperties;

--- a/packages/migration/src/migrations/v0046_removeRedundantScalingProperties.ts
+++ b/packages/migration/src/migrations/v0046_removeRedundantScalingProperties.ts
@@ -68,7 +68,10 @@ export interface PageV46 extends Omit<PageV45, 'elements'> {
   elements: UnionElementV46[];
 }
 
-function removeRedundantScalingProperties({ pages, ...rest }: StoryV45): StoryV46 {
+function removeRedundantScalingProperties({
+  pages,
+  ...rest
+}: StoryV45): StoryV46 {
   return {
     pages: pages.map(reducePage),
     ...rest,

--- a/packages/migration/src/migrations/v0046_removeRedundantScalingProperties.ts
+++ b/packages/migration/src/migrations/v0046_removeRedundantScalingProperties.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import type {
+  GifResourceV45,
+  ImageResourceV45,
+  VideoResourceV45,
+  GifElementV45,
+  ImageElementV45,
+  PageV45,
+  ProductElementV45,
+  ShapeElementV45,
+  StoryV45,
+  TextElementV45,
+  VideoElementV45,
+  UnionElementV45,
+} from './v0045_globalPageAdvancement';
+
+export type TextElementV46 = Omit<
+  TextElementV45,
+  'focalX' | 'focalY' | 'scale'
+>;
+export type ProductElementV46 = Omit<
+  ProductElementV45,
+  'focalX' | 'focalY' | 'scale'
+>;
+export type ShapeElementV46 = Omit<
+  ShapeElementV45,
+  'focalX' | 'focalY' | 'scale'
+>;
+export type ImageElementV46 = ImageElementV45;
+export type VideoElementV46 = VideoElementV45;
+export type GifElementV46 = GifElementV45;
+
+export type ImageResourceV46 = ImageResourceV45;
+export type VideoResourceV46 = VideoResourceV45;
+export type GifResourceV46 = GifResourceV45;
+
+export type UnionElementV46 =
+  | ShapeElementV46
+  | ImageElementV46
+  | VideoElementV46
+  | GifElementV46
+  | TextElementV46
+  | ProductElementV46;
+
+export interface StoryV46 extends Omit<StoryV45, 'pages'> {
+  pages: PageV46[];
+}
+
+export interface PageV46 extends Omit<PageV45, 'elements'> {
+  elements: UnionElementV46[];
+}
+
+function unusedProperties({ pages, ...rest }: StoryV45): StoryV46 {
+  return {
+    pages: pages.map(reducePage),
+    ...rest,
+  };
+}
+
+function reducePage({ elements, ...rest }: PageV45): PageV46 {
+  return {
+    elements: elements.map(updateElement),
+    ...rest,
+  };
+}
+
+function updateElement(element: UnionElementV45): UnionElementV46 {
+  if (!('resource' in element)) {
+    delete element.focalX;
+    delete element.focalY;
+    delete element.scale;
+  }
+  return element;
+}
+
+export default unusedProperties;

--- a/packages/migration/src/types/element.ts
+++ b/packages/migration/src/types/element.ts
@@ -86,6 +86,10 @@ export interface ElementV0 extends ElementBoxV0 {
   groupId?: string;
   border?: BorderV0;
   borderRadius?: BorderRadiusV0;
+
+  scale?: number;
+  focalX?: number;
+  focalY?: number;
 }
 
 export interface MediaElementV0 extends ElementV0 {

--- a/packages/story-editor/src/components/canvas/utils/getElementProperties.js
+++ b/packages/story-editor/src/components/canvas/utils/getElementProperties.js
@@ -60,7 +60,7 @@ function getElementProperties(
     ...rest
   }
 ) {
-  const { isMaskable } = getDefinitionForType(type);
+  const { isMaskable, isMedia } = getDefinitionForType(type);
 
   const attrs = { type, ...rest };
 
@@ -93,6 +93,12 @@ function getElementProperties(
   x = dataPixels(x);
   y = dataPixels(y);
 
+  const mediaProps = {
+    focalX,
+    focalY,
+    scale,
+  };
+
   return {
     ...attrs,
     resource,
@@ -101,9 +107,7 @@ function getElementProperties(
     width,
     height,
     rotationAngle,
-    scale,
-    focalX,
-    focalY,
+    ...(isMedia ? { ...mediaProps } : {}),
     ...(isMaskable
       ? {
           mask: mask || DEFAULT_MASK,

--- a/packages/types/src/element/shapeElement.ts
+++ b/packages/types/src/element/shapeElement.ts
@@ -25,8 +25,4 @@ export interface ShapeElement extends Element {
   isBackground?: boolean;
   isDefaultBackground?: boolean;
   type: ElementType.Shape;
-  // TODO(#12437): Figure out why shape elements end up having these properties & fix it.
-  scale?: number;
-  focalX?: number;
-  focalY?: number;
 }

--- a/packages/types/src/element/stickerElement.ts
+++ b/packages/types/src/element/stickerElement.ts
@@ -26,8 +26,4 @@ export interface Sticker {
 export interface StickerElement extends Element {
   type: ElementType.Sticker;
   sticker: Sticker;
-  // TODO(#12437): Figure out why sticker elements end up having these properties & fix it.
-  scale?: number;
-  focalX?: number;
-  focalY?: number;
 }

--- a/packages/types/src/element/textElement.ts
+++ b/packages/types/src/element/textElement.ts
@@ -83,9 +83,4 @@ export interface TextElement extends Element {
   marginOffset?: number;
   // TODO(#12258): Remove this.
   fontWeight?: number;
-
-  // TODO(#12437): Figure out why text elements end up having these properties & fix it.
-  scale?: number;
-  focalX?: number;
-  focalY?: number;
 }

--- a/packages/types/src/element/textElement.ts
+++ b/packages/types/src/element/textElement.ts
@@ -81,6 +81,4 @@ export interface TextElement extends Element {
   tagName?: 'h1' | 'h2' | 'h3' | 'p';
   padding?: Padding;
   marginOffset?: number;
-  // TODO(#12258): Remove this.
-  fontWeight?: number;
 }


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Remove `scale`, `focalX`, `focalY` from elements that are not media. Apparently all the elements were added those properties.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

- [x] Check about `backgroundColor` ending up in media properties (haven't been able to repro yet)

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
N/A
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add non-media elements.
2. Open our development tools (`shift + option + cmd + J`)
3. Verify that the added elements don't include any of the removed properties


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12437 
