### PR TITLE
Settings: Properly display page titles with HTML entities in them

### DIFF
--- a/packages/wp-dashboard/package.json
+++ b/packages/wp-dashboard/package.json
@@ -30,7 +30,7 @@
     "@googleforcreators/dashboard": "*",
     "@googleforcreators/date": "*",
     "@googleforcreators/design-system": "*",
-    "@googleforcreators/dom": "^0.1.202306211149",
+    "@googleforcreators/dom": "*",
     "@googleforcreators/fonts": "*",
     "@googleforcreators/i18n": "*",
     "@googleforcreators/media": "*",

--- a/packages/wp-dashboard/package.json
+++ b/packages/wp-dashboard/package.json
@@ -30,6 +30,7 @@
     "@googleforcreators/dashboard": "*",
     "@googleforcreators/date": "*",
     "@googleforcreators/design-system": "*",
+    "@googleforcreators/dom": "^0.1.202306211149",
     "@googleforcreators/fonts": "*",
     "@googleforcreators/i18n": "*",
     "@googleforcreators/media": "*",

--- a/packages/wp-dashboard/src/api/hooks/usePagesApi.js
+++ b/packages/wp-dashboard/src/api/hooks/usePagesApi.js
@@ -17,6 +17,7 @@
 /**
  * External dependencies
  */
+import { stripHTML } from '@googleforcreators/dom';
 import { useCallback } from '@googleforcreators/react';
 import { useConfig } from '@googleforcreators/dashboard';
 
@@ -33,30 +34,20 @@ export default function usePagesApi() {
     api: { pages: pagesApiPath },
   } = useConfig();
 
-  /**
-   * Un-escapes HTML characters.
-   */
-  const decodeHTMLContent = useCallback((escapedString) => {
-    return escapedString.replace(
-      /&#(\d+);/g,
-      (match, escapedCharacter) => `${String.fromCharCode(escapedCharacter)}`
-    );
-  }, []);
-
   const getPageById = useCallback(
     async (id) => {
       try {
         const { title, link } = await getPageByIdCallback(pagesApiPath, id);
 
         return {
-          title: decodeHTMLContent(title.rendered),
+          title: stripHTML(title.rendered),
           link,
         };
       } catch (e) {
         return null;
       }
     },
-    [pagesApiPath, decodeHTMLContent]
+    [pagesApiPath]
   );
 
   const searchPages = useCallback(
@@ -66,13 +57,13 @@ export default function usePagesApi() {
 
         return response.map(({ id, title }) => ({
           value: id,
-          label: decodeHTMLContent(title.rendered),
+          label: stripHTML(title.rendered),
         }));
       } catch (e) {
         return [];
       }
     },
-    [pagesApiPath, decodeHTMLContent]
+    [pagesApiPath]
   );
 
   return {

--- a/packages/wp-dashboard/src/api/hooks/usePagesApi.js
+++ b/packages/wp-dashboard/src/api/hooks/usePagesApi.js
@@ -33,13 +33,20 @@ export default function usePagesApi() {
     api: { pages: pagesApiPath },
   } = useConfig();
 
+  /**
+   * Un-escapes HTML characters.
+   */
+  const decodeHTMLContent = useCallback((escapedString) => {
+    return escapedString.replace(/&#(\d+);/g, ((match, escapedCharacter) => `${String.fromCharCode(escapedCharacter)}`));
+  }, []);
+
   const getPageById = useCallback(
     async (id) => {
       try {
         const { title, link } = await getPageByIdCallback(pagesApiPath, id);
 
         return {
-          title: title.rendered,
+          title: decodeHTMLContent(title.rendered),
           link,
         };
       } catch (e) {
@@ -56,7 +63,7 @@ export default function usePagesApi() {
 
         return response.map(({ id, title }) => ({
           value: id,
-          label: title.rendered,
+          label: decodeHTMLContent(title.rendered),
         }));
       } catch (e) {
         return [];

--- a/packages/wp-dashboard/src/api/hooks/usePagesApi.js
+++ b/packages/wp-dashboard/src/api/hooks/usePagesApi.js
@@ -37,7 +37,10 @@ export default function usePagesApi() {
    * Un-escapes HTML characters.
    */
   const decodeHTMLContent = useCallback((escapedString) => {
-    return escapedString.replace(/&#(\d+);/g, ((match, escapedCharacter) => `${String.fromCharCode(escapedCharacter)}`));
+    return escapedString.replace(
+      /&#(\d+);/g,
+      (match, escapedCharacter) => `${String.fromCharCode(escapedCharacter)}`
+    );
   }, []);
 
   const getPageById = useCallback(
@@ -53,7 +56,7 @@ export default function usePagesApi() {
         return null;
       }
     },
-    [pagesApiPath]
+    [pagesApiPath, decodeHTMLContent]
   );
 
   const searchPages = useCallback(
@@ -69,7 +72,7 @@ export default function usePagesApi() {
         return [];
       }
     },
-    [pagesApiPath]
+    [pagesApiPath, decodeHTMLContent]
   );
 
   return {


### PR DESCRIPTION
## Context

The goal of the PR is to fix escaped `title` characters for search field.

## Summary

Front-end fetches and searches pages by using [@wordpress/api-fetch](https://www.npmjs.com/package/@wordpress/api-fetch) API. This API calls WordPress REST Endpoint `/wp-json/wp/v2/posts` to fetch posts which results as:
<img width="1323" alt="image" src="https://github.com/GoogleForCreators/web-stories-wp/assets/75766877/0576fd28-35d0-4a89-a760-c27aa3578197">

Thus, it is required to un-escape character back to their original state. This PR addresses this issue.

## Relevant Technical Choices

Not applicable.

## User-facing changes

| Before | After |
|---|---|
| <img width="1302" alt="image" src="https://github.com/GoogleForCreators/web-stories-wp/assets/75766877/19573d04-5bd2-4a29-a607-e2d1371f4492"> | <img width="1302" alt="image" src="https://github.com/GoogleForCreators/web-stories-wp/assets/75766877/65a2c810-e9c7-4b88-bd00-55089dabbeaa"> |

## Testing Instructions

Follow instruction provided on the linked issue #13404 for testing instructions.

## Reviews

### Does this PR have a security-related impact?

No.

### Does this PR change what data or activity we track or use?

No.

### Does this PR have a legal-related impact?

No.

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #13404 
