### PR TITLE
Animations: hardening to prevent animations on first page

### DIFF
--- a/includes/AMP/Story_Sanitizer.php
+++ b/includes/AMP/Story_Sanitizer.php
@@ -55,6 +55,7 @@ class Story_Sanitizer extends AMP_Base_Sanitizer {
 		$this->add_poster_images( $this->dom, $this->args['poster_images'] );
 		// This needs to be called before use_semantic_heading_tags() because it relies on the style attribute.
 		$this->deduplicate_inline_styles( $this->dom );
+		$this->disable_first_page_animations( $this->dom );
 		$this->add_video_cache( $this->dom, $this->args['video_cache'] );
 		$this->remove_blob_urls( $this->dom );
 		$this->sanitize_srcset( $this->dom );

--- a/includes/AMP/Traits/Sanitization_Utils.php
+++ b/includes/AMP/Traits/Sanitization_Utils.php
@@ -485,6 +485,12 @@ trait Sanitization_Utils {
 	 * @param Document|AMP_Document $document Document instance.
 	 */
 	private function disable_first_page_animations( $document ): void {
+		$animated_elements = $document->xpath->query( './/div[ contains( @class, "animation-wrapper" ) ]' );
+
+		if ( ! $animated_elements || 0 === $animated_elements->length ) {
+			return;
+		}
+
 		$style_element = $document->createElement( 'style' );
 
 		if ( ! $style_element ) {

--- a/includes/AMP/Traits/Sanitization_Utils.php
+++ b/includes/AMP/Traits/Sanitization_Utils.php
@@ -471,6 +471,33 @@ trait Sanitization_Utils {
 	}
 
 	/**
+	 * Adds CSS to reset animations for elements on the first page.
+	 *
+	 * Animations on the first page of a story are not allowed,
+	 * and removed at both the creation & serialization level (in the output package),
+	 * as well as the renderer (in AMP itself).
+	 *
+	 * This inline CSS adds another layer of defense, especially for older stories
+	 * that might still have some animation data on the first page.
+	 *
+	 * @since 1.43.0
+	 *
+	 * @param Document|AMP_Document $document Document instance.
+	 */
+	private function disable_first_page_animations( $document ): void {
+		$style_element = $document->createElement( 'style' );
+
+		if ( ! $style_element ) {
+			return;
+		}
+
+		$style_rule = $document->createTextNode( 'amp-story-page:first-of-type .animation-wrapper { --initial-opacity: 1; --initial-transform: none; }' );
+		$style_element->appendChild( $style_rule );
+
+		$document->head->appendChild( $style_element );
+	}
+
+	/**
 	 * Enables using video cache by adding the necessary attribute to `<amp-video>`
 	 *
 	 * @since 1.10.0

--- a/packages/output/src/story.tsx
+++ b/packages/output/src/story.tsx
@@ -102,10 +102,10 @@ function OutputStory({
           poster-portrait-src={featuredMediaUrl}
           background-audio={backgroundAudio?.resource?.src ?? undefined}
         >
-          {pages.map((page) => (
+          {pages.map((page, index) => (
             <OutputPage
               key={page.id}
-              page={page}
+              page={index === 0 ? { ...page, animations: undefined } : page}
               defaultAutoAdvance={autoAdvance}
               defaultPageDuration={defaultPageDuration}
               flags={flags}

--- a/packages/output/src/utils/test/getStoryMarkup.ts
+++ b/packages/output/src/utils/test/getStoryMarkup.ts
@@ -119,6 +119,54 @@ describe('getStoryMarkup', () => {
           } as TextElement,
         ],
       },
+      {
+        id: '2',
+        backgroundColor: { color: { r: 255, g: 255, b: 255 } },
+        animations: [
+          {
+            id: '1',
+            targets: ['2'],
+            type: AnimationType.Bounce,
+            duration: 1000,
+          },
+          { id: '2', targets: ['2'], type: AnimationType.Spin, duration: 1000 },
+        ],
+        elements: [
+          {
+            id: '2',
+            type: ElementType.Text,
+            x: 0,
+            y: 0,
+            width: 211,
+            height: 221,
+            rotationAngle: 1,
+            content: 'Hello World',
+            font: {
+              family: 'Roboto',
+              service: FontService.GoogleFonts,
+              fallbacks: ['Arial', 'sans-serif'],
+            },
+            color: {
+              color: {
+                r: 255,
+                g: 255,
+                b: 255,
+                a: 0.5,
+              },
+            },
+            padding: {
+              locked: false,
+              vertical: 0,
+              horizontal: 0,
+            },
+            marginOffset: 0,
+            fontSize: 10,
+            lineHeight: 1,
+            textAlign: 'center',
+            backgroundColor: { color: { r: 255, g: 255, b: 255 } },
+          } as TextElement,
+        ],
+      },
     ];
     const markup = getStoryMarkup(story, pages, metadata);
     expect(markup).toContain('Hello World');


### PR DESCRIPTION
## Summary

<!-- A brief description of what this PR does. -->

Addresses report at https://wordpress.org/support/topic/older-stories-have-blank-pages-elements-that-wont-load/

1st page animations are usually prevent in the editor, but one could still move a page with animations to the front. But then they would be prevented by the format itself. However, that doesn't seem to be the case (anymore?). This caused elements to be hidden in their pre-animation state.

This PR fixes this in two ways:

1. Do not wastefully print the actual animations markup for the first page. _This only applies when actively saving a story in the editor._
2. Add CSS to reset visibility of animated elements on the first page.  _This applies to any published story, avoiding the need to re-save a story to fix this._


## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
