### PR TITLE
Improve dialog shown after publishing scheduled/private stories

### DIFF
--- a/packages/wp-story-editor/src/components/postPublishDialog/index.js
+++ b/packages/wp-story-editor/src/components/postPublishDialog/index.js
@@ -33,16 +33,18 @@ function PostPublishDialog() {
     embedPostLink: confirmURL,
     link: storyURL,
     isFreshlyPublished,
+    status,
   } = useStory(
     ({
       state: {
-        story: { embedPostLink, link },
+        story: { embedPostLink, link, status },
         meta: { isFreshlyPublished },
       },
     }) => ({
       embedPostLink,
       link,
       isFreshlyPublished,
+      status,
     })
   );
 
@@ -61,12 +63,19 @@ function PostPublishDialog() {
 
   const primaryText = confirmURL ? __('Add to new post', 'web-stories') : '';
 
+  const dialogTitle =
+    status === 'private'
+      ? __('Story published privately.', 'web-stories')
+      : status === 'future'
+      ? __('Story scheduled.', 'web-stories')
+      : __('Story published.', 'web-stories');
+
   return (
     <Dialog
       isOpen={isOpen}
       onClose={onClose}
       // Same as item_published post type label.
-      title={__('Story published.', 'web-stories')}
+      title={dialogTitle}
       secondaryText={__('Dismiss', 'web-stories')}
       primaryText={primaryText}
       onPrimary={onAddToPostClick}
@@ -87,10 +96,15 @@ function PostPublishDialog() {
             ),
           }}
         >
-          {__(
-            'Your story has been successfully published! <a>View story</a>.',
-            'web-stories'
-          )}
+          {status === 'future'
+            ? __(
+                'Your story has been successfully scheduled! <a>View story</a>.',
+                'web-stories'
+              )
+            : __(
+                'Your story has been successfully published! <a>View story</a>.',
+                'web-stories'
+              )}
         </TranslateWithMarkup>
       </Text.Paragraph>
       {confirmURL && (


### PR DESCRIPTION
The goal of the PR is to display separate message for post publish and schedule scenario. 

## Summary

Creating a **new Scheduled Story** and clicking on `Schedule` button shows `Story published.` message. In case of **Scheduled Story**, `title` and `description` of the feedback dialog needs to be corrected.

## User-facing changes

| Scenario | Current Behavior | Proposed Behavior |
|---|---|---|
| Scheduled Story | <img width="1382" alt="image" src="https://github.com/GoogleForCreators/web-stories-wp/assets/75766877/6e88353c-7f53-44e0-b53e-e1e7abc2cd72"> | <img width="1382" alt="image" src="https://github.com/GoogleForCreators/web-stories-wp/assets/75766877/8cfcb58f-615a-4048-aa96-fdf6281fb3ad"> |

> Updated dialog message should be: `Your story has been successfully scheduled! <a>View story</a>.`

## Testing Instructions

Follow https://github.com/GoogleForCreators/web-stories-wp/issues/13472 for the testing instruction.

## Reviews

### Does this PR have a security-related impact?

No.

### Does this PR change what data or activity we track or use?

No.

### Does this PR have a legal-related impact?

No.

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

Fixes #13472
