### PR TITLE
WordPress 6.6 Compatibility

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -146,6 +146,16 @@ jobs:
             wp: 'latest'
             snapshots: true
             shard: '2/2'
+          - browser: 'chrome'
+            wp: '6.6-RC1'
+            snapshots: false
+            shard: '1/2'
+            experimental: true
+          - browser: 'chrome'
+            wp: '6.6-RC1'
+            snapshots: false
+            shard: '2/2'
+            experimental: true
 
     steps:
       - name: Harden Runner

--- a/packages/e2e-test-utils/src/publishPost.js
+++ b/packages/e2e-test-utils/src/publishPost.js
@@ -70,7 +70,7 @@ async function publishPost() {
       document.querySelector(
         '.editor-post-publish-button[aria-disabled="true"]'
       ).textContent === 'Update',
-    { timeout: 5000 }
+    { timeout: 10000 }
   );
 
   // The first time around the selector might return undefined.

--- a/packages/e2e-test-utils/src/publishPost.js
+++ b/packages/e2e-test-utils/src/publishPost.js
@@ -27,7 +27,7 @@ async function openPublishPanel() {
   if (isEntityPublishToggle) {
     await page.waitForSelector('.editor-entities-saved-states__save-button');
   } else {
-    await page.waitForSelector('.editor-post-publish-button');
+    await page.waitForSelector('.editor-post-publish-button__button');
   }
 }
 
@@ -67,9 +67,12 @@ async function publishPost() {
     () =>
       wp.data.select('core/editor').getEditedPostAttribute('status') ===
         'publish' &&
-      document.querySelector(
+      (document.querySelector(
         '.editor-post-publish-button__button[aria-disabled="true"]'
-      ).textContent === 'Save'
+      ).textContent === 'Save' ||
+        document.querySelector(
+          '.editor-post-publish-button__button[aria-disabled="true"]'
+        ).textContent === 'Update')
   );
 
   // The first time around the selector might return undefined.

--- a/packages/e2e-test-utils/src/publishPost.js
+++ b/packages/e2e-test-utils/src/publishPost.js
@@ -66,13 +66,7 @@ async function publishPost() {
   await page.waitForFunction(
     () =>
       wp.data.select('core/editor').getEditedPostAttribute('status') ===
-        'publish' &&
-      (document.querySelector(
-        '.editor-post-publish-button__button[aria-disabled="true"]'
-      ).textContent === 'Save' ||
-        document.querySelector(
-          '.editor-post-publish-button__button[aria-disabled="true"]'
-        ).textContent === 'Update')
+      'publish'
   );
 
   // The first time around the selector might return undefined.

--- a/packages/e2e-test-utils/src/publishPost.js
+++ b/packages/e2e-test-utils/src/publishPost.js
@@ -27,7 +27,7 @@ async function openPublishPanel() {
   if (isEntityPublishToggle) {
     await page.waitForSelector('.editor-entities-saved-states__save-button');
   } else {
-    await page.waitForSelector('.editor-post-publish-button__button');
+    await page.waitForSelector('.editor-post-publish-button');
   }
 }
 
@@ -60,13 +60,16 @@ async function publishPost() {
   }
 
   // Publish the post
-  await page.click('.editor-post-publish-button__button');
+  await page.click('.editor-post-publish-button');
 
   // Wait until the selector returns a truthy value.
   await page.waitForFunction(
     () =>
       wp.data.select('core/editor').getEditedPostAttribute('status') ===
-      'publish'
+        'publish' &&
+      document.querySelector(
+        '.editor-post-publish-button[aria-disabled="true"]'
+      ).textContent === 'Update'
   );
 
   // The first time around the selector might return undefined.

--- a/packages/e2e-test-utils/src/publishPost.js
+++ b/packages/e2e-test-utils/src/publishPost.js
@@ -69,7 +69,7 @@ async function publishPost() {
         'publish' &&
       document.querySelector(
         '.editor-post-publish-button__button[aria-disabled="true"]'
-      ).textContent === 'Update'
+      ).textContent === 'Save'
   );
 
   // The first time around the selector might return undefined.

--- a/packages/e2e-test-utils/src/publishPost.js
+++ b/packages/e2e-test-utils/src/publishPost.js
@@ -60,7 +60,7 @@ async function publishPost() {
   }
 
   // Publish the post
-  await page.click('.editor-post-publish-button');
+  await page.click('.editor-post-publish-button__button');
 
   // Wait until the selector returns a truthy value.
   await page.waitForFunction(
@@ -68,9 +68,8 @@ async function publishPost() {
       wp.data.select('core/editor').getEditedPostAttribute('status') ===
         'publish' &&
       document.querySelector(
-        '.editor-post-publish-button[aria-disabled="true"]'
-      ).textContent === 'Update',
-    { timeout: 10000 }
+        '.editor-post-publish-button__button[aria-disabled="true"]'
+      ).textContent === 'Update'
   );
 
   // The first time around the selector might return undefined.

--- a/packages/e2e-test-utils/src/publishPost.js
+++ b/packages/e2e-test-utils/src/publishPost.js
@@ -67,9 +67,12 @@ async function publishPost() {
     () =>
       wp.data.select('core/editor').getEditedPostAttribute('status') ===
         'publish' &&
-      document.querySelector(
+      (document.querySelector(
         '.editor-post-publish-button[aria-disabled="true"]'
-      ).textContent === 'Update'
+      ).textContent === 'Update' ||
+        document.querySelector(
+          '.editor-post-publish-button[aria-disabled="true"]'
+        ).textContent === 'Save')
   );
 
   // The first time around the selector might return undefined.

--- a/packages/e2e-test-utils/src/publishPost.js
+++ b/packages/e2e-test-utils/src/publishPost.js
@@ -69,7 +69,8 @@ async function publishPost() {
         'publish' &&
       document.querySelector(
         '.editor-post-publish-button[aria-disabled="true"]'
-      ).textContent === 'Update'
+      ).textContent === 'Update',
+    { timeout: 5000 }
   );
 
   // The first time around the selector might return undefined.

--- a/packages/e2e-tests/src/config/bootstrap.js
+++ b/packages/e2e-tests/src/config/bootstrap.js
@@ -126,6 +126,9 @@ const ALLOWED_ERROR_MESSAGES = [
   // Coming from <amp-story-player>
   // See https://github.com/ampproject/amphtml/blob/413457c3598f8c6694ca4ee7b83a5d84f9b9f00c/src/amp-story-player/amp-story-player-impl.js#L562
   "Unrecognized feature: 'web-share'",
+
+  // This is a known issue in core.
+  'You are importing createRoot from "react-dom" which is not supported.',
 ];
 
 export function addAllowedErrorMessage(message) {

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Web Stories ===
 
 Contributors:      google
-Tested up to:      6.5
+Tested up to:      6.6
 Requires at least: 6.4
 Stable tag:        V.V.V
 License:           Apache-2.0


### PR DESCRIPTION
## Summary

This PR updates tests to run against WP 6.6-RC1.


## User-facing changes
None.

## Testing Instructions
None.

## Reviews

### Does this PR have a security-related impact?
No.

### Does this PR change what data or activity we track or use?
No.

### Does this PR have a legal-related impact?
No.

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #13702 
