### PR TITLE
Fix formatting keyboard shortcuts on non-text elements

### DIFF
--- a/packages/story-editor/src/components/panels/design/textStyle/test/textStyle.js
+++ b/packages/story-editor/src/components/panels/design/textStyle/test/textStyle.js
@@ -85,6 +85,7 @@ const DEFAULT_PADDING = {
 
 const textElement = {
   id: '1',
+  type: 'text',
   textAlign: 'normal',
   fontSize: 30,
   lineHeight: 1,

--- a/packages/story-editor/src/components/panels/design/textStyle/useRichTextFormatting.js
+++ b/packages/story-editor/src/components/panels/design/textStyle/useRichTextFormatting.js
@@ -178,15 +178,12 @@ function useRichTextFormatting(selectedElements, pushUpdate) {
     };
   }, [hasCurrentEditor, selectionActions, push, clearEditing, queuePush]);
 
-  const hasText = useCallback(() => {
-    const texts = selectedElements.filter(({ type }) => type === 'text');
-    return texts.length > 0;
-  }, [selectedElements]);
+  const hasText = selectedElements.find(({ type }) => type === 'text');
 
   useGlobalKeyDownEffect(
     { key: ['mod+b', 'mod+u', 'mod+i'] },
     ({ key }) => {
-      if (!hasText()) {
+      if (!hasText) {
         return;
       }
       switch (key) {

--- a/packages/story-editor/src/components/panels/design/textStyle/useRichTextFormatting.js
+++ b/packages/story-editor/src/components/panels/design/textStyle/useRichTextFormatting.js
@@ -186,7 +186,7 @@ function useRichTextFormatting(selectedElements, pushUpdate) {
   useGlobalKeyDownEffect(
     { key: ['mod+b', 'mod+u', 'mod+i'] },
     ({ key }) => {
-      if (!hasText) {
+      if (!hasText()) {
         return;
       }
       switch (key) {


### PR DESCRIPTION
## Context

The goal of the PR is to fix https://github.com/GoogleForCreators/web-stories-wp/issues/13281.

## Summary

Editor crashes when using a keyboard shortcut not applicable to a shape element. For example, enter `cmd+b`, `cmd+i` or `cmd+u` on a shape element.

This is happening because call to a callback function `hasText` has missing round brackets. `hasText` is never executed and following code-block never executes:
https://github.com/GoogleForCreators/web-stories-wp/blob/258b77e03e438fcb06f1625057d7c46d9266e00d/packages/story-editor/src/components/panels/design/textStyle/useRichTextFormatting.js#L189-L191

So, it do not return when text is not present.

## Relevant Technical Choices

```diff
// Previously proposed solution when `hasText` is a useCallback function
- if (!hasText) {
+ if (!hasText()) {

// Newely proposed solution
- const hasText = useCallback(...
+ const hasText = selectedElements.find(({ type }) => type === 'text');
```

## To-do

- [x] [Fixed] Unit-test case needs revision. Existing unit-test to mock key-press are failing. Refer: https://github.com/GoogleForCreators/web-stories-wp/actions/runs/4989520214/jobs/8933549034?pr=13299
  Fixed with: https://github.com/GoogleForCreators/web-stories-wp/pull/13299/commits/2ea1c81b3de0080c34ba4a6e5b5cb1ae7fa0fc48

## User-facing changes

Not applicable.

## Testing Instructions

This PR can be tested by following these steps:

1. Add shape element
2. Click cmd+b
3. RichText Component will not process non-text element key press and return.

## Reviews

No.

### Does this PR change what data or activity we track or use?

No.

### Does this PR have a legal-related impact?

No.

## Checklist

Not applicable.

---

Fixes https://github.com/GoogleForCreators/web-stories-wp/issues/13281