### PR TITLE
Adjusted footer layout

### DIFF
--- a/packages/story-editor/src/components/footer/constants.js
+++ b/packages/story-editor/src/components/footer/constants.js
@@ -37,9 +37,9 @@ const KEYBOARD_SHORTCUTS_WIDTH =
 const LARGE_BUTTON_WIDTH = THEME_CONSTANTS.LARGE_BUTTON_SIZE + 2 * BORDER_WIDTH;
 
 // What's the max space required for either menu? The widest possible menu is
-// the secondary one with two large buttons + shortcuts button + 2 gaps + right margin:
+// the secondary one with three large buttons + shortcuts button + 2 gaps + right margin:
 export const MAX_MENU_WIDTH =
-  2 * LARGE_BUTTON_WIDTH +
+  3 * LARGE_BUTTON_WIDTH +
   KEYBOARD_SHORTCUTS_WIDTH +
   2 * FOOTER_MENU_GAP +
   FOOTER_MARGIN;


### PR DESCRIPTION
## Context

Made room for hidden design menu button in footer layout

## User-facing changes

| Before | After |
|-|-|
| ![footer-layout-before](https://user-images.githubusercontent.com/637548/208890302-6d5dca9e-419c-4859-8d4b-ea834bad2208.gif) | ![footer-layout-after](https://user-images.githubusercontent.com/637548/208890293-32b0506a-c6e5-4b08-ac87-b3bba3973289.gif) |

## Testing Instructions

This PR can be tested by following these steps:

1. Show/hide the design menu use the settings dropdown
2. Observe that the thumbnail carousel does not adjust position as the extra button is displayed

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #12251
