### PR TITLE
Text Style: Remove incorrect scrollbar

### DIFF
--- a/packages/story-editor/src/components/panels/design/textStyle/stylePresets.js
+++ b/packages/story-editor/src/components/panels/design/textStyle/stylePresets.js
@@ -57,7 +57,7 @@ const PresetsHeader = styled.div`
 const StylesWrapper = styled.div``;
 
 const NoStylesWrapper = styled(DefaultNoStylesWrapper)`
-  width: calc(100% + 16px);
+  width: calc(100% + 28px);
 `;
 
 const SubHeading = styled(Text)`

--- a/packages/story-editor/src/components/panels/design/textStyle/stylePresets.js
+++ b/packages/story-editor/src/components/panels/design/textStyle/stylePresets.js
@@ -43,7 +43,7 @@ import useAddPreset from '../../../../utils/useAddPreset';
 import useSidebar from '../../../sidebar/useSidebar';
 import StyleGroup from '../../../styleManager/styleGroup';
 import StyleManager, {
-  NoStylesWrapper,
+  NoStylesWrapper as DefaultNoStylesWrapper,
   MoreButton,
 } from '../../../styleManager';
 import useApplyStyle from '../../../styleManager/useApplyStyle';
@@ -55,6 +55,10 @@ const PresetsHeader = styled.div`
 `;
 
 const StylesWrapper = styled.div``;
+
+const NoStylesWrapper = styled(DefaultNoStylesWrapper)`
+  width: calc(100% + 16px);
+`;
 
 const SubHeading = styled(Text)`
   color: ${({ theme }) => theme.colors.fg.secondary};


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
Before:
<img width="351" alt="Screenshot 2022-12-12 at 15 49 36" src="https://user-images.githubusercontent.com/3294597/207129692-79b10941-482b-4176-9b6a-8cfff8270992.png">

After:
<img width="364" alt="Screenshot 2022-12-12 at 15 51 09" src="https://user-images.githubusercontent.com/3294597/207129648-cfea4ea8-7b9f-4b4b-9825-1226a232cfaf.png">

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add a text
2. Open the Style panel
3. Go to the Saved Styles panel and remove all styles
4. Verify there's no horizontal scrollbar for "No Saved Styles" area.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #11979 
