### PR TITLE
Telemetry: complete GA4 migration

### DIFF
--- a/packages/tracking/README.md
+++ b/packages/tracking/README.md
@@ -2,7 +2,7 @@
 
 Helper library for interacting with Google Events to track page/screen views and events.
 
-Supports both Universal Analytics (`gtag.js`) as well as Google Analytics 4
+Supports only Google Analytics 4
 
 ## Usage
 
@@ -60,7 +60,7 @@ trackError('demo', 'Division by zero', false);
 
 At the core of this package is the `trackEvent` function.
 
-All you need to provide is the event name (aka event action in Universal Analyticcs), and as many optional event parameters as you want:
+All you need to provide is the event name and as many optional event parameters as you want:
 
 ```js
 trackEvent('insert_template', {
@@ -70,27 +70,10 @@ template_name: 'Awesome Template',
 
 ### User Timings
 
-`gtag.js` supports sending [user timing information](https://developers.google.com/analytics/devguides/collection/gtagjs/user-timings) to Google Analytics.
-You can do so using the following helper function which will start a timer and return a callback to stop it:
+Use the following helper function to start a timer and return a callback to stop it:
 
 ```js
-const trackTiming = getTimeTracker('video_transcoding');
+const trackTiming = getTimeTracker('video_transcoding'); // Start timer.
 // Perform some long task...
-trackTiming();
+trackTiming(); // Stop timer and send event.
 ```
-
-## Custom Dimensions
-
-While Google Analytics 4 supports any arbitrary custom event parameters, the Universal Analytics (`gtag.js`) configuration currently only supports the following custom dimensions:
-
-* `order`
-* `orderby`
-* `file_size`
-* `file_type`
-* `status`
-* `name`
-* `duration`
-* `duration`
-* `title_length`
-* `unread_count`
-* `template_id`

--- a/packages/tracking/src/enableTracking.ts
+++ b/packages/tracking/src/enableTracking.ts
@@ -47,7 +47,7 @@ async function loadTrackingScript(sendPageView = true): Promise<void> {
 
   try {
     await loadScriptTag(
-      `https://www.googletagmanager.com/gtag/js?id=${config.trackingId}&l=${DATA_LAYER}`
+      `https://www.googletagmanager.com/gtag/js?id=${config.trackingIdGA4}&l=${DATA_LAYER}`
     );
   } catch {
     // Loading was not possible, probably because of an ad blocker.
@@ -66,64 +66,25 @@ async function loadTrackingScript(sendPageView = true): Promise<void> {
   // Note: `set` commands need to be placed before `config` commands to ensure
   // those values are passed along with the initial config.
 
-  // Universal Analytics custom dimensions.
-  gtag('set', {
-    custom_map: {
-      dimension1: 'analytics',
-      dimension2: 'adNetwork',
-      dimension3: 'search_order',
-      dimension4: 'search_orderby',
-      dimension5: 'file_size',
-      dimension6: 'file_type',
-      dimension7: 'status',
-      dimension8: 'siteLocale',
-      dimension9: 'userLocale',
-      dimension10: 'userRole',
-      dimension11: 'enabledExperiments',
-      dimension12: 'wpVersion',
-      dimension13: 'phpVersion',
-      dimension14: 'isMultisite',
-      dimension15: 'name',
-      dimension16: 'activePlugins',
-      dimension20: 'serverEnvironment',
-    },
-  });
-
   // Google Analytics 4 user properties.
   // See https://developers.google.com/analytics/devguides/collection/ga4/persistent-values
   // See https://developers.google.com/analytics/devguides/collection/ga4/user-properties
   gtag('set', 'user_properties', {
     ...config.userProperties,
     app_version: config.appVersion,
-  });
-
-  gtag('config', config.trackingId, {
-    anonymize_ip: true,
-    app_name: config.appName,
-    app_version: config.appVersion,
-    send_page_view: sendPageView,
-    // Setting the transport method to 'beacon' lets the hit be sent
-    // using 'navigator.sendBeacon' in browsers that support it.
-    transport_type: 'beacon',
     page_title: pageTitle,
     page_path: pagePath,
-    // Re-using user properties values for the custom dimensions.
-    ...config.userProperties,
   });
 
-  // Support GA4 in parallel.
-  // At some point, only this will remain.
   gtag('config', config.trackingIdGA4, {
     app_name: config.appName,
-    // This doesn't seem to be fully working for web properties.
+    // Not really supported for web properties, but passed for completeness.
     // See https://support.google.com/analytics/answer/9268042
     app_version: config.appVersion,
     send_page_view: sendPageView,
     // Setting the transport method to 'beacon' lets the hit be sent
     // using 'navigator.sendBeacon' in browsers that support it.
     transport_type: 'beacon',
-    page_title: pageTitle,
-    page_path: pagePath,
   });
 }
 

--- a/packages/tracking/src/getTimeTracker.ts
+++ b/packages/tracking/src/getTimeTracker.ts
@@ -18,12 +18,9 @@
  * Internal dependencies
  */
 import trackEvent from './trackEvent';
-import { config } from './shared';
 
 /**
  * Starts a timer and returns a callback to stop it and send an analytics timing_complete event.
- *
- * Works for both Universal Analytics and Google Analytics 4.
  *
  * @see https://developers.google.com/analytics/devguides/collection/gtagjs/user-timings
  * @param eventName The event nae (e.g. 'load_items').
@@ -35,16 +32,8 @@ function getTimeTracker(eventName: string): () => void {
     const after = window.performance.now();
     const value = after - before;
 
-    // Universal Analytics has a special `timing_complete` event which
-    // does not exist in GA4.
-    void trackEvent('timing_complete', {
-      name: eventName,
-      value,
-      send_to: config.trackingId,
-    });
     void trackEvent(eventName, {
       value,
-      send_to: config.trackingIdGA4,
     });
   };
 }

--- a/packages/tracking/src/shared.ts
+++ b/packages/tracking/src/shared.ts
@@ -32,7 +32,6 @@ interface ConfigParams {
 
 export interface ControlParams {
   groups?: string | string[] | undefined;
-  send_to?: string | string[] | undefined;
   event_callback?: (() => void) | undefined;
   event_timeout?: number | undefined;
 }
@@ -40,7 +39,6 @@ export interface ControlParams {
 export interface EventParameters {
   name?: string;
   value?: string | number;
-  send_to?: string | number;
   search_type?: string;
   duration?: number;
   title_length?: number;
@@ -86,10 +84,6 @@ interface TrackingConfig {
    */
   trackingEnabled?: boolean;
   /**
-   * Tracking ID.
-   */
-  trackingId: string;
-  /**
    * GA4 tracking ID.
    */
   trackingIdGA4: string;
@@ -131,24 +125,17 @@ export const gtag: Gtag = function (): void {
 const DEFAULT_CONFIG = {
   trackingAllowed: false,
   trackingEnabled: false,
-  trackingId: '',
   trackingIdGA4: '',
   userProperties: {},
   appName: '',
 };
 
-const {
-  trackingAllowed,
-  trackingId,
-  trackingIdGA4,
-  appVersion,
-  userProperties,
-} = window.webStoriesTrackingSettings || {};
+const { trackingAllowed, trackingIdGA4, appVersion, userProperties } =
+  window.webStoriesTrackingSettings || {};
 
 export const config: TrackingConfig = {
   ...DEFAULT_CONFIG,
   trackingAllowed,
-  trackingId,
   trackingIdGA4,
   appVersion,
   userProperties,

--- a/packages/tracking/src/test/getTimeTracker.ts
+++ b/packages/tracking/src/test/getTimeTracker.ts
@@ -41,21 +41,14 @@ describe('getTimeTracker', () => {
     config.appName = 'Foo App';
     config.trackingAllowed = true;
     config.trackingEnabled = true;
-    config.trackingId = 'UA-12345678-1';
     config.trackingIdGA4 = 'G-ABC1234567';
 
     const trackTime = getTimeTracker('load_dependencies');
     trackTime();
 
-    expect(trackEvent).toHaveBeenCalledTimes(2);
-    expect(trackEvent).toHaveBeenNthCalledWith(1, 'timing_complete', {
-      name: 'load_dependencies',
+    expect(trackEvent).toHaveBeenCalledOnce();
+    expect(trackEvent).toHaveBeenNthCalledWith(1, 'load_dependencies', {
       value: 50,
-      send_to: 'UA-12345678-1',
-    });
-    expect(trackEvent).toHaveBeenNthCalledWith(2, 'load_dependencies', {
-      value: 50,
-      send_to: 'G-ABC1234567',
     });
   });
 });

--- a/packages/tracking/src/test/initializeTracking.ts
+++ b/packages/tracking/src/test/initializeTracking.ts
@@ -24,11 +24,11 @@ import initializeTracking from '../initializeTracking';
 
 describe('initializeTracking', () => {
   afterEach(() => {
-    config.trackingId = '';
+    config.trackingIdGA4 = '';
   });
 
   it('sets app name in config', async () => {
-    config.trackingId = '1234567';
+    config.trackingIdGA4 = '1234567';
     await initializeTracking('Foo App');
 
     expect(config.appName).toBe('Foo App');

--- a/packages/tracking/src/test/trackError.ts
+++ b/packages/tracking/src/test/trackError.ts
@@ -36,7 +36,7 @@ describe('trackError', () => {
     config.trackingEnabled = true;
     const error = new Error('mock error');
 
-    jest.mocked(gtag).mockImplementationOnce((_type, _eventName, eventData) => {
+    jest.mocked(gtag).mockImplementation((_type, _eventName, eventData) => {
       (eventData as ControlParams).event_callback?.();
     });
     await trackError('test_error', error.message, true);

--- a/packages/tracking/src/test/trackEvent.ts
+++ b/packages/tracking/src/test/trackEvent.ts
@@ -35,7 +35,7 @@ describe('trackEvent', () => {
     config.trackingAllowed = true;
     config.trackingEnabled = true;
 
-    jest.mocked(gtag).mockImplementationOnce((_type, _eventName, eventData) => {
+    jest.mocked(gtag).mockImplementation((_type, _eventName, eventData) => {
       (eventData as ControlParams).event_callback?.();
     });
 
@@ -58,10 +58,9 @@ describe('trackEvent', () => {
   it('sends two different tracking events for backwards compatibility', async () => {
     config.trackingAllowed = true;
     config.trackingEnabled = true;
-    config.trackingId = 'UA-12345678-1';
     config.trackingIdGA4 = 'G-ABC1234567';
 
-    jest.mocked(gtag).mockImplementationOnce((_type, _eventName, eventData) => {
+    jest.mocked(gtag).mockImplementation((_type, _eventName, eventData) => {
       (eventData as ControlParams).event_callback?.();
     });
 
@@ -79,43 +78,19 @@ describe('trackEvent', () => {
     });
     expect(gtag).toHaveBeenNthCalledWith(1, 'event', 'name', {
       event_callback: expect.any(Function) as () => void,
-      event_label: 'abc',
-      send_to: config.trackingId,
+      search_type: 'abc',
     });
     expect(gtag).toHaveBeenNthCalledWith(2, 'event', 'name', {
       event_callback: expect.any(Function) as () => void,
-      search_type: 'abc',
-      send_to: config.trackingIdGA4,
+      duration: 123,
     });
     expect(gtag).toHaveBeenNthCalledWith(3, 'event', 'name', {
       event_callback: expect.any(Function) as () => void,
-      value: 123,
-      send_to: config.trackingId,
+      title_length: 123,
     });
     expect(gtag).toHaveBeenNthCalledWith(4, 'event', 'name', {
       event_callback: expect.any(Function) as () => void,
-      duration: 123,
-      send_to: config.trackingIdGA4,
-    });
-    expect(gtag).toHaveBeenNthCalledWith(5, 'event', 'name', {
-      event_callback: expect.any(Function) as () => void,
-      value: 123,
-      send_to: config.trackingId,
-    });
-    expect(gtag).toHaveBeenNthCalledWith(6, 'event', 'name', {
-      event_callback: expect.any(Function) as () => void,
-      title_length: 123,
-      send_to: config.trackingIdGA4,
-    });
-    expect(gtag).toHaveBeenNthCalledWith(7, 'event', 'name', {
-      event_callback: expect.any(Function) as () => void,
-      value: 123,
-      send_to: config.trackingId,
-    });
-    expect(gtag).toHaveBeenNthCalledWith(8, 'event', 'name', {
-      event_callback: expect.any(Function) as () => void,
       unread_count: 123,
-      send_to: config.trackingIdGA4,
     });
   });
 });

--- a/packages/tracking/src/test/trackScreenView.ts
+++ b/packages/tracking/src/test/trackScreenView.ts
@@ -34,9 +34,8 @@ describe('trackScreenView', () => {
   it('adds a tracking event to the dataLayer', async () => {
     config.trackingAllowed = true;
     config.trackingEnabled = true;
-    config.trackingId = 'UA-12345678-1';
 
-    jest.mocked(gtag).mockImplementationOnce((_type, _eventName, eventData) => {
+    jest.mocked(gtag).mockImplementation((_type, _eventName, eventData) => {
       (eventData as ControlParams).event_callback?.();
     });
 

--- a/packages/tracking/src/test/trackTiming.ts
+++ b/packages/tracking/src/test/trackTiming.ts
@@ -41,24 +41,15 @@ describe('trackTiming', () => {
     config.appName = 'Foo App';
     config.trackingAllowed = true;
     config.trackingEnabled = true;
-    config.trackingId = 'UA-12345678-1';
     config.trackingIdGA4 = 'G-ABC1234567';
 
     trackTiming('page', 50, 'carousel_navigate', 'click');
 
-    expect(trackEvent).toHaveBeenCalledTimes(2);
-    expect(trackEvent).toHaveBeenNthCalledWith(1, 'timing_complete', {
-      name: 'click',
+    expect(trackEvent).toHaveBeenCalledOnce();
+    expect(trackEvent).toHaveBeenNthCalledWith(1, 'click', {
       event_category: 'page',
       event_label: 'carousel_navigate',
       value: 50,
-      send_to: 'UA-12345678-1',
-    });
-    expect(trackEvent).toHaveBeenNthCalledWith(2, 'click', {
-      event_category: 'page',
-      event_label: 'carousel_navigate',
-      value: 50,
-      send_to: 'G-ABC1234567',
     });
   });
 });

--- a/packages/tracking/src/trackClick.ts
+++ b/packages/tracking/src/trackClick.ts
@@ -28,8 +28,6 @@ import track from './track';
 /**
  * Send an Analytics tracking event for clicks.
  *
- * Works for both Universal Analytics and Google Analytics 4.
- *
  * @see https://developers.google.com/analytics/devguides/collection/gtagjs/events
  * @param event The actual click event.
  * @param eventName The event name (e.g. 'search').

--- a/packages/tracking/src/trackError.ts
+++ b/packages/tracking/src/trackError.ts
@@ -23,8 +23,6 @@ import track from './track';
 /**
  * Send an Analytics tracking event for exceptions.
  *
- * Works for both Universal Analytics and Google Analytics 4.
- *
  * @see https://developers.google.com/analytics/devguides/collection/ga4/exceptions
  * @see https://developers.google.com/analytics/devguides/collection/gtagjs/exceptions
  * @param prefix Error prefixed. Concatenated with description.

--- a/packages/tracking/src/trackEvent.ts
+++ b/packages/tracking/src/trackEvent.ts
@@ -17,7 +17,6 @@
 /**
  * Internal dependencies
  */
-import { config } from './shared';
 import type { EventParameters } from './shared';
 import isTrackingEnabled from './isTrackingEnabled';
 import track from './track';
@@ -39,45 +38,6 @@ async function trackEvent(
   eventParameters: EventParameters = {}
 ): Promise<void> {
   if (!(await isTrackingEnabled())) {
-    return Promise.resolve();
-  }
-
-  let gtagEventParameters = {};
-
-  // Universal Analytics backwards compatibility.
-  const { search_type, duration, title_length, unread_count, ...rest } =
-    eventParameters;
-  if (search_type) {
-    gtagEventParameters = {
-      ...rest,
-      event_label: search_type,
-    };
-  } else if (duration) {
-    gtagEventParameters = {
-      ...rest,
-      value: duration,
-    };
-  } else if (title_length) {
-    gtagEventParameters = {
-      ...rest,
-      value: title_length,
-    };
-  } else if (unread_count) {
-    gtagEventParameters = {
-      ...rest,
-      value: unread_count,
-    };
-  }
-
-  if (Object.values(gtagEventParameters).length) {
-    void track(eventName, {
-      ...gtagEventParameters,
-      send_to: config.trackingId,
-    });
-    void track(eventName, {
-      ...eventParameters,
-      send_to: config.trackingIdGA4,
-    });
     return Promise.resolve();
   }
 

--- a/packages/tracking/src/trackScreenView.ts
+++ b/packages/tracking/src/trackScreenView.ts
@@ -23,8 +23,6 @@ import isTrackingEnabled from './isTrackingEnabled';
 /**
  * Send an Analytics screen_view event.
  *
- * Works for both Universal Analytics and Google Analytics 4.
- *
  * @see https://developers.google.com/analytics/devguides/collection/gtagjs/screens
  * @see https://developers.google.com/analytics/devguides/collection/ga4/screen-view
  * @param screenName Screen name. Example: 'Explore Templates'.

--- a/packages/tracking/src/trackTiming.ts
+++ b/packages/tracking/src/trackTiming.ts
@@ -18,7 +18,6 @@
  * Internal dependencies
  */
 import trackEvent from './trackEvent';
-import { config } from './shared';
 
 /**
  * Track event timing for performance measuring.
@@ -34,20 +33,10 @@ function trackTiming(
   label = '',
   eventName = 'click'
 ): void {
-  // Universal Analytics has a special `timing_complete` event which
-  // does not exist in GA4.
-  void trackEvent('timing_complete', {
-    name: eventName,
-    value: time,
-    event_category: category,
-    event_label: label,
-    send_to: config.trackingId,
-  });
   void trackEvent(eventName, {
     value: time,
     event_category: category,
     event_label: label,
-    send_to: config.trackingIdGA4,
   });
 }
 


### PR DESCRIPTION
For the longest time we have been using UA and GA4 in parallel to make migration easier at some point.

Since UA will [stop processing data](https://support.google.com/analytics/answer/11583528) on July 1, 2023, now is a good time to finally make the switch.

If anyone is stumbling upon this, **please note** that this has nothing to do with GA tracking for Web Stories in general. This change here is for the telemetry system in the admin so we can gather usage stats.