### PR TITLE
Block: Fix selected stories not being visible 

### DIFF
--- a/packages/stories-block/src/block/components/storyPicker/fetchSelectedStories.js
+++ b/packages/stories-block/src/block/components/storyPicker/fetchSelectedStories.js
@@ -54,7 +54,13 @@ function FetchSelectedStories({
     // has some value after the request
     // is undefined if the entities requested does not exist
     if (data !== null && data !== undefined) {
+      //Entities found
       setSelectedStories(data);
+      setIsFetching(false);
+    }
+    if (data === undefined) {
+      //could not find entities
+      setSelectedStories([]);
       setIsFetching(false);
     }
   }, [data, setSelectedStories, setIsFetching]);

--- a/packages/stories-block/src/block/components/storyPicker/fetchSelectedStories.js
+++ b/packages/stories-block/src/block/components/storyPicker/fetchSelectedStories.js
@@ -25,7 +25,8 @@ import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Placeholder } from '@wordpress/components';
 import { BlockIcon } from '@wordpress/block-editor';
-import { useEntityRecords } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -39,23 +40,24 @@ function FetchSelectedStories({
   setSelectedStories,
   setIsFetching,
 }) {
-  const { records, isResolving, status } = useEntityRecords(
-    'postType',
-    'web-story',
-    {
+  const data = useSelect((select) => {
+    return select(coreStore).getEntityRecords('postType', 'web-story', {
       _embed: 'wp:featuredmedia,author',
       context: 'view',
       include: selectedStoryIds,
-    }
-  );
+      orderby: selectedStoryIds.length > 0 ? 'include' : undefined,
+    });
+  });
 
   useEffect(() => {
-    if (!isResolving && status === 'SUCCESS') {
-      // Done fetching stories
-      setSelectedStories(records);
+    // data is null before a response
+    // has some value after the request
+    // is undefined if the entities requested does not exist
+    if (data !== null && data !== undefined) {
+      setSelectedStories(data);
       setIsFetching(false);
     }
-  }, [isResolving, status, setSelectedStories, setIsFetching, records]);
+  }, [data, setSelectedStories, setIsFetching]);
 
   return (
     <Placeholder


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
After publishing a post with the Web Stories block selected stories were not visible. 

## Summary

<!-- A brief description of what this PR does. -->
~~This PR changes how selected stories are fetched. Now the `FetchSelectedStories` component uses [useEntityRecords](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-core-data/#useentityrecords) hook.~~

We can just `getEntityRecords` action here. The problem here was `isResolving` yields `false` for the first render which removes the `FetchSelectedStories` from the component tree.


## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #13067 
