### PR TITLE
Floating menu: fix sub-menu font size

### DIFF
--- a/packages/design-system/src/components/contextMenu/components/item.js
+++ b/packages/design-system/src/components/contextMenu/components/item.js
@@ -48,11 +48,11 @@ const StyledButton = styled(Button)`
 `;
 
 function MenuItemWithRef(
-  { label, shortcut, icon, SuffixIcon, ...buttonProps },
+  { label, shortcut, icon, SuffixIcon, className, ...buttonProps },
   ref
 ) {
   return (
-    <StyledButton ref={ref} {...buttonProps}>
+    <StyledButton className={className} ref={ref} {...buttonProps}>
       {icon}
       {label}
       {shortcut && <Shortcut>{shortcut.display}</Shortcut>}

--- a/packages/story-editor/src/components/floatingMenu/elements/settings.js
+++ b/packages/story-editor/src/components/floatingMenu/elements/settings.js
@@ -43,6 +43,13 @@ import { useCanvas } from '../../../app';
 import { states, useHighlights } from '../../../app/highlights';
 import { IconButton } from './shared';
 
+const MenuItem = styled(ContextMenuComponents.MenuItem)`
+  span {
+    font-size: 14px;
+    font-weight: 400;
+  }
+`;
+
 const StyledIconButton = styled(IconButton)`
   svg {
     width: 24px;
@@ -171,7 +178,7 @@ function Settings() {
           parentMenuRef={buttonRef}
         >
           {subMenuItems.map(({ key, ...menuItemProps }) => (
-            <ContextMenuComponents.MenuItem key={key} {...menuItemProps} />
+            <MenuItem key={key} {...menuItemProps} />
           ))}
         </ContextMenu>
       </SubMenuContainer>


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Changes the font size from 12 to 14px.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Open the Settings menu of the floating menu
2. Verify the font-size is 14px, the same as the "More" text.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12257 
