### PR TITLE
Remove manual AMP runtime check from tests

### DIFF
--- a/packages/jest-amp/src/utils.js
+++ b/packages/jest-amp/src/utils.js
@@ -24,8 +24,6 @@ import AmpOptimizer, {
   TRANSFORMATIONS_AMP_FIRST,
 } from '@ampproject/toolbox-optimizer';
 import amphtmlValidator from 'amphtml-validator';
-// eslint-disable-next-line import/no-extraneous-dependencies -- Required by @ampproject/toolbox-optimizer anyway.
-import runtimeVersion from '@ampproject/toolbox-runtime-version';
 
 const fallback = tmpdir() + '/validator_wasm.js';
 const validatorJs =
@@ -125,7 +123,6 @@ async function getAMPValidationErrors(string, optimize = true) {
     });
     const params = {
       canonical: 'https://example.com',
-      ampRuntimeVersion: await runtimeVersion.currentVersion(),
     };
     completeString = await ampOptimizer.transformHtml(completeString, params);
   }


### PR DESCRIPTION
This check makes an external HTTP request which often fails. Quite annoying on CI.

Maybe it's not needed anymore?