### PR TITLE
Various Gutenberg Block Improvements

### DIFF
--- a/blocks/embed/block.json
+++ b/blocks/embed/block.json
@@ -3,13 +3,9 @@
   "title": "Web Stories",
   "description": "Embed Web Stories.",
   "category": "embed",
-  "keywords": [
-    "embed",
-    "web stories",
-    "story",
-    "stories"
-  ],
+  "keywords": ["embed", "web stories", "story", "stories"],
   "textdomain": "web-stories",
+  "usesContext": ["postId", "postType", "queryId"],
   "attributes": {
     "blockType": {
       "type": "string"

--- a/blocks/embed/block.json
+++ b/blocks/embed/block.json
@@ -74,6 +74,10 @@
     "fieldState": {
       "type": "object",
       "default": {}
+    },
+    "taxQuery": {
+      "type": "object",
+      "default": {}
     }
   },
   "supports": {

--- a/blocks/embed/block.json
+++ b/blocks/embed/block.json
@@ -78,6 +78,10 @@
     "taxQuery": {
       "type": "object",
       "default": {}
+    },
+    "previewOnly": {
+      "type": "boolean",
+      "default": false
     }
   },
   "supports": {

--- a/includes/Block/Web_Stories_Block.php
+++ b/includes/Block/Web_Stories_Block.php
@@ -36,6 +36,7 @@ use Google\Web_Stories\Stories_Script_Data;
 use Google\Web_Stories\Story_Post_Type;
 use Google\Web_Stories\Story_Query;
 use Google\Web_Stories\Tracking;
+use WP_Block;
 
 /**
  * Latest Stories block class.
@@ -167,9 +168,17 @@ class Web_Stories_Block extends Embed_Base {
 	 *
 	 * @phpstan-param BlockAttributesWithDefaults $attributes
 	 */
-	public function render_block( array $attributes ): string {
+	public function render_block( array $attributes, string $content, WP_Block $block ): string {
 		if ( false === $this->initialize_block_attributes( $attributes ) ) {
 			return '';
+		}
+
+		if ( 'web-story' === $block->context['postType'] && ! empty( $block->context['postId'] ) ) {
+			$attributes = wp_parse_args( $attributes, $this->default_attrs() );
+
+			$attributes['class'] = 'wp-block-web-stories-embed';
+
+			return $this->render( $attributes );
 		}
 
 		if ( ! empty( $attributes['blockType'] )

--- a/includes/Renderer/Story/Singleton.php
+++ b/includes/Renderer/Story/Singleton.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * Class Singleton
+ *
+ * @link      https://github.com/googleforcreators/web-stories-wp
+ *
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ */
+
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types = 1);
+
+namespace Google\Web_Stories\Renderer\Story;
+
+use Google\Web_Stories\AMP_Story_Player_Assets;
+use Google\Web_Stories\Assets;
+use Google\Web_Stories\Embed_Base;
+use Google\Web_Stories\Model\Story;
+use Google\Web_Stories\Renderer\Stories\Renderer;
+
+/**
+ * Class Singleton
+ */
+class Singleton {
+	/**
+	 * Number of instances invoked. Kept it static to keep track.
+	 */
+	protected static int $instances = 0;
+
+	/**
+	 * Current post.
+	 *
+	 * @var Story Post object.
+	 */
+	protected Story $story;
+
+	/**
+	 * Assets instance.
+	 *
+	 * @var Assets Assets instance.
+	 */
+	private Assets $assets;
+
+	/**
+	 * Object ID for the Renderer class.
+	 * To enable support for multiple carousels and lightboxes
+	 * on the same page, we needed to identify each Renderer instance.
+	 *
+	 * This variable is used to add appropriate class to the Web Stories
+	 * wrapper.
+	 */
+	protected int $instance_id = 0;
+
+	/**
+	 * Singleton constructor.
+	 *
+	 * @since 1.30.0
+	 *
+	 * @param Story  $story   Story instance.
+	 * @param Assets $assets  Assets instance.
+	 */
+	public function __construct( Story $story, Assets $assets ) {
+		$this->assets = $assets;
+		$this->story  = $story;
+	}
+
+	/**
+	 * Renders the block output in default context.
+	 *
+	 * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+	 *
+	 * @since 1.30.0
+	 *
+	 * @param array<string,string|int> $args Array of Argument to render.
+	 * @return string Rendered block type output.
+	 */
+	public function render( array $args = [] ): string {
+		++self::$instances;
+		$this->instance_id = self::$instances;
+
+		$defaults = [
+			'align'  => 'none',
+			'class'  => 'wp-block-web-stories-embed',
+			'height' => 600,
+			'width'  => 360,
+		];
+
+		$args = wp_parse_args( $args, $defaults );
+
+		$args['align'] = ! empty( $args['align'] ) ? $args['align'] : 'none';
+		$align         = sprintf( 'align%s', $args['align'] );
+		$class         = $args['class'];
+		$wrapper_style = sprintf(
+			'--aspect-ratio: %F; --width: %dpx; --height: %dpx',
+			0 !== $args['height'] ? $args['width'] / $args['height'] : 1,
+			(int) $args['width'],
+			(int) $args['height']
+		);
+
+		$this->assets->enqueue_style( AMP_Story_Player_Assets::SCRIPT_HANDLE );
+		$this->assets->enqueue_script( AMP_Story_Player_Assets::SCRIPT_HANDLE );
+		$this->assets->enqueue_script_asset( Renderer::LIGHTBOX_SCRIPT_HANDLE );
+		$this->assets->enqueue_style_asset( Embed_Base::SCRIPT_HANDLE );
+
+		ob_start();
+		?>
+		<div class="<?php echo esc_attr( "$class web-stories-singleton $align" ); ?>" data-id="<?php echo esc_attr( 'singleton-' . $this->instance_id ); ?>">
+			<div class="wp-block-embed__wrapper" style="<?php echo esc_attr( $wrapper_style ); ?>">
+			<?php $this->render_story_with_poster( $args ); ?>
+			</div>
+			<?php
+
+			$data = [
+				'controls' => [
+					[
+						'name'     => 'close',
+						'position' => 'start',
+					],
+					[
+						'name' => 'skip-next',
+					],
+				],
+				'behavior' => [
+					'autoplay' => false,
+				],
+			];
+
+			?>
+			<div class="web-stories-singleton__lightbox-wrapper <?php echo esc_attr( 'ws-lightbox-singleton-' . $this->instance_id ); ?>">
+				<div class="web-stories-singleton__lightbox">
+					<amp-story-player width="3.6" height="6" layout="responsive">
+						<script type="application/json">
+							<?php echo wp_json_encode( $data ); ?>
+						</script>
+						<a href="<?php echo esc_url( $this->story->get_url() ); ?>"><?php echo esc_html( $this->story->get_title() ); ?></a>
+					</amp-story-player>
+				</div>
+			</div>
+		</div>
+		<?php
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Renders a story with story's poster image.
+	 *
+	 * @since 1.30.0
+	 *
+	 * @param array<string,string|int> $args Array of Argument to render.
+	 */
+	protected function render_story_with_poster( array $args ): void {
+		$poster_url    = $this->story->get_poster_portrait();
+		$poster_srcset = $this->story->get_poster_srcset();
+		$poster_sizes  = $this->story->get_poster_sizes();
+
+		if ( ! $poster_url ) {
+			?>
+			<div class="web-stories-singleton-poster">
+				<div class="web-stories-singleton-poster-placeholder">
+					<a href="<?php echo esc_url( $this->story->get_url() ); ?>">
+						<?php echo esc_html( $this->story->get_title() ); ?>
+					</a>
+				</div>
+			</div>
+			<?php
+		} else {
+			?>
+			<div class="web-stories-singleton-poster">
+				<a href="<?php echo esc_url( $this->story->get_url() ); ?>">
+					<img
+						src="<?php echo esc_url( $poster_url ); ?>"
+						alt="<?php echo esc_attr( $this->story->get_title() ); ?>"
+						width="<?php echo absint( $args['width'] ); ?>"
+						height="<?php echo absint( $args['height'] ); ?>"
+						<?php if ( ! empty( $poster_srcset ) ) { ?>
+							srcset="<?php echo esc_attr( $poster_srcset ); ?>"
+						<?php } ?>
+						<?php if ( ! empty( $poster_sizes ) ) { ?>
+							sizes="<?php echo esc_attr( $poster_sizes ); ?>"
+						<?php } ?>
+						loading="lazy"
+						decoding="async"
+					>
+				</a>
+			</div>
+			<?php
+		}
+		$this->render_content_overlay();
+	}
+
+	/**
+	 * Renders the content overlay markup.
+	 *
+	 * @since 1.30.0
+	 */
+	protected function render_content_overlay(): void {
+		?>
+		<div class="web-stories-singleton-overlay">
+			<div class="web-stories-singleton-overlay__title">
+					<?php echo esc_html( $this->story->get_title() ); ?>
+				</div>
+		</div>
+		<?php
+	}
+}

--- a/packages/stories-block/src/block/block-types/latest-stories/edit.js
+++ b/packages/stories-block/src/block/block-types/latest-stories/edit.js
@@ -46,7 +46,7 @@ import StoriesPreview from '../../components/storiesPreview';
  * @return {*} JSX markup for the editor.
  */
 function LatestStoriesEdit({ attributes, setAttributes }) {
-  const { numOfStories, order, orderby, archiveLinkLabel, authors } =
+  const { numOfStories, order, orderby, archiveLinkLabel, authors, taxQuery } =
     attributes;
 
   /**
@@ -63,6 +63,7 @@ function LatestStoriesEdit({ attributes, setAttributes }) {
         orderby: orderby || 'modified',
         order: order || 'desc',
         author: authors || undefined,
+        ...taxQuery,
       };
 
       return {
@@ -72,7 +73,7 @@ function LatestStoriesEdit({ attributes, setAttributes }) {
           isResolving('postType', 'web-story', newQuery) || false,
       };
     },
-    [order, orderby, authors]
+    [order, orderby, authors, taxQuery]
   );
 
   const viewAllLabel = archiveLinkLabel
@@ -130,6 +131,7 @@ LatestStoriesEdit.propTypes = {
     authors: PropTypes.array,
     circleSize: PropTypes.number,
     fieldState: PropTypes.object,
+    taxQuery: PropTypes.objectOf(PropTypes.number),
   }),
   setAttributes: PropTypes.func.isRequired,
 };

--- a/packages/stories-block/src/block/block-types/single-story/edit.css
+++ b/packages/stories-block/src/block/block-types/single-story/edit.css
@@ -1,6 +1,5 @@
 .block-editor-block-list__block[data-type='web-stories/embed'] .wp-block {
   height: auto;
-  overflow: hidden;
 }
 
 /* Loading Indicator */
@@ -94,10 +93,15 @@
   line-height: 1.25;
 }
 
-.web-stories-embed-size-control__width {
+.block-editor-block-inspector .web-stories-embed-size-control__width,
+.block-editor-block-inspector .web-stories-embed-size-control__height {
+  margin-bottom: 0 !important;
+}
+
+.block-editor-block-inspector .web-stories-embed-size-control__width {
   margin-right: 5px;
 }
 
-.web-stories-embed-size-control__height {
+.block-editor-block-inspector .web-stories-embed-size-control__height {
   margin-left: 5px;
 }

--- a/packages/stories-block/src/block/block-types/single-story/edit.js
+++ b/packages/stories-block/src/block/block-types/single-story/edit.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/* eslint complexity: ["error", { "max": 21 }] -- TODO: Refactor this. */
+/* eslint complexity: ["error", { "max": 25 }] -- TODO: Refactor this. */
 
 /**
  * External dependencies
@@ -53,6 +53,7 @@ function StoryEmbedEdit({
   className,
   isSelected,
   _isResizable,
+  context = {},
 }) {
   const {
     url: outerURL = '',
@@ -64,13 +65,20 @@ function StoryEmbedEdit({
     stories = [],
   } = attributes;
 
+  const { postId, queryId } = context;
+  const isDescendentOfQueryLoop = Number.isFinite(queryId);
+
   const [editingURL, setEditingURL] = useState(false);
-  const [localURL, setLocalURL] = useState(outerURL);
+  const [localURL, setLocalURL] = useState(
+    isDescendentOfQueryLoop ? undefined : outerURL
+  );
   const [isFetchingData, setIsFetchingData] = useState(false);
   const [isFetching, setIsFetching] = useState(false);
   const [storyData, setStoryData] = useState({});
   const [cannotEmbed, setCannotEmbed] = useState(false);
-  const [selectedStoryIds, setSelectedStoryIds] = useState(stories);
+  const [selectedStoryIds, setSelectedStoryIds] = useState(
+    isDescendentOfQueryLoop ? [postId] : stories
+  );
   const [selectedStories, _setSelectedStories] = useState([]);
 
   const showLoadingIndicator = isFetchingData;
@@ -222,7 +230,7 @@ function StoryEmbedEdit({
           icon={<BlockIcon />}
           label={label}
           selectedStoryIds={selectedStoryIds}
-          setSelectedStories={_setSelectedStories}
+          setSelectedStories={setSelectedStories}
           setIsFetching={setIsFetching}
         />
       );
@@ -356,6 +364,10 @@ StoryEmbedEdit.propTypes = {
   className: PropTypes.string.isRequired,
   isSelected: PropTypes.bool,
   _isResizable: PropTypes.bool,
+  context: PropTypes.shape({
+    postType: PropTypes.string,
+    postId: PropTypes.number,
+  }),
 };
 
 export default withViewportMatch({ _isResizable: 'medium' })(StoryEmbedEdit);

--- a/packages/stories-block/src/block/block-types/single-story/editInLoop.js
+++ b/packages/stories-block/src/block/block-types/single-story/editInLoop.js
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useRef } from '@wordpress/element';
+import { Placeholder, ResizableBox } from '@wordpress/components';
+import * as compose from '@wordpress/compose';
+import { withViewportMatch } from '@wordpress/viewport';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { store as blockEditorStore, BlockIcon } from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import LoaderContainer from '../../components/loaderContainer';
+import { BlockIcon as Icon } from '../../icons';
+import EmbedLoading from './embedLoading';
+import EmbedPreview from './embedPreview';
+import './edit.css';
+import Singleton from './singleton';
+import EmbedControlsInLoop from './embedControlsInLoop';
+
+const MIN_SIZE = 20;
+
+function StoryEmbedEditInLoop({
+  attributes,
+  setAttributes,
+  className,
+  isSelected,
+  _isResizable,
+  context = {},
+}) {
+  const {
+    width = 360,
+    height = 600,
+    align = 'none',
+    previewOnly = false,
+  } = attributes;
+
+  const { postId } = context;
+
+  const { story, isFetching } = useSelect(
+    (select) => {
+      const { getEntityRecord, isResolving } = select(coreStore);
+
+      let story = null;
+
+      const record = getEntityRecord('postType', 'web-story', postId);
+
+      if (record) {
+        story = {
+          url: record.link,
+          title: record.title?.rendered,
+          poster: record._embedded?.['wp:featuredmedia']?.[0]?.source_url,
+        };
+      }
+
+      return {
+        story,
+        isFetching: isResolving('postType', 'web-story', postId) || false,
+      };
+    },
+    [postId]
+  );
+
+  const { isRTL, maxWidth } = useSelect((select) => {
+    const { getSettings } = select(blockEditorStore);
+    const settings = getSettings();
+    return {
+      isRTL: settings.isRTL,
+      maxWidth: settings.maxWidth,
+    };
+  }, []);
+
+  const isResizable = compose.useViewportMatch
+    ? compose.useViewportMatch('medium')
+    : _isResizable;
+
+  const ref = useRef();
+
+  useEffect(() => {
+    if (ref.current && window.AmpStoryPlayer && !previewOnly) {
+      const player = new window.AmpStoryPlayer(window, ref.current);
+      try {
+        player.load();
+      } catch {
+        // Player already loaded.
+      }
+    }
+  }, [story, isResizable, previewOnly]);
+
+  const { toggleSelection } = useDispatch(blockEditorStore);
+
+  if (isFetching) {
+    return <EmbedLoading />;
+  }
+
+  const onResizeStart = () => toggleSelection(false);
+  const onResizeStop = () => toggleSelection(true);
+
+  const label = __('Single Story', 'web-stories');
+
+  if (isFetching) {
+    return (
+      <Placeholder
+        icon={<BlockIcon icon={<Icon />} showColors />}
+        label={label}
+        className="wp-block-web-stories-embed"
+        instructions={false}
+      >
+        <LoaderContainer>{__('Loading Story…', 'web-stories')}</LoaderContainer>
+      </Placeholder>
+    );
+  }
+
+  const ratio = width / height;
+  const minWidth = width < height ? MIN_SIZE : MIN_SIZE * ratio;
+  const minHeight = height < width ? MIN_SIZE : MIN_SIZE / ratio;
+
+  const previewClassName = classNames(
+    className,
+    { 'web-stories-embed': !previewOnly },
+    { 'web-stories-singleton': previewOnly },
+    `align${align || 'none'}`
+  );
+
+  if (!isResizable) {
+    return (
+      <>
+        <EmbedControlsInLoop
+          setAttributes={setAttributes}
+          width={width}
+          height={height}
+          minWidth={Math.ceil(minWidth)}
+          maxWidth={Math.floor(maxWidth)}
+          minHeight={Math.floor(minHeight)}
+          maxHeight={Math.ceil(maxWidth / ratio)}
+        />
+        <div className={previewClassName}>
+          <EmbedPreview
+            url={story.url}
+            title={story.title}
+            poster={story.poster}
+            ref={ref}
+            isSelected={isSelected}
+            width={width}
+            height={height}
+          />
+        </div>
+      </>
+    );
+  }
+
+  const showRightHandle =
+    align === 'center' ||
+    align === 'none' ||
+    (align === 'right' && isRTL) ||
+    (align === 'left' && !isRTL);
+
+  const showLeftHandle =
+    align === 'center' ||
+    (align === 'left' && isRTL) ||
+    (align === 'right' && !isRTL);
+
+  return (
+    <>
+      <EmbedControlsInLoop
+        setAttributes={setAttributes}
+        width={width}
+        height={height}
+        minWidth={Math.ceil(minWidth)}
+        maxWidth={Math.floor(maxWidth)}
+        minHeight={Math.floor(minHeight)}
+        maxHeight={Math.ceil(maxWidth / ratio)}
+        previewOnly={previewOnly}
+      />
+      <div className={previewClassName}>
+        <ResizableBox
+          className={isSelected ? 'show-resize-handle' : 'hide-resize-handle'}
+          size={{
+            width,
+            height,
+          }}
+          minWidth={minWidth}
+          maxWidth={maxWidth}
+          minHeight={minHeight}
+          maxHeight={maxWidth / ratio}
+          lockAspectRatio
+          enable={{
+            top: false,
+            right: showRightHandle,
+            bottom: true,
+            left: showLeftHandle,
+          }}
+          onResizeStart={onResizeStart}
+          onResizeStop={(event, direction, elt, delta) => {
+            onResizeStop();
+            setAttributes({
+              width: parseInt(width + delta.width),
+              height: parseInt(height + delta.height),
+            });
+          }}
+        >
+          {previewOnly ? (
+            <Singleton
+              title={story.title}
+              poster={story.poster}
+              width={width}
+              height={height}
+            />
+          ) : (
+            <EmbedPreview
+              url={story.url}
+              title={story.title}
+              poster={story.poster}
+              ref={ref}
+              isSelected={isSelected}
+              width={width}
+              height={height}
+            />
+          )}
+        </ResizableBox>
+      </div>
+    </>
+  );
+}
+
+StoryEmbedEditInLoop.propTypes = {
+  attributes: PropTypes.shape({
+    url: PropTypes.string,
+    title: PropTypes.string,
+    poster: PropTypes.string,
+    stories: PropTypes.array,
+    width: PropTypes.number,
+    height: PropTypes.number,
+    align: PropTypes.string,
+    previewOnly: PropTypes.bool,
+  }),
+  setAttributes: PropTypes.func.isRequired,
+  className: PropTypes.string.isRequired,
+  isSelected: PropTypes.bool,
+  _isResizable: PropTypes.bool,
+  context: PropTypes.shape({
+    postType: PropTypes.string,
+    postId: PropTypes.number,
+  }),
+};
+
+export default withViewportMatch({ _isResizable: 'medium' })(
+  StoryEmbedEditInLoop
+);

--- a/packages/stories-block/src/block/block-types/single-story/embedControls.js
+++ b/packages/stories-block/src/block/block-types/single-story/embedControls.js
@@ -30,6 +30,7 @@ import {
   PanelRow,
   ToolbarGroup,
   ToolbarButton,
+  ToggleControl,
 } from '@wordpress/components';
 import {
   BlockControls,
@@ -54,6 +55,7 @@ const EmbedControls = (props) => {
     maxHeight,
     poster,
     title,
+    previewOnly,
     setAttributes,
   } = props;
 
@@ -75,6 +77,10 @@ const EmbedControls = (props) => {
     // Move focus back to the Media Upload button.
     posterImageButton.current.focus();
   }, [setAttributes, posterImageButton]);
+
+  const onChangePreviewOnly = useCallback(() => {
+    setAttributes({ previewOnly: !previewOnly });
+  }, [setAttributes, previewOnly]);
 
   const hasPoster = Boolean(poster);
 
@@ -194,6 +200,19 @@ const EmbedControls = (props) => {
               </div>
             </BaseControl>
           </PanelRow>
+          <PanelRow>
+            <BaseControl>
+              <ToggleControl
+                label={__('Display as preview', 'web-stories')}
+                checked={previewOnly}
+                onChange={onChangePreviewOnly}
+                help={__(
+                  'Displays the story poster that opens the story in a lightbox on click',
+                  'web-stories'
+                )}
+              />
+            </BaseControl>
+          </PanelRow>
         </PanelBody>
       </InspectorControls>
     </>
@@ -211,6 +230,7 @@ EmbedControls.propTypes = {
   poster: PropTypes.string,
   title: PropTypes.string,
   setAttributes: PropTypes.func,
+  previewOnly: PropTypes.bool,
 };
 
 export default EmbedControls;

--- a/packages/stories-block/src/block/block-types/single-story/embedControlsInLoop.js
+++ b/packages/stories-block/src/block/block-types/single-story/embedControlsInLoop.js
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
+ * WordPress dependencies
+ */
+import {
+  BaseControl,
+  TextControl,
+  PanelBody,
+  PanelRow,
+  ToggleControl,
+} from '@wordpress/components';
+import { InspectorControls } from '@wordpress/block-editor';
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+const EmbedControlsInLoop = (props) => {
+  const {
+    width,
+    height,
+    minWidth,
+    maxWidth,
+    minHeight,
+    maxHeight,
+    previewOnly,
+    setAttributes,
+  } = props;
+
+  const onChangePreviewOnly = useCallback(() => {
+    setAttributes({ previewOnly: !previewOnly });
+  }, [setAttributes, previewOnly]);
+
+  return (
+    <InspectorControls>
+      <PanelBody title={__('Embed Settings', 'web-stories')}>
+        <PanelRow>
+          <BaseControl className="web-stories-embed-size-control">
+            <BaseControl.VisualLabel>
+              {__('Story dimensions', 'web-stories')}
+            </BaseControl.VisualLabel>
+            <div className="web-stories-embed-size-control__row">
+              <TextControl
+                type="number"
+                className="web-stories-embed-size-control__width"
+                label={__('Width', 'web-stories')}
+                value={width || ''}
+                min={minWidth}
+                max={maxWidth}
+                onChange={(value) => setAttributes({ width: parseInt(value) })}
+              />
+              <TextControl
+                type="number"
+                className="web-stories-embed-size-control__height"
+                label={__('Height', 'web-stories')}
+                value={height || ''}
+                min={minHeight}
+                max={maxHeight}
+                onChange={(value) =>
+                  setAttributes({
+                    height: parseInt(value),
+                  })
+                }
+              />
+            </div>
+          </BaseControl>
+        </PanelRow>
+        <PanelRow>
+          <BaseControl>
+            <ToggleControl
+              label={__('Display as preview', 'web-stories')}
+              checked={previewOnly}
+              onChange={onChangePreviewOnly}
+              help={__(
+                'Displays the story poster that opens the story in a lightbox on click',
+                'web-stories'
+              )}
+            />
+          </BaseControl>
+        </PanelRow>
+      </PanelBody>
+    </InspectorControls>
+  );
+};
+
+EmbedControlsInLoop.propTypes = {
+  width: PropTypes.number,
+  height: PropTypes.number,
+  minWidth: PropTypes.number,
+  maxWidth: PropTypes.number,
+  minHeight: PropTypes.number,
+  maxHeight: PropTypes.number,
+  setAttributes: PropTypes.func,
+  previewOnly: PropTypes.bool,
+};
+
+export default EmbedControlsInLoop;

--- a/packages/stories-block/src/block/block-types/single-story/singleton.js
+++ b/packages/stories-block/src/block/block-types/single-story/singleton.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
+ * WordPress dependencies
+ */
+import { RawHTML } from '@wordpress/element';
+
+function Singleton({ title, poster, width, height }) {
+  return (
+    <div className="web-stories-singleton">
+      <div
+        className="wp-block-embed__wrapper"
+        style={{
+          '--aspect-ratio': 0 !== height ? width / height : 1,
+          '--width': `${width}px`,
+          '--height': `${height}px`,
+        }}
+      >
+        <div className="web-stories-singleton-poster">
+          {poster ? (
+            <img src={poster} alt={title} />
+          ) : (
+            <div className="web-stories-singleton-poster-placeholder">
+              <span>{title}</span>
+            </div>
+          )}
+        </div>
+        <div className="web-stories-singleton-overlay">
+          {title && (
+            <RawHTML className="story-content-overlay__title">{title}</RawHTML>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+Singleton.propTypes = {
+  title: PropTypes.string,
+  poster: PropTypes.string,
+  width: PropTypes.number,
+  height: PropTypes.number,
+};
+
+export default Singleton;

--- a/packages/stories-block/src/block/components/taxonomyItem.js
+++ b/packages/stories-block/src/block/components/taxonomyItem.js
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
+ * WordPress dependencies
+ */
+import { FormTokenField } from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
+import { useDebounce } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+const BASE_QUERY = {
+  order: 'asc',
+  _fields: 'id,name',
+  context: 'view',
+};
+
+// Helper function to get the term id based on user input in terms `FormTokenField`.
+const getTermIdByTermValue = (terms, termValue) => {
+  // First we check for exact match by `term.id` or case-sensitive `term.name` match.
+  const termId =
+    termValue?.id || terms?.find((term) => term.name === termValue)?.id;
+  if (termId) {
+    return termId;
+  }
+
+  /**
+   * Here we make an extra check for entered terms in a non case sensitive way,
+   * to match user expectations, due to `FormTokenField` behaviour that shows
+   * suggestions which are case insensitive.
+   *
+   * Although WP tries to discourage users to add terms with the same name (case insensitive),
+   * it's still possible if you manually change the name, as long as the terms have different slugs.
+   * In this edge case we always apply the first match from the terms list.
+   */
+  const termValueLower = termValue.toLocaleLowerCase();
+  return terms?.find((term) => term.name.toLocaleLowerCase() === termValueLower)
+    ?.id;
+};
+
+/**
+ * Renders a `FormTokenField` for a given taxonomy.
+ *
+ * @param {Object}   props          The props for the component.
+ * @param {Object}   props.taxonomy The taxonomy object.
+ * @param {number[]} props.termIds  An array with the block's term ids for the given taxonomy.
+ * @param {Function} props.onChange Callback `onChange` function.
+ * @return {*} JSX markup.
+ */
+function TaxonomyItem({ taxonomy, termIds, onChange }) {
+  const [search, setSearch] = useState('');
+  const [value, setValue] = useState([]);
+  const [suggestions, setSuggestions] = useState([]);
+  const debouncedSearch = useDebounce(setSearch, 250);
+  const { searchResults, searchHasResolved } = useSelect(
+    (select) => {
+      if (!search) {
+        return { searchResults: [], searchHasResolved: true };
+      }
+      const { getEntityRecords, hasFinishedResolution } = select(coreStore);
+      const selectorArgs = [
+        'taxonomy',
+        taxonomy.slug,
+        {
+          ...BASE_QUERY,
+          search,
+          orderby: 'name',
+          exclude: termIds,
+          per_page: 20,
+        },
+      ];
+      return {
+        searchResults: getEntityRecords(...selectorArgs),
+        searchHasResolved: hasFinishedResolution(
+          'getEntityRecords',
+          selectorArgs
+        ),
+      };
+    },
+    [search, termIds, taxonomy.slug]
+  );
+  // `existingTerms` are the ones fetched from the API and their type is `{ id: number; name: string }`.
+  // They are used to extract the terms' names to populate the `FormTokenField` properly
+  // and to sanitize the provided `termIds`, by setting only the ones that exist.
+  const existingTerms = useSelect(
+    (select) => {
+      if (!termIds?.length) {
+        return [];
+      }
+      const { getEntityRecords } = select(coreStore);
+      return getEntityRecords('taxonomy', taxonomy.slug, {
+        ...BASE_QUERY,
+        include: termIds,
+        per_page: termIds.length,
+      });
+    },
+    [termIds, taxonomy.slug]
+  );
+  // Update the `value` state only after the selectors are resolved
+  // to avoid emptying the input when we're changing terms.
+  useEffect(() => {
+    if (!termIds?.length) {
+      setValue([]);
+    }
+    if (!existingTerms?.length) {
+      return;
+    }
+    // Returns only the existing entity ids. This prevents the component
+    // from crashing in the editor, when non-existing ids are provided.
+    const sanitizedValue = termIds.reduce((accumulator, id) => {
+      const entity = existingTerms.find((term) => term.id === id);
+      if (entity) {
+        accumulator.push({
+          id,
+          value: entity.name,
+        });
+      }
+      return accumulator;
+    }, []);
+    setValue(sanitizedValue);
+  }, [termIds, existingTerms]);
+  // Update suggestions only when the query has resolved.
+  useEffect(() => {
+    if (!searchHasResolved) {
+      return;
+    }
+    setSuggestions(searchResults.map((result) => result.name));
+  }, [searchResults, searchHasResolved]);
+  const onTermsChange = (newTermValues) => {
+    const newTermIds = new Set();
+    for (const termValue of newTermValues) {
+      const termId = getTermIdByTermValue(searchResults, termValue);
+      if (termId) {
+        newTermIds.add(termId);
+      }
+    }
+    setSuggestions([]);
+    onChange(Array.from(newTermIds));
+  };
+  return (
+    <div className="block-library-query-inspector__taxonomy-control">
+      <FormTokenField
+        label={taxonomy.name}
+        value={value}
+        onInputChange={debouncedSearch}
+        suggestions={suggestions}
+        onChange={onTermsChange}
+        __experimentalShowHowTo={false}
+      />
+    </div>
+  );
+}
+
+TaxonomyItem.propTypes = {
+  taxonomy: PropTypes.shape({
+    id: PropTypes.number,
+    slug: PropTypes.string,
+    name: PropTypes.string,
+  }).isRequired,
+  onChange: PropTypes.func.isRequired,
+  termIds: PropTypes.arrayOf(PropTypes.number),
+};
+
+export default TaxonomyItem;

--- a/packages/stories-block/src/block/edit.js
+++ b/packages/stories-block/src/block/edit.js
@@ -29,6 +29,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { BlockIcon } from './icons';
 import SingleStoryEmbed from './block-types/single-story/edit';
+import SingleStoryEmbedInLoop from './block-types/single-story/editInLoop';
 import StoriesBlockControls from './components/storiesBlockControls';
 import BlockConfigurationPanel from './components/storiesBlockConfigurationPanel';
 import LatestStoriesEdit from './block-types/latest-stories/edit';
@@ -60,7 +61,7 @@ function WebStoriesEdit({
     'web-story' === postType
   ) {
     return (
-      <SingleStoryEmbed
+      <SingleStoryEmbedInLoop
         icon={<BlockIcon />}
         attributes={attributes}
         setAttributes={setAttributes}

--- a/packages/stories-block/src/block/edit.js
+++ b/packages/stories-block/src/block/edit.js
@@ -41,8 +41,35 @@ import {
   VIEW_TYPES,
 } from './constants';
 
-function WebStoriesEdit({ attributes, setAttributes, className, isSelected }) {
+function WebStoriesEdit({
+  attributes,
+  setAttributes,
+  className,
+  isSelected,
+  context,
+}) {
   const { blockType, viewType } = attributes;
+  const { postType, postId, queryId } = context;
+
+  const isDescendentOfQueryLoop = Number.isFinite(queryId);
+
+  if (
+    isDescendentOfQueryLoop &&
+    postType &&
+    postId &&
+    'web-story' === postType
+  ) {
+    return (
+      <SingleStoryEmbed
+        icon={<BlockIcon />}
+        attributes={attributes}
+        setAttributes={setAttributes}
+        context={context}
+        className={className}
+        isSelected={isSelected}
+      />
+    );
+  }
 
   if (!blockType) {
     return (
@@ -129,6 +156,11 @@ WebStoriesEdit.propTypes = {
   setAttributes: PropTypes.func.isRequired,
   className: PropTypes.string.isRequired,
   isSelected: PropTypes.bool,
+  context: PropTypes.shape({
+    postType: PropTypes.string,
+    postId: PropTypes.number,
+    queryId: PropTypes.number,
+  }),
 };
 
 export default WebStoriesEdit;

--- a/packages/stories-block/src/css/common.css
+++ b/packages/stories-block/src/css/common.css
@@ -97,6 +97,7 @@
   );
   top: 0;
   left: 0;
+  pointer-events: none;
 }
 
 .web-stories-list__story-content-overlay {

--- a/packages/stories-block/src/css/embed.css
+++ b/packages/stories-block/src/css/embed.css
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@import 'singleton.css';
+
 .web-stories-embed.alignnone,
 .web-stories-embed.alignleft,
 .web-stories-embed.alignright {

--- a/packages/stories-block/src/css/lightbox.css
+++ b/packages/stories-block/src/css/lightbox.css
@@ -4,7 +4,8 @@
   overflow-y: hidden;
 }
 
-.web-stories-list__lightbox {
+.web-stories-list__lightbox,
+.web-stories-singleton__lightbox {
   justify-content: center;
   align-items: center;
   position: fixed;
@@ -19,16 +20,19 @@
 
 /* amp-lightbox needs to have z-index to render on top of other elements in the page. */
 .web-stories-list__lightbox-wrapper amp-lightbox,
-.web-stories-list__lightbox.show {
+.web-stories-list__lightbox.show,
+.web-stories-singleton__lightbox.show {
   z-index: 999999999;
 }
 
-.web-stories-list__lightbox.show {
+.web-stories-list__lightbox.show,
+.web-stories-singleton__lightbox.show {
   transform: translate(0, 0);
   opacity: 1;
 }
 
-.web-stories-list__lightbox amp-story-player {
+.web-stories-list__lightbox amp-story-player,
+.web-stories-singleton__lightbox amp-story-player {
   width: 100%;
   height: 100%;
 }
@@ -67,6 +71,7 @@
  * because of the 'a' links. Making 'a' absolutely positioned removes them from normal
  * relative flow, removes the space.
  */
+html:not([amp]) .web-stories-singleton__lightbox amp-story-player a,
 html:not([amp])
   .web-stories-list
   .web-stories-list__lightbox
@@ -76,7 +81,8 @@ html:not([amp])
 }
 
 @media all and (min-width: 676px) {
-  .admin-bar .web-stories-list__lightbox {
+  .admin-bar .web-stories-list__lightbox,
+  .admin-bar .web-stories-singleton__lightbox {
     top: 46px;
   }
 
@@ -92,7 +98,8 @@ html:not([amp])
 }
 
 @media all and (min-width: 783px) {
-  .admin-bar .web-stories-list__lightbox {
+  .admin-bar .web-stories-list__lightbox,
+  .admin-bar .web-stories-singleton__lightbox {
     top: 32px;
   }
 }

--- a/packages/stories-block/src/css/singleton.css
+++ b/packages/stories-block/src/css/singleton.css
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.web-stories-singleton.alignnone,
+.web-stories-singleton.alignleft,
+.web-stories-singleton.alignright {
+  display: block;
+  width: 100%;
+}
+
+.web-stories-singleton.aligncenter {
+  text-align: initial;
+}
+
+.web-stories-singleton .wp-block-embed__wrapper {
+  position: relative;
+}
+
+.web-stories-singleton.alignleft .wp-block-embed__wrapper {
+  margin-right: auto;
+}
+
+.web-stories-singleton.alignright .wp-block-embed__wrapper {
+  margin-left: auto;
+}
+
+.web-stories-singleton.alignnone .wp-block-embed__wrapper {
+  max-width: var(--width);
+}
+
+.web-stories-singleton.aligncenter .wp-block-embed__wrapper {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: var(--width);
+}
+
+/* Curved corners by default.*/
+.web-stories-singleton-poster {
+  position: relative;
+  aspect-ratio: var(--aspect-ratio);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.web-stories-singleton-poster a {
+  display: block;
+  margin: 0;
+  aspect-ratio: var(--aspect-ratio);
+}
+
+.web-stories-singleton-poster .web-stories-singleton-poster-placeholder {
+  box-sizing: border-box;
+}
+
+/*
+  We want the placeholder to be clickable but hidden from screen readers.
+  This improves the no-js experience.
+  In the block edit component, placeholders are not links.
+*/
+.web-stories-singleton-poster .web-stories-singleton-poster-placeholder a,
+.web-stories-singleton-poster .web-stories-singleton-poster-placeholder span {
+  border: 0;
+  clip: rect(1px, 1px, 1px, 1px);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute !important;
+  width: 1px;
+  word-wrap: normal !important;
+  word-break: normal;
+}
+
+.web-stories-singleton-poster img {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  box-sizing: border-box;
+}
+
+.web-stories-singleton-poster::after {
+  content: '';
+  display: block;
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0) 0%,
+    rgba(0, 0, 0, 0.8) 100%
+  );
+  top: 0;
+  left: 0;
+  pointer-events: none;
+}
+
+.web-stories-singleton .web-stories-singleton-overlay {
+  padding: 10px;
+  line-height: var(--ws-overlay-text-lh);
+  position: absolute;
+  bottom: 0;
+  color: var(--ws-overlay-text-color);
+  z-index: 1;
+}

--- a/tests/phpunit/integration/tests/Block/Web_Stories_Block.php
+++ b/tests/phpunit/integration/tests/Block/Web_Stories_Block.php
@@ -21,6 +21,7 @@ declare(strict_types = 1);
 namespace Google\Web_Stories\Tests\Integration\Block;
 
 use Google\Web_Stories\Tests\Integration\DependencyInjectedTestCase;
+use WP_Block;
 use WP_Block_Type_Registry;
 
 /**
@@ -63,7 +64,9 @@ class Web_Stories_Block extends DependencyInjectedTestCase {
 				'align'  => 'none',
 				'width'  => 360,
 				'height' => 600,
-			]
+			],
+			'',
+			new WP_Block( [ 'blockName' => 'web-stories/embed' ] )
 		);
 
 		$this->assertStringContainsString( '<amp-story-player', $actual );
@@ -83,7 +86,9 @@ class Web_Stories_Block extends DependencyInjectedTestCase {
 				'align'  => 'none',
 				'width'  => 360,
 				'height' => 600,
-			]
+			],
+			'',
+			new WP_Block( [ 'blockName' => 'web-stories/embed' ] )
 		);
 
 		$this->assertEmpty( $actual );
@@ -103,7 +108,9 @@ class Web_Stories_Block extends DependencyInjectedTestCase {
 				'align'  => 'none',
 				'width'  => 360,
 				'height' => 600,
-			]
+			],
+			'',
+			new WP_Block( [ 'blockName' => 'web-stories/embed' ] )
 		);
 
 		$this->assertStringContainsString( __( 'Web Story', 'web-stories' ), $actual );
@@ -123,7 +130,9 @@ class Web_Stories_Block extends DependencyInjectedTestCase {
 				'url'   => 'https://example.com/story.html',
 				'title' => 'Example Story',
 				'align' => 'none',
-			]
+			],
+			'',
+			new WP_Block( [ 'blockName' => 'web-stories/embed' ] )
 		);
 
 		$this->assertStringNotContainsString( '<amp-story-player', $actual );
@@ -147,7 +156,9 @@ class Web_Stories_Block extends DependencyInjectedTestCase {
 				'align'  => 'none',
 				'width'  => 360,
 				'height' => 600,
-			]
+			],
+			'',
+			new WP_Block( [ 'blockName' => 'web-stories/embed' ] )
 		);
 
 		$this->assertStringNotContainsString( '<amp-story-player', $actual );


### PR DESCRIPTION
* Improve Query Loop block support
* Allow filtering Latest Stories by taxonomies (See #8897)
* Support embedding single stories with a poster/preview that opens a lightbox upon clicking (Fixes #6894)
* Update URL in address bar when opening lightbox (Fixes #12999)

