### PR TITLE
Blocks: Fix hidden lightbox interfering with rest of the page

### DIFF
--- a/packages/stories-block/src/css/lightbox.css
+++ b/packages/stories-block/src/css/lightbox.css
@@ -73,12 +73,15 @@
  * relative flow, removes the space.
  */
 html:not([amp]) .web-stories-singleton__lightbox amp-story-player a,
-html:not([amp]) .web-stories-list .web-stories-list__lightbox amp-story-player a {
+html:not([amp])
+  .web-stories-list
+  .web-stories-list__lightbox
+  amp-story-player
+  a {
   position: absolute;
 }
 
 @media all and (min-width: 676px) {
-
   .admin-bar .web-stories-list__lightbox,
   .admin-bar .web-stories-singleton__lightbox {
     top: 46px;
@@ -96,7 +99,6 @@ html:not([amp]) .web-stories-list .web-stories-list__lightbox amp-story-player a
 }
 
 @media all and (min-width: 783px) {
-
   .admin-bar .web-stories-list__lightbox,
   .admin-bar .web-stories-singleton__lightbox {
     top: 32px;

--- a/packages/stories-block/src/css/lightbox.css
+++ b/packages/stories-block/src/css/lightbox.css
@@ -16,6 +16,7 @@
   height: 100%;
   opacity: 0;
   transform: translate(0, -100vh);
+  z-index: -999999999;
 }
 
 /* amp-lightbox needs to have z-index to render on top of other elements in the page. */
@@ -72,15 +73,12 @@
  * relative flow, removes the space.
  */
 html:not([amp]) .web-stories-singleton__lightbox amp-story-player a,
-html:not([amp])
-  .web-stories-list
-  .web-stories-list__lightbox
-  amp-story-player
-  a {
+html:not([amp]) .web-stories-list .web-stories-list__lightbox amp-story-player a {
   position: absolute;
 }
 
 @media all and (min-width: 676px) {
+
   .admin-bar .web-stories-list__lightbox,
   .admin-bar .web-stories-singleton__lightbox {
     top: 46px;
@@ -98,6 +96,7 @@ html:not([amp])
 }
 
 @media all and (min-width: 783px) {
+
   .admin-bar .web-stories-list__lightbox,
   .admin-bar .web-stories-singleton__lightbox {
     top: 32px;


### PR DESCRIPTION
This PR fixes the conflict between the Web Stories blocks and theme hamburger menu on mobile devices.

## Summary

<!-- A brief description of what this PR does. -->
To fix the issue, `z-index: -999999999;` is added to `.web-stories-list__lightbox` and `.web-stories-singleton__lightbox` classes.


## User-facing changes.

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

Before:

https://github.com/GoogleForCreators/web-stories-wp/assets/75439077/a5884bbc-f1b7-4209-873d-a1626562c764

After:

https://github.com/GoogleForCreators/web-stories-wp/assets/75439077/96904451-53c9-4edd-81f6-261773902b62

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

1. Activate WordPress Twenty Twenty Three theme
2. Insert Web Stories blocks (more than one story)
3. View page on physical mobile device
4. Click on top right corner burger menu
5. The menu should open.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->
No.

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->
No.

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->
No.

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #13587 
