### PR TITLE
Canvas: Fix text element margin issue in page previews

### DIFF
--- a/packages/element-library/src/text/display.js
+++ b/packages/element-library/src/text/display.js
@@ -123,7 +123,7 @@ const FillElement = styled.p.attrs(
             fontSize: `${fontSize}px`,
             fontWeight,
             fontFamily: generateFontFamily(font),
-            margin: `${-dataToEditorY(marginOffset / 2)}px 0`,
+            margin: `${dataToEditorY(-marginOffset / 2)} 0`,
             padding: padding || 0,
             lineHeight,
             textAlign,


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
Solves issue #12829. Vertical margins for text elements( rotated or otherwise ) were not being applied.

## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

Before - 
The top of the T in "Title 1" is a little above the box on its left in the generated preview.
![Before-12829](https://user-images.githubusercontent.com/53055971/225520622-4ecede53-205f-49c5-810b-5d08f2e8fb94.png)

After - 
![After-12829](https://user-images.githubusercontent.com/53055971/225520679-c89a03a7-eb5f-4666-aaf2-26a69e4155cd.png)

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add a text element on the page.
2. Add a fill textbox to it with some vertical padding.
3. Duplicate the page. 
4. There should be no differences ( in terms of text box padding ) in the thumbnail and the current page  


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12829 
