### PR TITLE
Canvas: properly remove stale design space guideline

### DIFF
--- a/packages/story-editor/src/components/canvas/utils/useFullbleedMediaAsBackground.js
+++ b/packages/story-editor/src/components/canvas/utils/useFullbleedMediaAsBackground.js
@@ -29,7 +29,7 @@ import SAT from 'sat';
 /**
  * Internal dependencies
  */
-import { useStory, useCanvas } from '../../../app';
+import { useStory, useCanvas, useTransform } from '../../../app';
 import useElementPolygon from '../../../utils/useElementPolygon';
 
 function useFullbleedMediaAsBackground() {
@@ -51,6 +51,9 @@ function useFullbleedMediaAsBackground() {
       fullbleedContainer,
     })
   );
+  const { clearTransforms } = useTransform((state) => ({
+    clearTransforms: state.actions.clearTransforms,
+  }));
   const { showSnackbar } = useSnackbar();
   const getElementPolygon = useElementPolygon();
 
@@ -89,6 +92,7 @@ function useFullbleedMediaAsBackground() {
         );
         setIsBackgroundSnackbarMessageDismissed(true);
       }
+      clearTransforms();
     }
   };
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

<!-- A brief description of what this PR does. -->
Fixes Design space guideline not disappearing after an image is used as the page background by clearing all transforms using `clearTransforms` in `useFullbleedMediaAsBackground`

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #12828 
