### PR TITLE
Fixed `*.tsx` tests

### DIFF
--- a/packages/animation/src/components/test/WAAPIWrapper.tsx
+++ b/packages/animation/src/components/test/WAAPIWrapper.tsx
@@ -17,6 +17,7 @@
 /**
  * External dependencies
  */
+import { useMemo } from '@googleforcreators/react';
 import { render, act } from '@testing-library/react';
 import type { FunctionComponent } from 'react';
 
@@ -42,15 +43,18 @@ function Trackers({
   ElOneWAAPIInvocationTracker,
   ElTwoWAAPIInvocationTracker,
 }: TrackersProps) {
-  return (
-    <div>
-      <ElOneWAAPIInvocationTracker target={'elOne'}>
-        <div />
-      </ElOneWAAPIInvocationTracker>
-      <ElTwoWAAPIInvocationTracker target={'elTwo'}>
-        <div />
-      </ElTwoWAAPIInvocationTracker>
-    </div>
+  return useMemo(
+    () => (
+      <div>
+        <ElOneWAAPIInvocationTracker target={'elOne'}>
+          <div />
+        </ElOneWAAPIInvocationTracker>
+        <ElTwoWAAPIInvocationTracker target={'elTwo'}>
+          <div />
+        </ElTwoWAAPIInvocationTracker>
+      </div>
+    ),
+    [ElOneWAAPIInvocationTracker, ElTwoWAAPIInvocationTracker]
   );
 }
 
@@ -171,7 +175,6 @@ describe('StoryAnimation.WAAPIWrapper', () => {
       });
 
       // See that only the element effected by the animation update rerendered
-      // See that mock methods were called on mount
       expect(ElOneWAAPIInvocationTracker).toHaveBeenCalledTimes(2);
       expect(ElTwoWAAPIInvocationTracker).toHaveBeenCalledTimes(1);
     });

--- a/packages/rich-text/src/formatters/test/color.tsx
+++ b/packages/rich-text/src/formatters/test/color.tsx
@@ -19,7 +19,7 @@
  */
 import { createSolid } from '@googleforcreators/patterns';
 import type { EditorState } from 'draft-js';
-import type { OrderedSet } from 'immutable';
+import { OrderedSet } from 'immutable';
 
 /**
  * Internal dependencies
@@ -90,23 +90,19 @@ describe('Color formatter', () => {
 
   describe('stylesToCSS', () => {
     it('should ignore styles without a color style', () => {
-      const css = stylesToCSS({} as OrderedSet<string>);
+      const css = stylesToCSS(OrderedSet<string>([]));
 
       expect(css).toBeNull();
     });
 
     it('should ignore invalid color style', () => {
-      const css = stylesToCSS({
-        toArray: () => [`${COLOR}-invalid`],
-      } as OrderedSet<string>);
+      const css = stylesToCSS(OrderedSet.of(`${COLOR}-invalid`));
 
       expect(css).toBeNull();
     });
 
     it('should return correct CSS for a valid color style', () => {
-      const css = stylesToCSS({
-        toArray: () => [`${COLOR}-ff000032`],
-      } as OrderedSet<string>);
+      const css = stylesToCSS(OrderedSet.of(`${COLOR}-ff000032`));
 
       expect(css).toStrictEqual({ color: 'rgba(255,0,0,0.5)' });
     });

--- a/packages/rich-text/src/formatters/test/italic.tsx
+++ b/packages/rich-text/src/formatters/test/italic.tsx
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import type { EditorState } from 'draft-js';
-import type { OrderedSet } from 'immutable';
+import { OrderedSet } from 'immutable';
 
 /**
  * Internal dependencies
@@ -79,17 +79,13 @@ describe('Italic formatter', () => {
 
   describe('stylesToCSS', () => {
     it('should ignore styles without italic style', () => {
-      const css = stylesToCSS({
-        toArray: () => ['NOT-ITALIC', 'ALSO-NOT-ITALIC'],
-      } as OrderedSet<string>);
+      const css = stylesToCSS(OrderedSet.of('NOT-ITALIC', 'ALSO-NOT-ITALIC'));
 
       expect(css).toBeNull();
     });
 
     it('should return correct CSS if italic is present', () => {
-      const css = stylesToCSS({
-        toArray: () => [ITALIC],
-      } as OrderedSet<string>);
+      const css = stylesToCSS(OrderedSet.of(ITALIC));
 
       expect(css).toStrictEqual({ fontStyle: 'italic' });
     });

--- a/packages/rich-text/src/formatters/test/underline.tsx
+++ b/packages/rich-text/src/formatters/test/underline.tsx
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import type { EditorState } from 'draft-js';
-import type { OrderedSet } from 'immutable';
+import { OrderedSet } from 'immutable';
 
 /**
  * Internal dependencies
@@ -79,17 +79,15 @@ describe('Underline formatter', () => {
 
   describe('stylesToCSS', () => {
     it('should ignore styles without underline style', () => {
-      const css = stylesToCSS({
-        toArray: () => ['NOT-UNDERLINE', 'ALSO-NOT-UNDERLINE'],
-      } as OrderedSet<string>);
+      const css = stylesToCSS(
+        OrderedSet.of('NOT-UNDERLINE', 'ALSO-NOT-UNDERLINE')
+      );
 
       expect(css).toBeNull();
     });
 
     it('should return correct CSS if underline is present', () => {
-      const css = stylesToCSS({
-        toArray: () => [UNDERLINE],
-      } as OrderedSet<string>);
+      const css = stylesToCSS(OrderedSet.of(UNDERLINE));
 
       expect(css).toStrictEqual({ textDecoration: 'underline' });
     });

--- a/packages/rich-text/src/formatters/test/uppercase.tsx
+++ b/packages/rich-text/src/formatters/test/uppercase.tsx
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import type { OrderedSet } from 'immutable';
+import { OrderedSet } from 'immutable';
 import type { EditorState } from 'draft-js';
 
 /**
@@ -79,17 +79,15 @@ describe('Uppercase formatter', () => {
 
   describe('stylesToCSS', () => {
     it('should ignore styles without uppercase style', () => {
-      const css = stylesToCSS({
-        toArray: () => ['NOT-UPPERCASE', 'ALSO-NOT-UPPERCASE'],
-      } as OrderedSet<string>);
+      const css = stylesToCSS(
+        OrderedSet.of('NOT-UPPERCASE', 'ALSO-NOT-UPPERCASE')
+      );
 
       expect(css).toBeNull();
     });
 
     it('should return correct CSS if uppercase is present', () => {
-      const css = stylesToCSS({
-        toArray: () => [UPPERCASE],
-      } as OrderedSet<string>);
+      const css = stylesToCSS(OrderedSet.of(UPPERCASE));
 
       expect(css).toStrictEqual({ textTransform: 'uppercase' });
     });

--- a/packages/rich-text/src/formatters/test/weight.tsx
+++ b/packages/rich-text/src/formatters/test/weight.tsx
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import type { EditorState } from 'draft-js';
-import type { OrderedSet } from 'immutable';
+import { OrderedSet } from 'immutable';
 
 /**
  * Internal dependencies
@@ -81,25 +81,19 @@ describe('Color formatter', () => {
 
   describe('stylesToCSS', () => {
     it('should ignore styles without a font weight style', () => {
-      const css = stylesToCSS({
-        toArray: () => ['NOT-WEIGHT', 'ALSO-NOT-WEIGHT'],
-      } as OrderedSet<string>);
+      const css = stylesToCSS(OrderedSet.of('NOT-WEIGHT', 'ALSO-NOT-WEIGHT'));
 
       expect(css).toBeNull();
     });
 
     it('should ignore invalid font weight style', () => {
-      const css = stylesToCSS({
-        toArray: () => [`${WEIGHT}-invalid`],
-      } as OrderedSet<string>);
+      const css = stylesToCSS(OrderedSet.of(`${WEIGHT}-invalid`));
 
       expect(css).toBeNull();
     });
 
     it('should return correct CSS for a valid style', () => {
-      const css = stylesToCSS({
-        toArray: () => [`${WEIGHT}-500`],
-      } as OrderedSet<string>);
+      const css = stylesToCSS(OrderedSet.of(`${WEIGHT}-500`));
 
       expect(css).toStrictEqual({ fontWeight: 500 });
     });

--- a/tests/js/jest.config.js
+++ b/tests/js/jest.config.js
@@ -44,7 +44,7 @@ export default {
   // See https://jestjs.io/docs/configuration#transformignorepatterns-arraystring
   transformIgnorePatterns: ['/node_modules/(?!(use-reduction)/)'],
   testEnvironment: 'jsdom',
-  testMatch: ['**/test/**/*.[jt]s'],
+  testMatch: ['**/test/**/*.{js,jsx,ts,tsx}'],
   globals: {
     WEB_STORIES_ENV: 'development',
     WEB_STORIES_DISABLE_ERROR_BOUNDARIES: true,

--- a/tests/js/setup-globals.js
+++ b/tests/js/setup-globals.js
@@ -81,6 +81,13 @@ if (typeof window !== 'undefined') {
   File.prototype.arrayBuffer = () =>
     new Promise((resolve) => resolve(new ArrayBuffer(0)));
 
+  window.KeyframeEffect = class KeyframeEffect {};
+  window.Animation = class Animation {
+    cancel() {}
+    play() {}
+  };
+  window.AnimationPlaybackEvent = class AnimationPlaybackEvent {};
+
   // Prevent React warnings when setting the `muted` attribute on `<video>` elements.
   // See https://github.com/testing-library/react-testing-library/issues/470
   // See https://github.com/facebook/react/issues/10389


### PR DESCRIPTION
## Context

Because of a missing config, these tests were not actually run before, so they had not been correctly modified after the animation package had been refactored. This has now been corrected.

## User-facing changes

_None_

## Testing Instructions

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #12895
