### PR TITLE
Bump WordPress version requirement to 6.2

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -132,7 +132,7 @@ jobs:
       matrix:
         # TODO: add back Firefox once support is more mature.
         browser: ['chrome']
-        wp: ['6.1']
+        wp: ['6.2']
         snapshots: [false]
         experimental: [false]
         # We want to split up the tests into 2 parts running in parallel.

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -66,7 +66,7 @@ jobs:
             experimental: false
 
           - php: '7.4'
-            wp: '6.1'
+            wp: '6.2'
             experimental: false
 
           - php: '8.0'

--- a/bin/local-env/install-wordpress.sh
+++ b/bin/local-env/install-wordpress.sh
@@ -145,13 +145,8 @@ wp plugin install rtl-tester --activate --force --quiet
 echo -e $(status_message "Installing WordPress importer...")
 wp plugin install wordpress-importer --activate --force --quiet
 
-# WooCommerce 8.0+ requires WordPress 6.2, but we still support WordPress 6.1.
 echo -e $(status_message "Installing WooCommerce plugin...")
-if [ "$WP_VERSION" == "latest" ]; then
-  wp plugin install woocommerce --activate --force --quiet
-else
-  wp plugin install woocommerce --version=7.9.0 --activate --force --quiet
-fi
+wp plugin install woocommerce --activate --force --quiet
 
 echo -e $(status_message "Installing AMP plugin...")
 wp plugin install amp --force --quiet

--- a/package-lock.json
+++ b/package-lock.json
@@ -13160,9 +13160,9 @@
       }
     },
     "node_modules/@wordpress/hooks": {
-      "version": "3.43.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.43.0.tgz",
-      "integrity": "sha512-SHSiyFUEsggihl0pDvY1l72q+fHMDyFHtIR3GCt0uV2ifctvoa/PIYdVwrxpGQaGdNEV25XCZ4kNldqJmfTddw==",
+      "version": "3.42.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.42.0.tgz",
+      "integrity": "sha512-GUePaweJgINbOyeWDG1p0ffxKZXZIOJdkdSCG8oWoAohJPOYe8WeYl/nAsECiUjbIuVletQe1RoTGrNdNkFTdg==",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -13182,12 +13182,12 @@
       }
     },
     "node_modules/@wordpress/i18n": {
-      "version": "4.43.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.43.0.tgz",
-      "integrity": "sha512-XHU/vGgI+pgjJU9WzWDHke1u948z8i3OPpKUNdxc/gMcTkKaKM4D8DW1+VMSQHyU6pneP8+ph7EF+1RIehP3lQ==",
+      "version": "4.42.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.42.0.tgz",
+      "integrity": "sha512-6cEcsVk9EX0c2azz0h1aAZqGjts+VrGMHzMB22GBIhsiz/TWAqkMapt1QF1YbsJ4/VR2CHnKlONjhHNtsHn8Ew==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^3.43.0",
+        "@wordpress/hooks": "^3.42.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
         "sprintf-js": "^1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13160,9 +13160,9 @@
       }
     },
     "node_modules/@wordpress/hooks": {
-      "version": "3.42.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.42.0.tgz",
-      "integrity": "sha512-GUePaweJgINbOyeWDG1p0ffxKZXZIOJdkdSCG8oWoAohJPOYe8WeYl/nAsECiUjbIuVletQe1RoTGrNdNkFTdg==",
+      "version": "3.43.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.43.0.tgz",
+      "integrity": "sha512-SHSiyFUEsggihl0pDvY1l72q+fHMDyFHtIR3GCt0uV2ifctvoa/PIYdVwrxpGQaGdNEV25XCZ4kNldqJmfTddw==",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -13182,12 +13182,12 @@
       }
     },
     "node_modules/@wordpress/i18n": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.42.0.tgz",
-      "integrity": "sha512-6cEcsVk9EX0c2azz0h1aAZqGjts+VrGMHzMB22GBIhsiz/TWAqkMapt1QF1YbsJ4/VR2CHnKlONjhHNtsHn8Ew==",
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.43.0.tgz",
+      "integrity": "sha512-XHU/vGgI+pgjJU9WzWDHke1u948z8i3OPpKUNdxc/gMcTkKaKM4D8DW1+VMSQHyU6pneP8+ph7EF+1RIehP3lQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^3.42.0",
+        "@wordpress/hooks": "^3.43.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
         "sprintf-js": "^1.1.1",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <ruleset name="Web Stories PHP Coding Standards Rules">
-  <config name="minimum_supported_wp_version" value="6.1" />
+  <config name="minimum_supported_wp_version" value="6.2" />
 
   <rule ref="WordPress-Core">
     <type>error</type>

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors:      google
 Tested up to:      6.3
-Requires at least: 6.1
+Requires at least: 6.2
 Stable tag:        V.V.V
 License:           Apache-2.0
 License URI:       https://www.apache.org/licenses/LICENSE-2.0

--- a/tests/phpstan/bootstrap.php
+++ b/tests/phpstan/bootstrap.php
@@ -11,7 +11,7 @@ define( 'WEBSTORIES_PLUGIN_DIR_PATH', dirname( WEBSTORIES_PLUGIN_FILE ) );
 define( 'WEBSTORIES_PLUGIN_DIR_URL', 'https://example.com/wp-content/plugins/web-stories/' );
 define( 'WEBSTORIES_CDN_URL', 'https://wp.stories.google/static/main/' );
 define( 'WEBSTORIES_MINIMUM_PHP_VERSION', '7.4' );
-define( 'WEBSTORIES_MINIMUM_WP_VERSION', '6.1' );
+define( 'WEBSTORIES_MINIMUM_WP_VERSION', '6.2' );
 define( 'WEBSTORIES_DEV_MODE', true );
 
 define( 'WPCOM_IS_VIP_ENV', true );

--- a/web-stories.php
+++ b/web-stories.php
@@ -10,7 +10,7 @@
  * Author: Google
  * Author URI: https://opensource.google.com/
  * Version: 1.35.0-alpha.0
- * Requires at least: 6.1
+ * Requires at least: 6.2
  * Requires PHP: 7.4
  * Text Domain: web-stories
  * License: Apache License 2.0
@@ -47,7 +47,7 @@ define( 'WEBSTORIES_PLUGIN_FILE', __FILE__ );
 define( 'WEBSTORIES_PLUGIN_DIR_PATH', plugin_dir_path( WEBSTORIES_PLUGIN_FILE ) );
 define( 'WEBSTORIES_PLUGIN_DIR_URL', plugin_dir_url( WEBSTORIES_PLUGIN_FILE ) );
 define( 'WEBSTORIES_MINIMUM_PHP_VERSION', '7.4' );
-define( 'WEBSTORIES_MINIMUM_WP_VERSION', '6.1' );
+define( 'WEBSTORIES_MINIMUM_WP_VERSION', '6.2' );
 define( 'WEBSTORIES_CDN_URL', 'https://wp.stories.google/static/main' );
 
 if ( ! defined( 'WEBSTORIES_DEV_MODE' ) ) {


### PR DESCRIPTION
## Summary

The goal of the PR is to Bump WordPress minimum to 6.2 in following:
- Bump in `readme.txt`
- Bump in `web-stories.php`
- Bump in `tests/phpstan/bootstrap.php` for consistency
- Update `minimum_supported_wp_version` in `phpcs.xml.dist`

This PR also reverts:
- Revert https://github.com/GoogleForCreators/web-stories-wp/commit/6749017043569b9c7c77318d804ad5a101ee274a

## User-facing changes

Not applicable.

## Testing Instructions

Not applicable.


## Reviews

### Does this PR have a security-related impact?

No.

### Does this PR change what data or activity we track or use?

No.

### Does this PR have a legal-related impact?

No.

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

Partially Fixes #13424