### PR TITLE
Improve heading check in tag name sanitizer

### DIFF
--- a/tests/phpunit/unit/tests/AMP/Story_Sanitizer.php
+++ b/tests/phpunit/unit/tests/AMP/Story_Sanitizer.php
@@ -661,7 +661,7 @@ HTML;
 	<amp-story-page>
 		<amp-story-grid-layer>
 			<p class="text-wrapper" style="font-size:.582524em">Title 1B</p>
-			<h3 class="text-wrapper" style="font-size:.339805em">Title 3B</h3>
+			<p class="text-wrapper" style="font-size:.339805em">Title 3B</p>
 			<p class="text-wrapper" style="font-size:.436893em">Title 2B</p>
 			<p class="text-wrapper" style="font-size:.582524em">Title 1B</p>
 			<p class="text-wrapper" style="font-size:.291262em">ParagraphB</p>
@@ -690,7 +690,7 @@ HTML;
 		$this->assertStringContainsString( 'Title 1B</p>', $actual );
 		$this->assertStringContainsString( 'Title 1B</p>', $actual );
 		$this->assertStringContainsString( 'Title 2B</p>', $actual );
-		$this->assertStringContainsString( 'Title 3B</h3>', $actual );
+		$this->assertStringContainsString( 'Title 3B</p>', $actual );
 		$this->assertStringContainsString( 'ParagraphB</p>', $actual );
 	}
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

The `use_semantic_heading_tags` sanitizer turned paragraphs into headings when there were none, even though an element was explicitly marked as a heading.

## Summary

<!-- A brief description of what this PR does. -->

The sanitizer used to bail early if it could find any heading elements on an individual story page.

This check is now adapted to check for _any_ heading elements in the entire story, which is more correct.

After all, it is only really meant for older stories that haven't been updated in a while, where there are no headings being used.

There is still an edge case if a user forces *all* text elements to be paragraphs, but that's negligible.

## Relevant Technical Choices

<!-- Please describe your changes. -->

Adjusted heading tag check in the sanitizer

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Create a new story
2. Add a heading on page 1
3. Add a heading on page 2, but mark it as a paragraph
4. Preview the story
5. The first text element should be an `<h1>`, the second should just be a `<p>`


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [xI have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12850
