### PR TITLE
Correctly filter revision fields for story revisions

### DIFF
--- a/includes/Story_Revisions.php
+++ b/includes/Story_Revisions.php
@@ -38,6 +38,12 @@ use WP_Post;
  *   name: string,
  *   diff: string
  * }
+ * @phpstan-type PostData array{
+ *   post_parent: int,
+ *   post_type: string,
+ *   post_content?: string,
+ *   post_content_filtered?: string
+ * }
  */
 class Story_Revisions extends Service_Base {
 
@@ -101,13 +107,22 @@ class Story_Revisions extends Service_Base {
 	 * @param array|mixed         $fields Array of allowed revision fields.
 	 * @param array<string,mixed> $story  Story post array.
 	 * @return array|mixed Array of allowed fields.
+	 *
+	 * @phpstan-param PostData $story
 	 */
 	public function filter_revision_fields( $fields, array $story ) {
 		if ( ! \is_array( $fields ) ) {
 			return $fields;
 		}
 
-		if ( $this->story_post_type->get_slug() === $story['post_type'] ) {
+		if (
+			$this->story_post_type->get_slug() === $story['post_type'] ||
+			(
+				'revision' === $story['post_type'] &&
+				! empty( $story['post_parent'] ) &&
+				get_post_type( $story['post_parent'] ) === $this->story_post_type->get_slug()
+			)
+		) {
 			$fields['post_content_filtered'] = __( 'Story data', 'web-stories' );
 		}
 

--- a/tests/phpunit/integration/tests/Story_Revisions.php
+++ b/tests/phpunit/integration/tests/Story_Revisions.php
@@ -20,7 +20,7 @@ namespace Google\Web_Stories\Tests\Integration;
 use Google\Web_Stories\Story_Post_Type;
 
 /**
- * @coversDefaultClass \Google\Web_Stories\Admin\Admin
+ * @coversDefaultClass \Google\Web_Stories\Story_Revisions
  */
 class Story_Revisions extends DependencyInjectedTestCase {
 
@@ -105,10 +105,16 @@ class Story_Revisions extends DependencyInjectedTestCase {
 		];
 	}
 
+	/**
+	 * @covers ::filter_revision_fields
+	 */
 	public function test_filter_revision_fields_not_an_array(): void {
 		$this->assertSame( 'foo', $this->instance->filter_revision_fields( 'foo', [] ) );
 	}
 
+	/**
+	 * @covers ::filter_revision_fields
+	 */
 	public function test_filter_revision_fields_wrong_post_type(): void {
 		$fields = [
 			'post_title' => 'Post title',
@@ -126,6 +132,9 @@ class Story_Revisions extends DependencyInjectedTestCase {
 		);
 	}
 
+	/**
+	 * @covers ::filter_revision_fields
+	 */
 	public function test_filter_revision_fields_story_post_type(): void {
 		$fields = [
 			'post_title' => 'Post title',
@@ -142,6 +151,9 @@ class Story_Revisions extends DependencyInjectedTestCase {
 		$this->assertArrayHasKey( 'post_content_filtered', $actual );
 	}
 
+	/**
+	 * @covers ::filter_revision_fields
+	 */
 	public function test_filter_revision_fields_story_post_type_revision(): void {
 		$fields = [
 			'post_title' => 'Post title',

--- a/tests/phpunit/integration/tests/Story_Revisions.php
+++ b/tests/phpunit/integration/tests/Story_Revisions.php
@@ -17,6 +17,8 @@
 
 namespace Google\Web_Stories\Tests\Integration;
 
+use Google\Web_Stories\Story_Post_Type;
+
 /**
  * @coversDefaultClass \Google\Web_Stories\Admin\Admin
  */
@@ -101,5 +103,64 @@ class Story_Revisions extends DependencyInjectedTestCase {
 				'expected' => 0,
 			],
 		];
+	}
+
+	public function test_filter_revision_fields_not_an_array(): void {
+		$this->assertSame( 'foo', $this->instance->filter_revision_fields( 'foo', [] ) );
+	}
+
+	public function test_filter_revision_fields_wrong_post_type(): void {
+		$fields = [
+			'post_title' => 'Post title',
+		];
+
+		$this->assertSame(
+			$fields,
+			$this->instance->filter_revision_fields(
+				$fields,
+				[
+					'post_type'   => 'post',
+					'post_parent' => 0,
+				]
+			)
+		);
+	}
+
+	public function test_filter_revision_fields_story_post_type(): void {
+		$fields = [
+			'post_title' => 'Post title',
+		];
+
+		$actual = $this->instance->filter_revision_fields(
+			$fields,
+			[
+				'post_type'   => Story_Post_Type::POST_TYPE_SLUG,
+				'post_parent' => 0,
+			]
+		);
+
+		$this->assertArrayHasKey( 'post_content_filtered', $actual );
+	}
+
+	public function test_filter_revision_fields_story_post_type_revision(): void {
+		$fields = [
+			'post_title' => 'Post title',
+		];
+
+		$story = self::factory()->post->create(
+			[
+				'post_type' => Story_Post_Type::POST_TYPE_SLUG,
+			]
+		);
+
+		$actual = $this->instance->filter_revision_fields(
+			$fields,
+			[
+				'post_type'   => 'revision',
+				'post_parent' => $story,
+			]
+		);
+
+		$this->assertArrayHasKey( 'post_content_filtered', $actual );
 	}
 }


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

When restoring a story from an autosave, the story content was not correctly restored.

This is because when filtering `_wp_post_revision_fields`, the post type can either be `web-story` or `revision`, and we didn't check for the latter.

## Summary

<!-- A brief description of what this PR does. -->

Correctly filter revision fields for story revisions by checking the post parent.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Publish a new story.
2. Add some more content to it, then wait for to be autosaved to the database
3. Refresh the page, then click on the (second) dialog CTA to view the autosaves
4. On the revisions comparison screen, restore the latest version
5. Verify that the correct content has been restored

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12547
