### PR TITLE
Dashboard: Add update notification banner

### DIFF
--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -50,6 +50,9 @@ jobs:
             github.com:443
             objects.githubusercontent.com:443
             packagist.org:443
+            repo.packagist.org:443
+            getcomposer.org:443
+            dl.cloudsmith.io:443
 
       - name: Checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -95,6 +95,8 @@ jobs:
             raw.github.com:443
             repo.packagist.org:443
             wordpress.org:443
+            getcomposer.org:443
+            dl.cloudsmith.io:443
 
       - name: Checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c

--- a/includes/Admin/Dashboard.php
+++ b/includes/Admin/Dashboard.php
@@ -469,6 +469,16 @@ class Dashboard extends Service_Base {
 		$auto_advance  = $this->settings->get_setting( $this->settings::SETTING_NAME_AUTO_ADVANCE );
 		$page_duration = $this->settings->get_setting( $this->settings::SETTING_NAME_DEFAULT_PAGE_DURATION );
 
+		$plugin_file          = plugin_basename( WEBSTORIES_PLUGIN_FILE );
+		$auto_updates         = (array) get_site_option( 'auto_update_plugins', [] );
+		$auto_updates_enabled = \in_array( $plugin_file, $auto_updates, true );
+		$plugin_updates       = get_site_transient( 'update_plugins' );
+		$needs_update         = \is_object( $plugin_updates ) &&
+								property_exists( $plugin_updates, 'response' ) &&
+								\is_array( $plugin_updates->response ) &&
+								! empty( $plugin_updates->response[ $plugin_file ] );
+		$can_update           = current_user_can( 'update_plugins' );
+
 		$settings = [
 			'isRTL'                   => is_rtl(),
 			'userId'                  => get_current_user_id(),
@@ -504,6 +514,10 @@ class Dashboard extends Service_Base {
 			'plugins'                 => [
 				'siteKit'     => $this->site_kit->get_plugin_status(),
 				'woocommerce' => $this->woocommerce->get_plugin_status(),
+				'web-stories' => [
+					'needsUpdate' => $needs_update && ! $auto_updates_enabled,
+					'updateLink'  => $can_update ? admin_url( 'plugins.php' ) : null,
+				],
 			],
 			'flags'                   => array_merge(
 				$this->experiments->get_experiment_statuses( 'general' ),

--- a/includes/Integrations/Plugin_Status.php
+++ b/includes/Integrations/Plugin_Status.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Class Plugin_Status
+ *
+ * @link      https://github.com/googleforcreators/web-stories-wp
+ *
+ * @copyright 2023 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ */
+
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types = 1);
+
+namespace Google\Web_Stories\Integrations;
+
+/**
+ * Class Plugin_Status.
+ */
+class Plugin_Status {
+	/**
+	 * Array of arrays of plugin data, keyed by plugin file name.
+	 *
+	 * @see get_plugin_data()
+	 *
+	 * @var array<string, array<string, string|bool>>
+	 */
+	protected array $plugins = [];
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		$this->plugins = get_plugins();
+	}
+
+	/**
+	 * Retrieves all plugin files with plugin data.
+	 *
+	 * @since 1.30.0
+	 *
+	 * @return array<string, array<string, string|bool>>
+	 */
+	public function get_plugins(): array {
+		return $this->plugins;
+	}
+}

--- a/includes/Integrations/Plugin_Status.php
+++ b/includes/Integrations/Plugin_Status.php
@@ -28,6 +28,8 @@ declare(strict_types = 1);
 
 namespace Google\Web_Stories\Integrations;
 
+use function function_exists;
+
 /**
  * Class Plugin_Status.
  */

--- a/includes/Integrations/Site_Kit.php
+++ b/includes/Integrations/Site_Kit.php
@@ -58,14 +58,23 @@ class Site_Kit extends Service_Base {
 	private Context $context;
 
 	/**
+	 * Plugin_Status instance.
+	 *
+	 * @var Plugin_Status Plugin_Status instance.
+	 */
+	private Plugin_Status $plugin_status;
+
+	/**
 	 * Constructor.
 	 *
-	 * @param Analytics $analytics Analytics instance.
-	 * @param Context   $context   Context instance.
+	 * @param Analytics     $analytics     Analytics instance.
+	 * @param Context       $context       Context instance.
+	 * @param Plugin_Status $plugin_status Plugin_Status instance.
 	 */
-	public function __construct( Analytics $analytics, Context $context ) {
-		$this->analytics = $analytics;
-		$this->context   = $context;
+	public function __construct( Analytics $analytics, Context $context, Plugin_Status $plugin_status ) {
+		$this->analytics     = $analytics;
+		$this->context       = $context;
+		$this->plugin_status = $plugin_status;
 	}
 
 	/**
@@ -117,11 +126,7 @@ class Site_Kit extends Service_Base {
 	 * @return array{installed: bool, active: bool, analyticsActive: bool, adsenseActive: bool, analyticsLink: string, adsenseLink: string} Plugin status.
 	 */
 	public function get_plugin_status(): array {
-		if ( ! function_exists( 'get_plugins' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
-
-		$is_installed        = \array_key_exists( 'google-site-kit/google-site-kit.php', get_plugins() );
+		$is_installed        = \array_key_exists( 'google-site-kit/google-site-kit.php', $this->plugin_status->get_plugins() );
 		$is_active           = $this->is_plugin_active();
 		$is_analytics_active = $this->is_analytics_module_active();
 		$is_adsense_active   = $this->is_adsense_module_active();

--- a/includes/Integrations/WooCommerce.php
+++ b/includes/Integrations/WooCommerce.php
@@ -38,6 +38,22 @@ class WooCommerce {
 	protected const PLUGIN = 'woocommerce/woocommerce.php';
 
 	/**
+	 * Plugin_Status instance.
+	 *
+	 * @var Plugin_Status Plugin_Status instance.
+	 */
+	private Plugin_Status $plugin_status;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Plugin_Status $plugin_status Plugin_Status instance.
+	 */
+	public function __construct( Plugin_Status $plugin_status ) {
+		$this->plugin_status = $plugin_status;
+	}
+
+	/**
 	 * Returns the WooCommerce plugin status.
 	 *
 	 * @since 1.21.0
@@ -45,11 +61,7 @@ class WooCommerce {
 	 * @return array{installed: bool, active: bool, canManage: bool, link: string} Plugin status.
 	 */
 	public function get_plugin_status(): array {
-		if ( ! function_exists( 'get_plugins' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
-
-		$is_installed = \array_key_exists( self::PLUGIN, get_plugins() );
+		$is_installed = \array_key_exists( self::PLUGIN, $this->plugin_status->get_plugins() );
 		$is_active    = $this->is_plugin_active();
 		$can_manage   = false;
 		$link         = '';

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -182,6 +182,7 @@ class Plugin extends ServiceBasedPlugin {
 			Experiments::class,
 			Story_Post_Type::class,
 			Injector::class,
+			Integrations\Plugin_Status::class,
 			Integrations\Site_Kit::class,
 			Integrations\WooCommerce::class,
 			Media\Types::class,

--- a/packages/wp-dashboard/src/components/editorSettings/archive/index.js
+++ b/packages/wp-dashboard/src/components/editorSettings/archive/index.js
@@ -211,7 +211,6 @@ export default function ArchiveSettings({
                     rel="noreferrer"
                     target="_blank"
                     size={TextSize.Small}
-                    as="a"
                   />
                 ),
                 code: <code />,

--- a/packages/wp-dashboard/src/components/editorSettings/editorSettings.js
+++ b/packages/wp-dashboard/src/components/editorSettings/editorSettings.js
@@ -25,8 +25,10 @@ import {
   MIN_IMG_WIDTH,
   MIN_IMG_HEIGHT,
   useConfig,
+  StandardViewContentGutter,
 } from '@googleforcreators/dashboard';
 import { preloadImage } from '@googleforcreators/media';
+import styled from 'styled-components';
 
 /**
  * Internal dependencies
@@ -46,6 +48,8 @@ import useEditorSettings from './useEditorSettings';
 import CustomFontsSettings from './customFonts';
 import Shopping from './shopping';
 import PageAdvancement from './pageAdvancement';
+
+const BodyViewOptionsHeader = styled.div``;
 
 function EditorSettings() {
   const {
@@ -326,6 +330,9 @@ function EditorSettings() {
     <Layout.Provider>
       <Wrapper data-testid="editor-settings">
         <PageHeading heading={__('Settings', 'web-stories')} />
+        <StandardViewContentGutter>
+          <BodyViewOptionsHeader id="body-view-options-header" />
+        </StandardViewContentGutter>
         <Layout.Scrollable>
           <Main>
             {canManageSettings && (

--- a/packages/wp-dashboard/src/components/editorSettings/googleAnalytics/index.js
+++ b/packages/wp-dashboard/src/components/editorSettings/googleAnalytics/index.js
@@ -263,7 +263,6 @@ function GoogleAnalyticsSettings({
                     rel="noreferrer"
                     target="_blank"
                     size={TextSize.Small}
-                    as="a"
                     onClick={onContextClick}
                   />
                 ),

--- a/packages/wp-dashboard/src/components/layout/index.js
+++ b/packages/wp-dashboard/src/components/layout/index.js
@@ -24,6 +24,7 @@ import { InterfaceSkeleton } from '@googleforcreators/dashboard';
 import { useSyncAdminMenu } from '../../effects';
 import { EditorSettingsProvider, EditorSettings } from '../editorSettings';
 import TelemetryBanner from '../telemetryBanner';
+import UpdateBanner from '../updateBanner';
 import { EDITOR_SETTINGS_ROUTE } from '../../constants';
 
 function Layout() {
@@ -40,6 +41,7 @@ function Layout() {
         ]}
       />
       <TelemetryBanner />
+      <UpdateBanner />
     </EditorSettingsProvider>
   );
 }

--- a/packages/wp-dashboard/src/components/updateBanner/index.js
+++ b/packages/wp-dashboard/src/components/updateBanner/index.js
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+import {
+  useRef,
+  useEffect,
+  createPortal,
+  useState,
+  useCallback,
+} from '@googleforcreators/react';
+import { __, TranslateWithMarkup } from '@googleforcreators/i18n';
+import {
+  Banner,
+  Link,
+  localStore,
+  Text,
+} from '@googleforcreators/design-system';
+import {
+  APP_ROUTES,
+  useRouteHistory,
+  useConfig,
+} from '@googleforcreators/dashboard';
+
+/**
+ * Internal dependencies
+ */
+import useTelemetryOptIn from '../../effects/useTelemetryOptIn';
+import { EDITOR_SETTINGS_ROUTE } from '../../constants';
+
+const StyledBanner = styled(Banner)`
+  background: ${({ theme }) => theme.colors.interactiveBg.brandNormal};
+`;
+
+const StyledLink = styled(Link)`
+  color: ${({ theme }) => theme.colors.interactiveFg.brandNormal};
+  text-decoration: underline;
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.interactiveFg.brandHover};
+  }
+
+  &:focus {
+    color: ${({ theme }) => theme.colors.interactiveFg.brandPress};
+  }
+`;
+
+function NoLink({ children }) {
+  return children;
+}
+
+// The value associated with this key indicates if the user has interacted with
+// the banner previously. If they have, we do not show the banner again for 2 days.
+const LOCAL_STORAGE_KEY = 'web_stories_update_banner_closed';
+
+function getStateFromLocalStorage() {
+  const storageValue = localStore.getItemByKey(LOCAL_STORAGE_KEY);
+
+  if (!storageValue) {
+    return true;
+  }
+
+  if (new Date().getTime() > storageValue) {
+    localStore.setItemByKey(LOCAL_STORAGE_KEY, null);
+    return true;
+  }
+
+  return false;
+}
+
+export function UpdateBannerContainer() {
+  const { bannerVisible: hasTelemetryBanner } = useTelemetryOptIn();
+  const {
+    plugins: { 'web-stories': webStories = {} },
+  } = useConfig();
+  const { needsUpdate, updateLink } = webStories;
+
+  const ref = useRef();
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    setIsVisible(getStateFromLocalStorage() && needsUpdate);
+  }, [needsUpdate]);
+
+  const onClose = useCallback(() => {
+    const dayInMs = 8.64e7;
+    const expiry = new Date().getTime() + 2 * dayInMs;
+    localStore.setItemByKey(LOCAL_STORAGE_KEY, expiry);
+    setIsVisible(false);
+  }, []);
+
+  if (!isVisible) {
+    return null;
+  }
+
+  if (hasTelemetryBanner) {
+    return null;
+  }
+
+  const UpdateLink = updateLink ? StyledLink : NoLink;
+
+  return (
+    <StyledBanner
+      closeButtonLabel={__('Dismiss update notification', 'web-stories')}
+      onClose={onClose}
+      title={__('Update available.', 'web-stories')}
+      ref={ref}
+    >
+      <Text.Paragraph>
+        <TranslateWithMarkup
+          mapping={{
+            a: <UpdateLink href={updateLink} />,
+          }}
+        >
+          {__(
+            'A new version of the plugin is available. <a>Please update now</a>.',
+            'web-stories'
+          )}
+        </TranslateWithMarkup>
+      </Text.Paragraph>
+    </StyledBanner>
+  );
+}
+
+export default function UpdateBanner() {
+  const { currentPath, hasAvailableRoutes } = useRouteHistory(({ state }) => ({
+    currentPath: state.currentPath,
+    hasAvailableRoutes: state.availableRoutes.length > 0,
+  }));
+  const headerEl = useRef(null);
+  const [, forceUpdate] = useState(false);
+
+  useEffect(() => {
+    if (!hasAvailableRoutes) {
+      return;
+    }
+
+    if (
+      [
+        APP_ROUTES.DASHBOARD,
+        APP_ROUTES.TEMPLATES_GALLERY,
+        EDITOR_SETTINGS_ROUTE,
+      ].includes(currentPath)
+    ) {
+      headerEl.current = document.getElementById('body-view-options-header');
+      forceUpdate((value) => !value);
+    }
+  }, [currentPath, hasAvailableRoutes]);
+
+  if (!headerEl.current) {
+    return null;
+  }
+
+  return createPortal(<UpdateBannerContainer />, headerEl.current);
+}

--- a/tests/phpunit/integration/tests/Integrations/Site_Kit.php
+++ b/tests/phpunit/integration/tests/Integrations/Site_Kit.php
@@ -22,6 +22,7 @@ namespace Google\Web_Stories\Tests\Integration\Integrations;
 
 use Google\Web_Stories\Analytics;
 use Google\Web_Stories\Context;
+use Google\Web_Stories\Integrations\Plugin_Status;
 use Google\Web_Stories\Story_Post_Type;
 use Google\Web_Stories\Tests\Integration\DependencyInjectedTestCase;
 
@@ -126,7 +127,8 @@ class Site_Kit extends DependencyInjectedTestCase {
 
 		$this->instance = new \Google\Web_Stories\Integrations\Site_Kit(
 			$analytics,
-			$this->injector->make( Context::class )
+			$this->injector->make( Context::class ),
+			$this->injector->make( Plugin_Status::class )
 		);
 		$actual         = $this->instance->filter_site_kit_gtag_opt( $gtag );
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

Maybe this gets a bit more people to update. Not perfect, but it's a start.

## Summary

<!-- A brief description of what this PR does. -->

Adds a simple update notification banner to the dashboard if a new version of the plugin is available. If hidden, it reappears after 2 days.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

![Screenshot 2023-02-15 at 13 59 09](https://user-images.githubusercontent.com/841956/219035992-93b21042-2f07-401f-8246-687fa51614ca.png)
![Screenshot 2023-02-15 at 13 59 20](https://user-images.githubusercontent.com/841956/219035999-966db363-ef90-4ec2-af5a-66814afa7e50.png)


## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
