### PR TITLE
Fix page template poster image generation

### DIFF
--- a/includes/Admin/Dashboard.php
+++ b/includes/Admin/Dashboard.php
@@ -365,7 +365,7 @@ class Dashboard extends Service_Base {
 								'link',
 								'preview_link',
 								'edit_link',
-								'_links', // Needed for WP 6.1+
+								'_links', // Needed for WP 6.1+.
 								'_embedded',
 								// _web_stories_envelope will add these fields, we need them too.
 								'body',

--- a/includes/Admin/Dashboard.php
+++ b/includes/Admin/Dashboard.php
@@ -366,6 +366,7 @@ class Dashboard extends Service_Base {
 								'preview_link',
 								'edit_link',
 								'_links', // Needed for WP 6.1+
+								'_embedded',
 								// _web_stories_envelope will add these fields, we need them too.
 								'body',
 								'status',

--- a/includes/templates/admin/edit-story.php
+++ b/includes/templates/admin/edit-story.php
@@ -115,6 +115,7 @@ $story_query_params = [
 				'style_presets',
 				'password',
 				'_links',
+				'_embedded',
 			]
 		)
 	),

--- a/packages/story-editor/src/components/library/panes/pageTemplates/savedPageTemplate.js
+++ b/packages/story-editor/src/components/library/panes/pageTemplates/savedPageTemplate.js
@@ -158,6 +158,7 @@ function SavedPageTemplate(
           mediaSource: 'page-template',
         });
 
+        console.log(resource);
         await updatePageTemplate(page.templateId, {
           featured_media: resource.id,
         });

--- a/packages/story-editor/src/components/library/panes/pageTemplates/savedPageTemplate.js
+++ b/packages/story-editor/src/components/library/panes/pageTemplates/savedPageTemplate.js
@@ -142,7 +142,9 @@ function SavedPageTemplate(
     if (!shouldPostBlob) {
       return;
     }
-
+    console.log(page);
+    console.log(pageDataUrl);
+    console.log(page.image);
     (async () => {
       try {
         const blob = await fetchRemoteBlob(pageDataUrl);

--- a/packages/story-editor/src/components/library/panes/pageTemplates/savedPageTemplate.js
+++ b/packages/story-editor/src/components/library/panes/pageTemplates/savedPageTemplate.js
@@ -158,7 +158,7 @@ function SavedPageTemplate(
           mediaSource: 'page-template',
         });
 
-        updatePageTemplate(page.templateId, {
+        await updatePageTemplate(page.templateId, {
           featured_media: resource.id,
         });
         updateSavedTemplate({

--- a/packages/story-editor/src/components/library/panes/pageTemplates/savedPageTemplate.js
+++ b/packages/story-editor/src/components/library/panes/pageTemplates/savedPageTemplate.js
@@ -142,9 +142,7 @@ function SavedPageTemplate(
     if (!shouldPostBlob) {
       return;
     }
-    console.log(page);
-    console.log(pageDataUrl);
-    console.log(page.image);
+
     (async () => {
       try {
         const blob = await fetchRemoteBlob(pageDataUrl);
@@ -158,7 +156,6 @@ function SavedPageTemplate(
           mediaSource: 'page-template',
         });
 
-        console.log(resource);
         await updatePageTemplate(page.templateId, {
           featured_media: resource.id,
         });

--- a/packages/wp-dashboard/src/api/constants/index.js
+++ b/packages/wp-dashboard/src/api/constants/index.js
@@ -26,6 +26,7 @@ export const STORY_FIELDS = [
   'preview_link',
   'edit_link',
   '_links', // Needed for WP 6.1+
+  '_embedded',
   // _web_stories_envelope will add these fields, we need them too.
   'body',
   'status',

--- a/packages/wp-story-editor/src/api/constants/index.js
+++ b/packages/wp-story-editor/src/api/constants/index.js
@@ -33,6 +33,7 @@ export const STORY_FIELDS = [
   'style_presets',
   'password',
   '_links',
+  '_embedded',
 ].join(',');
 
 export const STORY_EMBED = 'wp:lock,author,wp:publisherlogo,wp:term';

--- a/packages/wp-story-editor/src/api/pageTemplate.js
+++ b/packages/wp-story-editor/src/api/pageTemplate.js
@@ -30,6 +30,7 @@ const TEMPLATE_FIELDS = [
   // _web_stories_envelope will add these fields, we need them too.
   'body',
   'headers',
+  '_embedded',
 ];
 
 const TEMPLATE_EMBED = 'wp:featuredmedia';


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
There seems to be a new bug (?) in WP 6.1 where 
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Open the Page Templates
2. Add the current page as template
3. Wait a couple of seconds and check the image URL of the new saved page template in the library (should be something like `..../web-stories-page-template-[ID].jpg`
4. Reload the page, open the Saved Page Templates and check the image URL of the previously added template again. Verify the URL is the same and not something like `web-stories-page-template-[ID]-1.jpg` which would indicate that a new image for the same template had been added.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12805 
