### PR TITLE
Saved Templates: fix buttons being hidden under elements

### DIFF
--- a/packages/story-editor/src/components/library/panes/pageTemplates/savedPageTemplate.js
+++ b/packages/story-editor/src/components/library/panes/pageTemplates/savedPageTemplate.js
@@ -84,6 +84,14 @@ PreviewPageWrapper.propTypes = {
   pageSize: PageSizePropType.isRequired,
 };
 
+const ElementsWrapper = styled.div`
+  z-index: 10;
+`;
+
+const TemplateInsertionOverlay = styled(InsertionOverlay)`
+  z-index: 11;
+`;
+
 const DeleteButton = styled(ActionButton)`
   top: 4px;
   right: 4px;
@@ -218,18 +226,24 @@ function SavedPageTemplate(
             draggable={false}
           />
         ) : (
-          <UnitsProvider
-            pageSize={{
-              height: pageSize.height,
-              width: pageSize.width,
-            }}
-          >
-            {page.elements.map((element) => (
-              <DisplayElement key={element.id} previewMode element={element} />
-            ))}
-          </UnitsProvider>
+          <ElementsWrapper>
+            <UnitsProvider
+              pageSize={{
+                height: pageSize.height,
+                width: pageSize.width,
+              }}
+            >
+              {page.elements.map((element) => (
+                <DisplayElement
+                  key={element.id}
+                  previewMode
+                  element={element}
+                />
+              ))}
+            </UnitsProvider>
+          </ElementsWrapper>
         )}
-        {isActive && <InsertionOverlay showIcon={false} />}
+        {isActive && <TemplateInsertionOverlay showIcon={false} />}
         <ActionButton
           ref={insertButtonRef}
           onClick={(e) => {

--- a/packages/story-editor/src/components/library/panes/shared/index.js
+++ b/packages/story-editor/src/components/library/panes/shared/index.js
@@ -62,6 +62,7 @@ const ActionButton = styled(Button).attrs({ variant: BUTTON_VARIANTS.ICON })`
   width: ${ACTION_BUTTON_SIZE}px;
   height: ${ACTION_BUTTON_SIZE}px;
   opacity: ${({ $display }) => ($display ? '1' : '0')};
+  z-index: 99;
 `;
 
 const PageTemplateTitleContainer = styled.div`

--- a/packages/story-editor/src/components/library/panes/shared/index.js
+++ b/packages/story-editor/src/components/library/panes/shared/index.js
@@ -20,6 +20,11 @@
 import styled, { css } from 'styled-components';
 import { Button, BUTTON_VARIANTS } from '@googleforcreators/design-system';
 
+/**
+ * Internal dependencies
+ */
+import { Z_INDEX_LIBRARY_ACTION_BUTTON } from '../../../../constants/zIndex';
+
 export const PANE_PADDING = '1em';
 
 const Pane = styled.section.attrs(({ isActive }) => ({
@@ -62,7 +67,7 @@ const ActionButton = styled(Button).attrs({ variant: BUTTON_VARIANTS.ICON })`
   width: ${ACTION_BUTTON_SIZE}px;
   height: ${ACTION_BUTTON_SIZE}px;
   opacity: ${({ $display }) => ($display ? '1' : '0')};
-  z-index: 99;
+  z-index: ${Z_INDEX_LIBRARY_ACTION_BUTTON};
 `;
 
 const PageTemplateTitleContainer = styled.div`

--- a/packages/story-editor/src/components/library/panes/shared/insertionOverlay.js
+++ b/packages/story-editor/src/components/library/panes/shared/insertionOverlay.js
@@ -49,12 +49,12 @@ const Scrim = styled.div`
   pointer-events: none;
 `;
 
-function InsertionOverlay({ showIcon = true }) {
+function InsertionOverlay({ showIcon = true, className = '' }) {
   // The icon looks like a button but is just representational.
   // The real interactive element is the containing element.
   // If the showIcon is `false`, we still display the scrim for shade.
   return (
-    <Scrim>
+    <Scrim className={className}>
       {showIcon && (
         <IconContainer role="presentation">
           <Icons.PlusFilledSmall />
@@ -66,6 +66,7 @@ function InsertionOverlay({ showIcon = true }) {
 
 InsertionOverlay.propTypes = {
   showIcon: PropTypes.bool,
+  className: PropTypes.string,
 };
 
 export default InsertionOverlay;

--- a/packages/story-editor/src/constants/zIndex.js
+++ b/packages/story-editor/src/constants/zIndex.js
@@ -49,3 +49,6 @@ export const Z_INDEX_GRID_VIEW_SLIDER = 11;
 // In PublishTime, the time picker's tooltip's z-index needs to be higher than
 // the z-index of the date picker popup itself.
 export const Z_INDEX_TIME_PICKER_TOOLTIP = 11;
+
+// In the library, the action button has to be on top of the other layers.
+export const Z_INDEX_LIBRARY_ACTION_BUTTON = 20;


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Adds z-indexes to different layers to make sure the action buttons are visible in the Saved Templates
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add different elements to the page so that the page would be covered in the middle and in the upper right corner (where the buttons appear)
2. Go to the templates tab and click "Save current page as template"
3. Now hover over the newly saved template.
4. Verify the buttons for removing and inserting the template are visible.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12584 
