### PR TITLE
Fix `isBackgroundable` check

### DIFF
--- a/packages/elements/src/utils/elementIs.ts
+++ b/packages/elements/src/utils/elementIs.ts
@@ -56,7 +56,11 @@ function isBackgroundable(e: Element): e is BackgroundableElement;
 function isBackgroundable(e: Draft<Element>): e is Draft<BackgroundableElement>;
 function isBackgroundable(e: Element): e is BackgroundableElement {
   // All media is backgroundable.
-  return ('isBackground' in e && Boolean(e.isBackground)) || isMediaElement(e);
+  return (
+    // Property can be undefined if e is of type Draft<Element>.
+    ('isBackground' in e && typeof e.isBackground !== 'undefined') ||
+    isMediaElement(e)
+  );
 }
 
 function isProduct(e: Element): e is ProductElement;


### PR DESCRIPTION
Casting to a bool ignores any element with `isBackground: false`

Property can be `undefined` if `e` is of type `Draft<Element>`.

See https://github.com/GoogleForCreators/web-stories-wp/pull/12841#discussion_r1053394447