### PR TITLE
Fonts: ensure `per_page` is respected

### DIFF
--- a/includes/REST_API/Font_Controller.php
+++ b/includes/REST_API/Font_Controller.php
@@ -573,6 +573,11 @@ class Font_Controller extends WP_REST_Posts_Controller {
 			}
 		}
 
+		// Ensure our per_page parameter overrides any provided posts_per_page filter.
+		if ( isset( $registered['per_page'] ) ) {
+			$args['posts_per_page'] = $request['per_page'];
+		}
+
 		// Force search to be case-insensitive.
 
 		// Force the post_type argument, since it's not a user input variable.

--- a/packages/wp-story-editor/src/api/fonts.js
+++ b/packages/wp-story-editor/src/api/fonts.js
@@ -45,6 +45,7 @@ export function getFonts(config, { include: _include, search, service }) {
   let path = addQueryArgs(`${config.api.fonts}`, {
     search,
     service,
+    per_page: 100,
   });
   const include = getIncludeQueryArgs(_include);
   if (include.length > 0) {

--- a/packages/wp-story-editor/src/api/test/fonts.js
+++ b/packages/wp-story-editor/src/api/test/fonts.js
@@ -64,7 +64,7 @@ describe('Fonts API Callbacks', () => {
     expect(apiFetch).toHaveBeenCalledWith(
       expect.objectContaining({
         path: expect.stringContaining(
-          '?include[]=Roboto%20Mono&include[]=Roboto%20Serif'
+          'include[]=Roboto%20Mono&include[]=Roboto%20Serif'
         ),
       })
     );


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

<!-- A brief description of what this PR does. -->

Ensure the `per_page` query param is respected so that the settings page shows all custom fonts, regardless of your reading settings.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add more than one custom font on the settings page
2. Go to Wordpress Settings > Reading and change "blog pages show at most " and change it to 1.
3. Visit settings page and verify you still see all fonts

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #13441
