### PR TITLE
Settings: Prime options to reduce database queries

### DIFF
--- a/includes/Admin/Customizer.php
+++ b/includes/Admin/Customizer.php
@@ -30,7 +30,6 @@ namespace Google\Web_Stories\Admin;
 
 use Google\Web_Stories\Infrastructure\Conditional;
 use Google\Web_Stories\Service_Base;
-use Google\Web_Stories\Settings;
 use Google\Web_Stories\Stories_Script_Data;
 use Google\Web_Stories\Story_Post_Type;
 use Google\Web_Stories\Story_Query;
@@ -107,13 +106,6 @@ class Customizer extends Service_Base implements Conditional {
 	private WP_Customize_Manager $wp_customize;
 
 	/**
-	 * Settings instance.
-	 *
-	 * @var Settings Settings instance.
-	 */
-	private Settings $settings;
-
-	/**
 	 * Story_Post_Type instance.
 	 *
 	 * @var Story_Post_Type Story_Post_Type instance.
@@ -132,17 +124,14 @@ class Customizer extends Service_Base implements Conditional {
 	 *
 	 * @since 1.12.0
 	 *
-	 * @param Settings            $settings            Settings instance.
 	 * @param Story_Post_Type     $story_post_type     Story_Post_Type instance.
 	 * @param Stories_Script_Data $stories_script_data Stories_Script_Data instance.
 	 * @return void
 	 */
 	public function __construct(
-		Settings $settings,
 		Story_Post_Type $story_post_type,
 		Stories_Script_Data $stories_script_data
 	) {
-		$this->settings            = $settings;
 		$this->story_post_type     = $story_post_type;
 		$this->stories_script_data = $stories_script_data;
 	}

--- a/includes/Admin/Customizer.php
+++ b/includes/Admin/Customizer.php
@@ -548,13 +548,15 @@ class Customizer extends Service_Base implements Conditional {
 	 * @since 1.5.0
 	 */
 	public function render_stories(): string {
+		// Not using Settings::get_setting() to avoid calling rest_sanitize_value_from_schema().
+
 		/**
 		 * Render options.
 		 *
 		 * @var array<string,string|bool> $options
 		 * @phpstan-var StoryAttributes
 		 */
-		$options = (array) $this->settings->get_setting( self::STORY_OPTION );
+		$options = (array) get_option( self::STORY_OPTION );
 
 		if ( empty( $options['show_stories'] ) || true !== $options['show_stories'] ) {
 			return '';

--- a/includes/Admin/Dashboard.php
+++ b/includes/Admin/Dashboard.php
@@ -237,7 +237,14 @@ class Dashboard extends Service_Base {
 	public function add_menu_page(): void {
 		$parent = 'edit.php?post_type=' . $this->story_post_type->get_slug();
 
-		$settings = $this->get_dashboard_settings();
+		// Not using get_dashboard_settings() to avoid an extra database query.
+
+		$settings = [
+			'canViewDefaultTemplates' => true,
+		];
+
+		/** This filter is documented in includes/Admin/Dashboard.php */
+		$settings = apply_filters( 'web_stories_dashboard_settings', $settings );
 
 		/**
 		 * The edit_posts capability.

--- a/includes/Integrations/Core_Themes_Support.php
+++ b/includes/Integrations/Core_Themes_Support.php
@@ -30,7 +30,6 @@ namespace Google\Web_Stories\Integrations;
 
 use Google\Web_Stories\Admin\Customizer;
 use Google\Web_Stories\Assets;
-use Google\Web_Stories\Renderer\Stories\Renderer;
 use Google\Web_Stories\Service_Base;
 use function Google\Web_Stories\render_theme_stories;
 
@@ -98,7 +97,7 @@ class Core_Themes_Support extends Service_Base {
 	public function embed_web_stories(): void {
 		$stylesheet = get_stylesheet();
 		if ( is_readable( sprintf( '%sassets/css/web-stories-theme-style-%s.css', WEBSTORIES_PLUGIN_DIR_PATH, $stylesheet ) ) ) {
-			$this->assets->enqueue_style_asset( 'web-stories-theme-style-' . $stylesheet, [ Renderer::STYLE_HANDLE ] );
+			$this->assets->enqueue_style_asset( 'web-stories-theme-style-' . $stylesheet, [] );
 		}
 		?>
 		<div class="web-stories-theme-header-section">
@@ -134,15 +133,13 @@ class Core_Themes_Support extends Service_Base {
 	 * @since 1.5.0
 	 */
 	public function register(): void {
-		if ( is_admin() ) {
-			return;
-		}
-
 		if ( ! \in_array( get_stylesheet(), self::$supported_themes, true ) ) {
 			return;
 		}
 
 		$this->extend_theme_support();
+
+		// Not using Settings::get_setting() to avoid calling rest_sanitize_value_from_schema().
 
 		/**
 		 * Customizer options.
@@ -168,6 +165,6 @@ class Core_Themes_Support extends Service_Base {
 	 * @return string Registration action to use.
 	 */
 	public static function get_registration_action(): string {
-		return 'after_setup_theme';
+		return 'wp_head';
 	}
 }

--- a/includes/Integrations/Core_Themes_Support.php
+++ b/includes/Integrations/Core_Themes_Support.php
@@ -134,6 +134,9 @@ class Core_Themes_Support extends Service_Base {
 	 * @since 1.5.0
 	 */
 	public function register(): void {
+		if ( is_admin() ) {
+			return;
+		}
 
 		if ( ! \in_array( get_stylesheet(), self::$supported_themes, true ) ) {
 			return;

--- a/includes/Integrations/Site_Kit.php
+++ b/includes/Integrations/Site_Kit.php
@@ -95,21 +95,29 @@ class Site_Kit extends Service_Base {
 	public function register(): void {
 		add_filter( 'googlesitekit_amp_gtag_opt', [ $this, 'filter_site_kit_gtag_opt' ] );
 
-		$handler = $this->settings->get_setting( $this->settings::SETTING_NAME_TRACKING_HANDLER );
+		add_filter(
+			'googlesitekit_analytics-4_tag_amp_blocked',
+			function ( $blocked ) {
+				$handler = $this->settings->get_setting( $this->settings::SETTING_NAME_TRACKING_HANDLER );
 
-		if ( 'web-stories' === $handler ) {
-			add_filter(
-				'googlesitekit_analytics-4_tag_amp_blocked',
-				function ( $blocked ) {
-					if ( $this->context->is_web_story() ) {
-						return true;
-					}
-					return $blocked;
+				if ( 'web-stories' === $handler && $this->context->is_web_story() ) {
+					return true;
 				}
-			);
-		} elseif ( 'site-kit' === $handler && $this->is_analytics_module_active() ) {
-			remove_action( 'web_stories_print_analytics', [ $this->analytics, 'print_analytics_tag' ] );
-		}
+
+				return $blocked;
+			}
+		);
+
+		add_action(
+			'web_stories_print_analytics',
+			function () {
+				$handler = $this->settings->get_setting( $this->settings::SETTING_NAME_TRACKING_HANDLER );
+				if ( 'site-kit' === $handler && $this->is_analytics_module_active() ) {
+					remove_action( 'web_stories_print_analytics', [ $this->analytics, 'print_analytics_tag' ] );
+				}
+			},
+			5
+		);
 	}
 
 	/**

--- a/includes/Integrations/Site_Kit.php
+++ b/includes/Integrations/Site_Kit.php
@@ -110,7 +110,7 @@ class Site_Kit extends Service_Base {
 
 		add_action(
 			'web_stories_print_analytics',
-			function () {
+			function (): void {
 				$handler = $this->settings->get_setting( $this->settings::SETTING_NAME_TRACKING_HANDLER );
 				if ( 'site-kit' === $handler && $this->is_analytics_module_active() ) {
 					remove_action( 'web_stories_print_analytics', [ $this->analytics, 'print_analytics_tag' ] );

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -150,6 +150,11 @@ class Settings implements Service, Registerable, PluginUninstallAware {
 	public const SETTING_NAME_TRACKING_HANDLER = 'web_stories_ga_tracking_handler';
 
 	/**
+	 * Customizer settings.
+	 */
+	public const SETTING_NAME_CUSTOMIZER_SETTINGS = 'web_stories_customizer_settings';
+
+	/**
 	 * Shopping_Vendors instance.
 	 *
 	 * @var Shopping_Vendors Shopping_Vendors instance.
@@ -348,10 +353,10 @@ class Settings implements Service, Registerable, PluginUninstallAware {
 			self::SETTING_GROUP_EXPERIMENTS,
 			self::SETTING_NAME_EXPERIMENTS,
 			[
-				'description'     => __( 'Experiments', 'web-stories' ),
-				'type'            => 'object',
-				'default'         => [],
-				'show_in_rest'    => [
+				'description'  => __( 'Experiments', 'web-stories' ),
+				'type'         => 'object',
+				'default'      => [],
+				'show_in_rest' => [
 					'schema' => [
 						'properties'           => [],
 						'additionalProperties' => true,
@@ -431,6 +436,17 @@ class Settings implements Service, Registerable, PluginUninstallAware {
 						'enum' => [ 'site-kit', 'web-stories', 'both' ],
 					],
 				],
+			]
+		);
+
+		register_setting(
+			self::SETTING_GROUP,
+			self::SETTING_NAME_CUSTOMIZER_SETTINGS,
+			[
+				'description'  => __( 'Customizer settings', 'web-stories' ),
+				'type'         => 'array',
+				'default'      => [],
+				'show_in_rest' => false,
 			]
 		);
 

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -163,6 +163,19 @@ class Settings implements Service, Registerable, PluginUninstallAware {
 	 */
 	public function __construct( Shopping_Vendors $shopping_vendors ) {
 		$this->shopping_vendors = $shopping_vendors;
+		add_action( 'init', [ $this, 'prime_option_caches' ] );
+	}
+
+	/**
+	 * Primes option caches for specified groups if the function exists.
+	 *
+	 * @since 1.37.0
+	 */
+	public function prime_option_caches(): void {
+		if ( \function_exists( 'wp_prime_option_caches_by_group' ) ) {
+			wp_prime_option_caches_by_group( self::SETTING_GROUP );
+			wp_prime_option_caches_by_group( self::SETTING_GROUP_EXPERIMENTS );
+		}
 	}
 
 	/**
@@ -438,11 +451,6 @@ class Settings implements Service, Registerable, PluginUninstallAware {
 	 * @return string|array<int|string,mixed>|bool|int Setting value.
 	 */
 	public function get_setting( string $key, $default_value = false ) {
-		if ( \function_exists( 'wp_prime_option_caches_by_group' ) ) {
-			wp_prime_option_caches_by_group( self::SETTING_GROUP );
-			wp_prime_option_caches_by_group( self::SETTING_GROUP_EXPERIMENTS );
-		}
-
 		// Distinguish between `false` as a default, and not passing one, just like WordPress.
 		$passed_default = \func_num_args() > 1;
 

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -438,6 +438,11 @@ class Settings implements Service, Registerable, PluginUninstallAware {
 	 * @return string|array<int|string,mixed>|bool|int Setting value.
 	 */
 	public function get_setting( string $key, $default_value = false ) {
+		if ( \function_exists( 'wp_prime_option_caches_by_group' ) ) {
+			wp_prime_option_caches_by_group( self::SETTING_GROUP );
+			wp_prime_option_caches_by_group( self::SETTING_GROUP_EXPERIMENTS );
+		}
+
 		// Distinguish between `false` as a default, and not passing one, just like WordPress.
 		$passed_default = \func_num_args() > 1;
 

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -163,7 +163,6 @@ class Settings implements Service, Registerable, PluginUninstallAware {
 	 */
 	public function __construct( Shopping_Vendors $shopping_vendors ) {
 		$this->shopping_vendors = $shopping_vendors;
-		add_action( 'init', [ $this, 'prime_option_caches' ] );
 	}
 
 	/**
@@ -437,6 +436,8 @@ class Settings implements Service, Registerable, PluginUninstallAware {
 				],
 			]
 		);
+
+		add_action( 'init', [ $this, 'prime_option_caches' ] );
 	}
 
 	/**

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -357,9 +357,6 @@ class Settings implements Service, Registerable, PluginUninstallAware {
 						'additionalProperties' => true,
 					],
 				],
-				// WPGraphQL errors when encountering array or object types.
-				// See https://github.com/wp-graphql/wp-graphql/issues/2065.
-				'show_in_graphql' => false,
 			]
 		);
 

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -287,8 +287,8 @@ class Story_Post_Type extends Post_Type_Base implements HasRequirements, HasMeta
 	 * @return bool|string Whether the post type should have an archive, or archive slug.
 	 */
 	public function get_has_archive() {
-		$archive_page_option    = $this->settings->get_setting( $this->settings::SETTING_NAME_ARCHIVE );
-		$has_archive            = true;
+		$archive_page_option = $this->settings->get_setting( $this->settings::SETTING_NAME_ARCHIVE );
+		$has_archive         = true;
 
 		if ( 'disabled' === $archive_page_option ) {
 			$has_archive = false;

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -288,19 +288,17 @@ class Story_Post_Type extends Post_Type_Base implements HasRequirements, HasMeta
 	 */
 	public function get_has_archive() {
 		$archive_page_option    = $this->settings->get_setting( $this->settings::SETTING_NAME_ARCHIVE );
-		$custom_archive_page_id = (int) $this->settings->get_setting( $this->settings::SETTING_NAME_ARCHIVE_PAGE_ID );
 		$has_archive            = true;
 
 		if ( 'disabled' === $archive_page_option ) {
 			$has_archive = false;
-		} elseif (
-			'custom' === $archive_page_option &&
-			$custom_archive_page_id &&
-			'publish' === get_post_status( $custom_archive_page_id )
-		) {
-			$uri = get_page_uri( $custom_archive_page_id );
-			if ( $uri ) {
-				$has_archive = urldecode( $uri );
+		} elseif ( 'custom' === $archive_page_option ) {
+			$custom_archive_page_id = (int) $this->settings->get_setting( $this->settings::SETTING_NAME_ARCHIVE_PAGE_ID );
+			if ( $custom_archive_page_id && 'publish' === get_post_status( $custom_archive_page_id ) ) {
+				$uri = get_page_uri( $custom_archive_page_id );
+				if ( $uri ) {
+					$has_archive = urldecode( $uri );
+				}
 			}
 		}
 

--- a/includes/Tracking.php
+++ b/includes/Tracking.php
@@ -137,15 +137,11 @@ class Tracking extends Service_Base {
 	/**
 	 * Initializes tracking.
 	 *
-	 * Registers the setting in WordPress.
+	 * Registers the script in WordPress.
 	 *
 	 * @since 1.0.0
 	 */
 	public function register(): void {
-		if ( ! $this->context->is_story_editor() && 'web-story' !== $this->context->get_screen_post_type() ) {
-			return;
-		}
-
 		// By not passing an actual script src we can print only the inline script.
 		$this->assets->register_script(
 			self::SCRIPT_HANDLE,
@@ -154,6 +150,10 @@ class Tracking extends Service_Base {
 			WEBSTORIES_VERSION,
 			false
 		);
+
+		if ( ! $this->context->is_story_editor() && 'web-story' !== $this->context->get_screen_post_type() ) {
+			return;
+		}
 
 		wp_add_inline_script(
 			self::SCRIPT_HANDLE,

--- a/includes/Tracking.php
+++ b/includes/Tracking.php
@@ -97,6 +97,13 @@ class Tracking extends Service_Base {
 	private WooCommerce $woocommerce;
 
 	/**
+	 * Context instance.
+	 *
+	 * @var Context Context instance.
+	 */
+	private Context $context;
+
+	/**
 	 * Tracking constructor.
 	 *
 	 * @since 1.4.0
@@ -107,6 +114,7 @@ class Tracking extends Service_Base {
 	 * @param Settings    $settings    Settings instance.
 	 * @param Preferences $preferences Preferences instance.
 	 * @param WooCommerce $woocommerce WooCommerce instance.
+	 * @param Context     $context     Context instance.
 	 */
 	public function __construct(
 		Experiments $experiments,
@@ -114,7 +122,8 @@ class Tracking extends Service_Base {
 		Assets $assets,
 		Settings $settings,
 		Preferences $preferences,
-		WooCommerce $woocommerce
+		WooCommerce $woocommerce,
+		Context $context
 	) {
 		$this->assets      = $assets;
 		$this->experiments = $experiments;
@@ -122,6 +131,7 @@ class Tracking extends Service_Base {
 		$this->settings    = $settings;
 		$this->preferences = $preferences;
 		$this->woocommerce = $woocommerce;
+		$this->context     = $context;
 	}
 
 	/**
@@ -132,6 +142,10 @@ class Tracking extends Service_Base {
 	 * @since 1.0.0
 	 */
 	public function register(): void {
+		if ( ! $this->context->is_story_editor() && 'web-story' !== $this->context->get_screen_post_type() ) {
+			return;
+		}
+
 		// By not passing an actual script src we can print only the inline script.
 		$this->assets->register_script(
 			self::SCRIPT_HANDLE,
@@ -155,7 +169,7 @@ class Tracking extends Service_Base {
 	 * @return string Registration action to use.
 	 */
 	public static function get_registration_action(): string {
-		return 'admin_init';
+		return 'admin_head';
 	}
 
 	/**

--- a/tests/phpunit/integration/tests/Integrations/Site_Kit.php
+++ b/tests/phpunit/integration/tests/Integrations/Site_Kit.php
@@ -72,7 +72,7 @@ class Site_Kit extends DependencyInjectedTestCase {
 		$this->instance->register();
 
 		$this->assertSame( 10, has_filter( 'googlesitekit_amp_gtag_opt', [ $this->instance, 'filter_site_kit_gtag_opt' ] ) );
-		$this->assertFalse( has_action( 'web_stories_print_analytics', [ $analytics, 'print_analytics_tag' ] ) );
+		$this->assertSame( 5, has_action( 'web_stories_print_analytics', [ $analytics, 'print_analytics_tag' ] ) );
 	}
 
 	/**

--- a/tests/phpunit/integration/tests/Integrations/Site_Kit.php
+++ b/tests/phpunit/integration/tests/Integrations/Site_Kit.php
@@ -72,7 +72,7 @@ class Site_Kit extends DependencyInjectedTestCase {
 		$this->instance->register();
 
 		$this->assertSame( 10, has_filter( 'googlesitekit_amp_gtag_opt', [ $this->instance, 'filter_site_kit_gtag_opt' ] ) );
-		$this->assertSame( 5, has_action( 'web_stories_print_analytics', [ $analytics, 'print_analytics_tag' ] ) );
+		$this->assertSame( 10, has_action( 'web_stories_print_analytics', [ $analytics, 'print_analytics_tag' ] ) );
 	}
 
 	/**

--- a/tests/phpunit/integration/tests/Tracking.php
+++ b/tests/phpunit/integration/tests/Tracking.php
@@ -26,6 +26,7 @@ use Google\Web_Stories\Experiments;
 use Google\Web_Stories\Integrations\Site_Kit;
 use Google\Web_Stories\Integrations\WooCommerce;
 use Google\Web_Stories\Settings;
+use Google\Web_Stories\Story_Post_Type;
 use Google\Web_Stories\User\Preferences;
 use PHPUnit\Framework\MockObject\MockObject;
 use WP_UnitTest_Factory;
@@ -69,6 +70,7 @@ class Tracking extends DependencyInjectedTestCase {
 		$assets            = $this->injector->make( Assets::class );
 		$settings          = $this->injector->make( Settings::class );
 		$preferences       = $this->injector->make( Preferences::class );
+		$context           = $this->injector->make( \Google\Web_Stories\Context::class );
 		$this->woocommerce = $this->createMock( WooCommerce::class );
 		$this->instance    = new \Google\Web_Stories\Tracking(
 			$this->experiments,
@@ -76,7 +78,8 @@ class Tracking extends DependencyInjectedTestCase {
 			$assets,
 			$settings,
 			$preferences,
-			$this->woocommerce
+			$this->woocommerce,
+			$context
 		);
 	}
 
@@ -84,6 +87,10 @@ class Tracking extends DependencyInjectedTestCase {
 	 * @covers ::register
 	 */
 	public function test_register_tracking_script(): void {
+		global $current_screen;
+
+		$current_screen = convert_to_screen( Story_Post_Type::POST_TYPE_SLUG );
+		
 		$this->site_kit->method( 'get_plugin_status' )->willReturn(
 			[
 				'installed'       => true,

--- a/tests/phpunit/integration/tests/Tracking.php
+++ b/tests/phpunit/integration/tests/Tracking.php
@@ -22,6 +22,7 @@ namespace Google\Web_Stories\Tests\Integration;
 
 use _WP_Dependency;
 use Google\Web_Stories\Assets;
+use Google\Web_Stories\Context;
 use Google\Web_Stories\Experiments;
 use Google\Web_Stories\Integrations\Site_Kit;
 use Google\Web_Stories\Integrations\WooCommerce;
@@ -70,7 +71,7 @@ class Tracking extends DependencyInjectedTestCase {
 		$assets            = $this->injector->make( Assets::class );
 		$settings          = $this->injector->make( Settings::class );
 		$preferences       = $this->injector->make( Preferences::class );
-		$context           = $this->injector->make( \Google\Web_Stories\Context::class );
+		$context           = $this->injector->make( Context::class );
 		$this->woocommerce = $this->createMock( WooCommerce::class );
 		$this->instance    = new \Google\Web_Stories\Tracking(
 			$this->experiments,
@@ -90,7 +91,7 @@ class Tracking extends DependencyInjectedTestCase {
 		global $current_screen;
 
 		$current_screen = convert_to_screen( Story_Post_Type::POST_TYPE_SLUG );
-		
+
 		$this->site_kit->method( 'get_plugin_status' )->willReturn(
 			[
 				'installed'       => true,


### PR DESCRIPTION
## Summary

This PR adds the use of `wp_prime_option_caches_by_group` to combine queries for `web-stories` related options on the dashboard.

## User-facing changes
None.

## Testing Instructions

This PR can be tested by following these steps:

1. Download the Query Monitor plugin.
2. Observe the Database queries on the Web Stories plugin dashboard.

<img width="1252" alt="image" src="https://github.com/GoogleForCreators/web-stories-wp/assets/75439077/4d5a3efc-6738-418d-99ab-572dd88572f6">

## Reviews

### Does this PR have a security-related impact?
No.

### Does this PR change what data or activity we track or use?
No.

### Does this PR have a legal-related impact?
No.

## Checklist

- [x] This PR addresses an existing issue and I have linked this PR to it
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

Fixes #13523 