### PR TITLE
Blocks: Fix box carousel layout on mobile devices

### DIFF
--- a/packages/stories-block/src/css/views/carousel.css
+++ b/packages/stories-block/src/css/views/carousel.css
@@ -1,5 +1,9 @@
 /* Web Stories: Carousel View */
 
+.carousel > .glider-track > .web-stories-list__story {
+  margin: 0 10px;
+}
+
 @media all and (min-width: 676px) {
   .web-stories-list.is-view-type-carousel .web-stories-list__story {
     margin: 0 5px;

--- a/packages/stories-block/src/css/views/list.css
+++ b/packages/stories-block/src/css/views/list.css
@@ -102,3 +102,10 @@
     overflow: hidden;
   }
 }
+
+@media all and (max-width: 675px) {
+  .carousel > .glider-track > .web-stories-list__story {
+    margin-right: 10px;
+    margin-left: 10px;
+  }
+}

--- a/packages/stories-block/src/css/views/list.css
+++ b/packages/stories-block/src/css/views/list.css
@@ -102,10 +102,3 @@
     overflow: hidden;
   }
 }
-
-@media all and (max-width: 675px) {
-  .carousel > .glider-track > .web-stories-list__story {
-    margin-right: 10px;
-    margin-left: 10px;
-  }
-}

--- a/packages/stories-carousel/src/index.js
+++ b/packages/stories-carousel/src/index.js
@@ -76,24 +76,12 @@ domReady(() => {
       // For Box Carousel we are showing single slide below tablets viewport.
       /* eslint-disable-next-line no-new -- we do not store the object as no further computation required with the built object. */
       new Glider(carouselWrapper, {
-        // Mobile-first defaults
-        slidesToShow: 1,
-        slidesToScroll: 1,
+        slidesToShow: 'auto',
+        slidesToScroll: 'auto',
+        itemWidth,
+        duration: 0.25,
         scrollLock: true,
         arrows: navArrows,
-        responsive: [
-          {
-            // screens greater than >= 775px
-            breakpoint: 775,
-            settings: {
-              // Set to `auto` and provide item width to adjust to viewport
-              slidesToShow: 'auto',
-              slidesToScroll: 'auto',
-              itemWidth,
-              duration: 0.25,
-            },
-          },
-        ],
       });
     }
   });


### PR DESCRIPTION
## Summary

This PR fixes the size and spacing of stories in the box carousel layout on mobile devices.

## User-facing changes
1. A horizontal margin of 10px has been added to stories for devices with width less than 675px.
2. The size of a story has been reduced to show two stories on the screen.

https://github.com/GoogleForCreators/web-stories-wp/assets/75439077/acb25aa1-598b-4a88-abdc-2b7e94c62ab8


## Testing Instructions

This PR can be tested by following these steps:

1. On your page, add the 'Web Stories' block.
2. Select the 'Box Carousel' layout.
3. Go to the 'Block' section in the Settings pane, and increase the 'Number of Stories' to 5.
4. Save your changes and click 'View Page'


## Reviews

### Does this PR have a security-related impact?
No.
### Does this PR change what data or activity we track or use?
No.
### Does this PR have a legal-related impact?
No.
## Checklist

- [x] This PR addresses an existing issue and I have linked this PR to it
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #13591 
