### PR TITLE
Disable feeds on custom post type archive

### DIFF
--- a/includes/Discovery.php
+++ b/includes/Discovery.php
@@ -83,7 +83,6 @@ class Discovery extends Service_Base implements HasRequirements {
 
 		add_action( 'web_stories_story_head', [ $this, 'print_feed_link' ], 4 );
 		add_action( 'wp_head', [ $this, 'print_feed_link' ], 4 );
-		add_action( 'template_redirect', [ $this, 'skip_feed_links_extra' ] );
 
 		// @todo Check if there's something to skip in the new version.
 		add_action( 'web_stories_story_head', 'rest_output_link_wp_head', 10, 0 );
@@ -477,25 +476,12 @@ class Discovery extends Service_Base implements HasRequirements {
 	}
 
 	/**
-	 * Remove the feed_links_extra action from wp_head if on post type archive.
-	 * Workaround to remove action, until 6.1 is min require and we
-	 * can use `feed_links_extra_show_post_type_archive_feed` filter.
-	 *
-	 * @since 1.29.0
-	 */
-	public function skip_feed_links_extra(): void {
-		if ( is_post_type_archive( $this->story_post_type->get_slug() ) ) {
-			remove_action( 'wp_head', 'feed_links_extra', 3 );
-		}
-	}
-
-	/**
 	 * Add RSS feed link for stories, if theme supports automatic-feed-links.
 	 *
 	 * @since 1.0.0
 	 */
 	public function print_feed_link(): void {
-		$enable_print_feed_link = current_theme_supports( 'automatic-feed-links' );
+		$enable_print_feed_link = current_theme_supports( 'automatic-feed-links' ) && ! is_post_type_archive( $this->story_post_type->get_slug() );
 
 		/**
 		 * Filters filter to enable / disable printing feed links.

--- a/tests/phpunit/integration/tests/Discovery.php
+++ b/tests/phpunit/integration/tests/Discovery.php
@@ -113,7 +113,6 @@ class Discovery extends DependencyInjectedTestCase {
 	 */
 	public function test_register(): void {
 		$this->instance->register();
-		$this->assertSame( 10, has_action( 'template_redirect', [ $this->instance, 'skip_feed_links_extra' ] ) );
 		$this->assertSame( 10, has_action( 'web_stories_story_head', [ $this->instance, 'print_document_title' ] ) );
 		$this->assertSame( 10, has_action( 'web_stories_story_head', [ $this->instance, 'print_metadata' ] ) );
 		$this->assertSame( 10, has_action( 'web_stories_story_head', [ $this->instance, 'print_schemaorg_metadata' ] ) );

--- a/tests/phpunit/integration/tests/Discovery.php
+++ b/tests/phpunit/integration/tests/Discovery.php
@@ -113,6 +113,7 @@ class Discovery extends DependencyInjectedTestCase {
 	 */
 	public function test_register(): void {
 		$this->instance->register();
+		$this->assertSame( 10, has_action( 'template_redirect', [ $this->instance, 'skip_feed_links_extra' ] ) );
 		$this->assertSame( 10, has_action( 'web_stories_story_head', [ $this->instance, 'print_document_title' ] ) );
 		$this->assertSame( 10, has_action( 'web_stories_story_head', [ $this->instance, 'print_metadata' ] ) );
 		$this->assertSame( 10, has_action( 'web_stories_story_head', [ $this->instance, 'print_schemaorg_metadata' ] ) );
@@ -211,6 +212,16 @@ class Discovery extends DependencyInjectedTestCase {
 
 		$this->assertStringContainsString( '<link rel="alternate"', $output );
 		$this->assertStringContainsString( get_bloginfo( 'name' ), $output );
+	}
+
+	/**
+	 * @covers ::print_feed_link
+	 */
+	public function test_print_feed_link_filter(): void {
+		add_filter( 'web_stories_enable_print_feed_link', '__return_false' );
+		$output = get_echo( [ $this->instance, 'print_feed_link' ] );
+		$this->assertEmpty( $output );
+		remove_filter( 'web_stories_enable_print_feed_link', '__return_false' );
 	}
 
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Remove the action `feed_links_extra` on custom post type archives for web stories. This stop a double print out of rss feed. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

#### Before
<img width="1183" alt="Screenshot 2022-12-15 at 12 02 19" src="https://user-images.githubusercontent.com/237508/207854462-0e11822c-f67e-42c9-a945-59d4199ef5c5.png">

#### After
<img width="1184" alt="Screenshot 2022-12-15 at 12 02 04" src="https://user-images.githubusercontent.com/237508/207854474-125b162c-a627-49f1-b29a-fb3120e17cba.png">


## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Go to custom post type archive, `/web-stories`. 
2. View source of page. 
3. See only one link to  `/web-stories/feed/` in the head. See screenshot for examples. 

Testing, it would be helpful to look at other url types, like single, page, category etc and check the feedback links. 

This change will NOT be affected by browser. Validate in chrome and should work everywhere. 


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12725

