### PR TITLE
Fix incorrect `<meta charset>` tags

### DIFF
--- a/includes/AMP/Output_Buffer.php
+++ b/includes/AMP/Output_Buffer.php
@@ -29,6 +29,7 @@ declare(strict_types = 1);
 namespace Google\Web_Stories\AMP;
 
 use Google\Web_Stories\Context;
+use Google\Web_Stories\Exception\SanitizationException;
 use Google\Web_Stories\Infrastructure\Conditional;
 use Google\Web_Stories\Service_Base;
 use Google\Web_Stories_Dependencies\AmpProject\Dom\Document;
@@ -221,7 +222,7 @@ class Output_Buffer extends Service_Base implements Conditional {
 		$dom = Document::fromHtml( $response );
 
 		if ( ! $dom instanceof Document ) {
-			return $this->render_error_page( \Google\Web_Stories\Exception\SanitizationException::from_document_parse_error() );
+			return $this->render_error_page( SanitizationException::from_document_parse_error() );
 		}
 
 		$this->sanitization->sanitize_document( $dom );
@@ -237,10 +238,12 @@ class Output_Buffer extends Service_Base implements Conditional {
 	 *
 	 * @param Throwable $throwable Exception or (as of PHP7) Error.
 	 * @return string Error page.
-	 *
-	 * @todo Improve error message.
 	 */
 	private function render_error_page( Throwable $throwable ): string {
-		return esc_html__( 'There was an error generating the web story, probably because of a server misconfiguration. Try contacting your hosting provider or open a new support request.', 'web-stories' );
+		return esc_html__( 'There was an error generating the web story, probably because of a server misconfiguration. Try contacting your hosting provider or open a new support request.', 'web-stories' ) .
+			"\n" .
+			"\n" .
+			// translators: 1: error message. 2: location.
+			sprintf( esc_html__( 'Error message: %1$s (%2$s)' ), $throwable->getMessage(), $throwable->getFile() . ':' . $throwable->getLine() );
 	}
 }

--- a/includes/AMP/Output_Buffer.php
+++ b/includes/AMP/Output_Buffer.php
@@ -244,6 +244,6 @@ class Output_Buffer extends Service_Base implements Conditional {
 			"\n" .
 			"\n" .
 			// translators: 1: error message. 2: location.
-			sprintf( esc_html__( 'Error message: %1$s (%2$s)' ), $throwable->getMessage(), $throwable->getFile() . ':' . $throwable->getLine() );
+			sprintf( esc_html__( 'Error message: %1$s (%2$s)', 'web-stories' ) ), $throwable->getMessage(), $throwable->getFile() . ':' . $throwable->getLine() );
 	}
 }

--- a/includes/AMP/Output_Buffer.php
+++ b/includes/AMP/Output_Buffer.php
@@ -244,6 +244,6 @@ class Output_Buffer extends Service_Base implements Conditional {
 			"\n" .
 			"\n" .
 			// translators: 1: error message. 2: location.
-			sprintf( esc_html__( 'Error message: %1$s (%2$s)', 'web-stories' ) ), $throwable->getMessage(), $throwable->getFile() . ':' . $throwable->getLine() );
+			sprintf( esc_html__( 'Error message: %1$s (%2$s)', 'web-stories' ), $throwable->getMessage(), $throwable->getFile() . ':' . $throwable->getLine() );
 	}
 }

--- a/includes/Renderer/Story/HTML.php
+++ b/includes/Renderer/Story/HTML.php
@@ -29,7 +29,6 @@ declare(strict_types = 1);
 namespace Google\Web_Stories\Renderer\Story;
 
 use Google\Web_Stories\Model\Story;
-use Google\Web_Stories_Dependencies\AmpProject\Dom\Document;
 
 /**
  * Class HTML
@@ -41,13 +40,6 @@ class HTML {
 	 * @var Story Post object.
 	 */
 	protected Story $story;
-
-	/**
-	 * Document instance.
-	 *
-	 * @var Document Document instance.
-	 */
-	protected Document $document;
 
 	/**
 	 * HTML constructor.

--- a/includes/Renderer/Story/HTML.php
+++ b/includes/Renderer/Story/HTML.php
@@ -61,6 +61,7 @@ class HTML {
 	 */
 	public function render(): string {
 		$markup = $this->story->get_markup();
+		$markup = $this->fix_incorrect_charset( $markup );
 		$markup = $this->fix_malformed_script_link_tags( $markup );
 		$markup = $this->replace_html_head( $markup );
 		$markup = wp_replace_insecure_home_url( $markup );
@@ -68,6 +69,21 @@ class HTML {
 		$markup = $this->print_social_share( $markup );
 
 		return $markup;
+	}
+
+	/**
+	 * Fix incorrect <meta charset> tags.
+	 *
+	 * React/JSX outputs the charset attribute name as "charSet",
+	 * but libdom and the AMP toolbox only recognize lowercase "charset"
+	 *
+	 * @since 1.28.0
+	 *
+	 * @param string $content Story markup.
+	 * @return string Filtered content
+	 */
+	public function fix_incorrect_charset( string $content ): string {
+		return (string) preg_replace( '/<meta charSet="utf-8"\s?\/>/i', '<meta charset="utf-8"/>', $content );
 	}
 
 	/**

--- a/tests/phpunit/integration/tests/Renderer/Story/HTML.php
+++ b/tests/phpunit/integration/tests/Renderer/Story/HTML.php
@@ -229,7 +229,7 @@ class HTML extends TestCase {
 
 		$actual = $this->call_private_method( $renderer, 'fix_incorrect_charset', [ $source ] );
 
-		$this->assertStringNotContainsString( '<meta charset="utf-8"/>', $actual );
+		$this->assertStringContainsString( '<meta charset="utf-8"/>', $actual );
 	}
 
 	/**

--- a/tests/phpunit/integration/tests/Renderer/Story/HTML.php
+++ b/tests/phpunit/integration/tests/Renderer/Story/HTML.php
@@ -219,6 +219,20 @@ class HTML extends TestCase {
 	}
 
 	/**
+	 * @covers ::fix_incorrect_charset
+	 */
+	public function test_fix_incorrect_charset(): void {
+		$source = '<html><head><meta charSet="utf-8" /></head><body><amp-story></amp-story></body></html>';
+
+		$story    = new Story();
+		$renderer = new \Google\Web_Stories\Renderer\Story\HTML( $story );
+
+		$actual = $this->call_private_method( $renderer, 'fix_incorrect_charset', [ $source ] );
+
+		$this->assertStringNotContainsString( '<meta charset="utf-8"/>', $actual );
+	}
+
+	/**
 	 * @covers ::fix_malformed_script_link_tags
 	 */
 	public function test_fix_malformed_script_link_tags(): void {


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

It was reported to us a couple of times that there are character issues on PHP 8.1.

I noticed it has to do with `DOMDocument` not recognizing `<meta charSet="utf-8"/>` (with uppercase S, as output by React) properly and thus assuming an incorrect encoding.

## Summary

<!-- A brief description of what this PR does. -->

Enforce lowercase `charset` attribute name.

This fixes the issue for me.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Use PHP 8.1
2. Create a story with content like
	```
	హలో
	â, î ñ ô ü
	español
	गईं।
	English
	தமிழ்
	```
3. Preview story
4. Characters should not be mangled


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12758
