### PR TITLE
CI: remove Percy

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     continue-on-error: ${{ matrix.experimental == true }}
-    needs: [build, nonce]
+    needs: [build]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -121,15 +121,6 @@ jobs:
           name: web-stories
           path: build/web-stories
 
-  nonce:
-    name: Percy Nonce
-    runs-on: ubuntu-latest
-    outputs:
-      result: ${{ env.result }}
-    steps:
-      - id: nonce
-        run: echo "result=${{ github.run_id }}-${{ github.run_attempt }}-$(date +%s)" >> $GITHUB_ENV
-
   e2e:
     name: '${{ matrix.browser }} - WP ${{ matrix.wp }} (${{ matrix.shard }})'
     runs-on: ubuntu-latest
@@ -215,24 +206,12 @@ jobs:
           AMP_VALIDATOR_FILE="${RUNNER_TEMP}/validator_wasm.js"
           echo "validator_file=$AMP_VALIDATOR_FILE" >> $GITHUB_ENV
 
-      - name: Run E2E tests with percy
-        run: npm run test:e2e:percy -- -- --shard=$SHARD
-        env:
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_E2E }}
-          WP_VERSION: ${{ matrix.wp }}
-          PERCY_BROWSER_EXECUTABLE: ${{ env.chromium_path }}
-          PERCY_PARALLEL_NONCE: ${{ needs.nonce.outputs.result }}
-          SHARD: ${{ matrix.shard }}
-          AMP_VALIDATOR_FILE: ${{ env.validator_file }}
-        if: ( matrix.snapshots ) && ( github.event.pull_request.draft == false )
-
       - name: Run E2E tests
         run: npm run test:e2e -- --shard=$SHARD
         env:
           WP_VERSION: ${{ matrix.wp }}
           SHARD: ${{ matrix.shard }}
           AMP_VALIDATOR_FILE: ${{ env.validator_file }}
-        if: ( ! matrix.snapshots ) || ( github.event.pull_request.draft == true )
 
       - name: Stop Docker environment
         run: npm run env:stop
@@ -247,44 +226,3 @@ jobs:
           name: failures-artifacts
           path: build/e2e-artifacts
           if-no-files-found: ignore
-
-  percy:
-    name: Percy
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    if: >
-      always() &&
-      github.event.pull_request.draft == false &&
-      github.event.pull_request.head.repo.fork == false &&
-      github.event.pull_request.user.login != 'dependabot[bot]'
-    needs: [e2e, nonce]
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@6b3083af2869dc3314a0257a42f4af696cc79ba3
-        with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            github.com:443
-            percy.io:443
-            registry.npmjs.org:443
-            storage.googleapis.com:443
-
-      - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
-
-      - name: Setup Node
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
-        with:
-          node-version-file: '.nvmrc'
-          cache: npm
-
-      - name: Install dependencies
-        run: npm install @percy/cli
-
-      - name: Finalize Percy build
-        run: npx percy build:finalize
-        env:
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_E2E }}
-          PERCY_PARALLEL_NONCE: ${{ needs.nonce.outputs.result }}

--- a/.github/workflows/tests-karma-dashboard.yml
+++ b/.github/workflows/tests-karma-dashboard.yml
@@ -41,15 +41,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  nonce:
-    name: Percy Nonce
-    runs-on: ubuntu-latest
-    outputs:
-      result: ${{ env.result }}
-    steps:
-      - id: nonce
-        run: echo "result=${{ github.run_id }}-${{ github.run_attempt }}-$(date +%s)" >> $GITHUB_ENV
-
   karma:
     name: Karma
     runs-on: ubuntu-latest
@@ -67,7 +58,6 @@ jobs:
             fonts.googleapis.com:443
             fonts.gstatic.com:443
             github.com:443
-            percy.io:443
             registry.npmjs.org:443
             storage.googleapis.com:443
             uploader.codecov.io:443
@@ -100,70 +90,13 @@ jobs:
           CHROMIUM=$(node -p "const puppeteer = require('puppeteer'); puppeteer.executablePath();")
           echo "chromium_path=${CHROMIUM}" >> $GITHUB_ENV
 
-      - name: Run integration tests with Percy
-        run: |
-          npx percy exec --quiet --parallel --config=percy.config.karma.yml -- \
-            npm run test:karma:dashboard -- --headless --viewport=1600:1000 --coverage --shard=$SHARD || \
-          npx percy exec --quiet --parallel --config=percy.config.karma.yml -- \
-            npm run test:karma:dashboard:retry-failed -- --headless --viewport=1600:1000 --shard=$SHARD
-        env:
-          DISABLE_ERROR_BOUNDARIES: true
-          SHARD: ${{ matrix.shard }}
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_DASHBOARD }}
-          PERCY_BROWSER_EXECUTABLE: ${{ env.chromium_path }}
-          PERCY_PARALLEL_NONCE: ${{ needs.nonce.outputs.result }}
-        if: github.event.pull_request.draft == false
-
       - name: Run integration tests
         run: npm run test:karma:dashboard -- --headless --viewport=1600:1000 --coverage || npm run test:karma:dashboard:retry-failed -- --headless --viewport=1600:1000
         env:
           DISABLE_ERROR_BOUNDARIES: true
-        if: github.event.pull_request.draft == true
 
       - name: Upload code coverage report
         uses: codecov/codecov-action@894ff025c7b54547a9a2a1e9f228beae737ad3c2
         with:
           file: build/logs/karma-coverage/dashboard/lcov.info
           flags: karmatests
-
-  percy:
-    name: Percy
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    if: >
-      always() &&
-      github.event.pull_request.draft == false &&
-      github.event.pull_request.head.repo.fork == false &&
-      github.event.pull_request.user.login != 'dependabot[bot]'
-    needs: [karma, nonce]
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@6b3083af2869dc3314a0257a42f4af696cc79ba3
-        with:
-          disable-sudo: true
-          disable-file-monitoring: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            github.com:443
-            percy.io:443
-            registry.npmjs.org:443
-            storage.googleapis.com:443
-
-      - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
-
-      - name: Setup Node
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
-        with:
-          node-version-file: '.nvmrc'
-          cache: npm
-
-      - name: Install dependencies
-        run: npm install @percy/cli
-
-      - name: Finalize Percy build
-        run: npx percy build:finalize
-        env:
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_DASHBOARD }}
-          PERCY_PARALLEL_NONCE: ${{ needs.nonce.outputs.result }}

--- a/.github/workflows/tests-karma-dashboard.yml
+++ b/.github/workflows/tests-karma-dashboard.yml
@@ -45,7 +45,6 @@ jobs:
     name: Karma
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: nonce
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@6b3083af2869dc3314a0257a42f4af696cc79ba3

--- a/.github/workflows/tests-karma-editor.yml
+++ b/.github/workflows/tests-karma-editor.yml
@@ -54,7 +54,6 @@ jobs:
     name: Karma (${{ matrix.shard }})
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: nonce
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests-karma-editor.yml
+++ b/.github/workflows/tests-karma-editor.yml
@@ -50,15 +50,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  nonce:
-    name: Percy Nonce
-    runs-on: ubuntu-latest
-    outputs:
-      result: ${{ env.result }}
-    steps:
-      - id: nonce
-        run: echo "result=${{ github.run_id }}-${{ github.run_attempt }}-$(date +%s)" >> $GITHUB_ENV
-
   karma:
     name: Karma (${{ matrix.shard }})
     runs-on: ubuntu-latest
@@ -103,7 +94,6 @@ jobs:
             fonts.googleapis.com:443
             fonts.gstatic.com:443
             github.com:443
-            percy.io:443
             registry.npmjs.org:443
             storage.googleapis.com:443
             uploader.codecov.io:443
@@ -138,20 +128,6 @@ jobs:
           CHROMIUM=$(node -p "const puppeteer = require('puppeteer'); puppeteer.executablePath();")
           echo "chromium_path=${CHROMIUM}" >> $GITHUB_ENV
 
-      - name: Run integration tests with Percy
-        run: |
-          npx percy exec --quiet --parallel --config=percy.config.karma.yml -- \
-            npm run test:karma:story-editor -- --headless --viewport=1600:1000 --coverage --shard=$SHARD || \
-          npx percy exec --quiet --parallel --config=percy.config.karma.yml -- \
-            npm run test:karma:story-editor:retry-failed -- --headless --viewport=1600:1000 --shard=$SHARD
-        env:
-          DISABLE_ERROR_BOUNDARIES: true
-          SHARD: ${{ matrix.shard }}
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
-          PERCY_BROWSER_EXECUTABLE: ${{ env.chromium_path }}
-          PERCY_PARALLEL_NONCE: ${{ needs.nonce.outputs.result }}
-        if: github.event.pull_request.draft == false
-
       - name: Run integration tests
         run: |
           npm run test:karma:story-editor -- --headless --viewport=1600:1000 --coverage --shard=$SHARD || \
@@ -159,52 +135,9 @@ jobs:
         env:
           DISABLE_ERROR_BOUNDARIES: true
           SHARD: ${{ matrix.shard }}
-        if: github.event.pull_request.draft == true
 
       - name: Upload code coverage report
         uses: codecov/codecov-action@894ff025c7b54547a9a2a1e9f228beae737ad3c2
         with:
           file: build/logs/karma-coverage/story-editor/lcov.info
           flags: karmatests
-
-  percy:
-    name: Percy
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    if: >
-      always() &&
-      github.event.pull_request.draft == false &&
-      github.event.pull_request.head.repo.fork == false &&
-      github.event.pull_request.user.login != 'dependabot[bot]'
-    needs: [karma, nonce]
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@6b3083af2869dc3314a0257a42f4af696cc79ba3
-        with:
-          disable-sudo: true
-          disable-file-monitoring: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            github.com:443
-            percy.io:443
-            registry.npmjs.org:443
-            storage.googleapis.com:443
-
-      - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
-
-      - name: Setup Node
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
-        with:
-          node-version-file: '.nvmrc'
-          cache: npm
-
-      - name: Install dependencies
-        run: npm install @percy/cli
-
-      - name: Finalize Percy build
-        run: npx percy build:finalize
-        env:
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
-          PERCY_PARALLEL_NONCE: ${{ needs.nonce.outputs.result }}


### PR DESCRIPTION
The visual regression testing setup doesn't seem to bring enough value anymore, so I went ahead and removed Percy here and downgraded our plan. We can still occasionally do manual before/after snapshots if deemed necessary.