### PR TITLE
Fix: 🐛 Add `Reset` button for scheduled stories

### DIFF
--- a/packages/wp-story-editor/src/components/documentPane/publish/publishTime.js
+++ b/packages/wp-story-editor/src/components/documentPane/publish/publishTime.js
@@ -102,7 +102,7 @@ function PublishTime() {
 
   // Floating date means an unset date so that the story publish date will match the time it will get published.
   const floatingDate =
-    ['draft', 'pending', 'auto-draft'].includes(status) &&
+    ['draft', 'pending', 'auto-draft', 'future'].includes(status) &&
     (date === modified || date === null);
 
   const displayLabel = !floatingDate
@@ -151,7 +151,7 @@ function PublishTime() {
             forwardedRef={dateTimeNode}
             onClose={() => setShowDatePicker(false)}
             canReset={
-              ['draft', 'pending', 'auto-draft'].includes(status) &&
+              ['draft', 'pending', 'auto-draft', 'future'].includes(status) &&
               !floatingDate
             }
           />


### PR DESCRIPTION
## Summary

The goal of the PR is to show `Reset` button for scheduled stories.

## User-facing changes

With this PR, `Reset` button will be shown in calendar for the scheduled stories. Clicking on the `Reset` button will enable user to publish story immediately.

Animated GIF:
![WebStories-AddResetButtonForScheduledStories](https://github.com/GoogleForCreators/web-stories-wp/assets/75766877/0dbe48f1-d3bb-49aa-8e09-e50999edc68f)

## Testing Instructions

This PR can be tested by following these steps described in the issue #13428.

## Reviews

### Does this PR have a security-related impact?

No.

### Does this PR change what data or activity we track or use?

No.

### Does this PR have a legal-related impact?

No.

## Checklist

- [x] This PR addresses an existing issue and I have linked this PR to it
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #13428 