### PR TITLE
Check read permissions and password protection in embed endpoint

### DIFF
--- a/includes/REST_API/Embed_Controller.php
+++ b/includes/REST_API/Embed_Controller.php
@@ -352,13 +352,33 @@ class Embed_Controller extends REST_Controller implements HasRequirements {
 	 * @return array{title: string, poster: string}|false Story metadata if the URL does belong to the current site. False otherwise.
 	 */
 	private function get_data_from_post( string $url ) {
+		$switched_blog = $this->maybe_switch_site( $url );
+
 		$post = $this->url_to_post( $url );
 
-		if ( ! $post || $this->story_post_type->get_slug() !== $post->post_type ) {
+		if ( ! $post instanceof WP_Post || $this->story_post_type->get_slug() !== $post->post_type ) {
+			if ( $switched_blog ) {
+				restore_current_blog();
+			}
+
 			return false;
 		}
 
-		return $this->get_data_from_document( $post->post_content );
+		if ( ( ! is_post_publicly_viewable( $post ) && ! current_user_can( 'read_post', $post->ID ) ) || post_password_required( $post ) ) {
+			if ( $switched_blog ) {
+				restore_current_blog();
+			}
+
+			return false;
+		}
+
+		$data = $this->get_data_from_document( $post->post_content );
+
+		if ( $switched_blog ) {
+			restore_current_blog();
+		}
+
+		return $data;
 	}
 
 	/**
@@ -376,10 +396,8 @@ class Embed_Controller extends REST_Controller implements HasRequirements {
 	 * @param string $url Permalink to check.
 	 * @return WP_Post|null Post object on success, null otherwise.
 	 */
-	private function url_to_post( $url ): ?WP_Post {
-		$post          = null;
-		$switched_blog = $this->maybe_switch_site( $url );
-
+	private function url_to_post( string $url ): ?WP_Post {
+		$post = null;
 
 		if ( \function_exists( 'wpcom_vip_url_to_postid' ) ) {
 			$post_id = wpcom_vip_url_to_postid( $url );
@@ -419,11 +437,11 @@ class Embed_Controller extends REST_Controller implements HasRequirements {
 			if ( $url_host && $home_url_host && $url_host === $home_url_host ) {
 				$values = [];
 				if (
-				preg_match(
-					'#[?&](' . preg_quote( $this->story_post_type->get_slug(), '#' ) . ')=([^&]+)#',
-					$url,
-					$values
-				)
+					preg_match(
+						'#[?&](' . preg_quote( $this->story_post_type->get_slug(), '#' ) . ')=([^&]+)#',
+						$url,
+						$values
+					)
 				) {
 					$slug = $values[2];
 
@@ -435,10 +453,6 @@ class Embed_Controller extends REST_Controller implements HasRequirements {
 					}
 				}
 			}
-		}
-
-		if ( $switched_blog ) {
-			restore_current_blog();
 		}
 
 		if ( ! $post instanceof WP_Post ) {

--- a/tests/phpunit/integration/tests/REST_API/Embed_Controller.php
+++ b/tests/phpunit/integration/tests/REST_API/Embed_Controller.php
@@ -38,6 +38,9 @@ class Embed_Controller extends DependencyInjectedRestTestCase {
 	public const VALID_URL                = 'https://preview.amp.dev/documentation/examples/introduction/stories_in_amp';
 
 	protected static int $story_id;
+	protected static int $draft_story_id;
+	protected static int $protected_story_id;
+	protected static int $private_story_id;
 	protected static int $subscriber;
 	protected static int $contributor;
 	protected static int $author;
@@ -85,12 +88,43 @@ class Embed_Controller extends DependencyInjectedRestTestCase {
 		remove_filter( 'content_save_pre', 'wp_filter_post_kses' );
 		remove_filter( 'content_filtered_save_pre', 'wp_filter_post_kses' );
 
-		$story_content  = file_get_contents( WEB_STORIES_TEST_DATA_DIR . '/story_post_content.html' );
+		$story_content  = (string) file_get_contents( WEB_STORIES_TEST_DATA_DIR . '/story_post_content.html' );
 		self::$story_id = $factory->post->create(
 			[
 				'post_type'    => Story_Post_Type::POST_TYPE_SLUG,
 				'post_title'   => 'Embed Controller Test Story',
 				'post_status'  => 'publish',
+				'post_content' => $story_content,
+			]
+		);
+
+		self::$draft_story_id = $factory->post->create(
+			[
+				'post_type'    => Story_Post_Type::POST_TYPE_SLUG,
+				'post_title'   => 'Draft Story',
+				'post_status'  => 'draft',
+				'post_author'  => self::$author,
+				'post_content' => $story_content,
+			]
+		);
+
+		self::$protected_story_id = $factory->post->create(
+			[
+				'post_type'     => Story_Post_Type::POST_TYPE_SLUG,
+				'post_title'    => 'Protected Story',
+				'post_status'   => 'publish',
+				'post_password' => 'secret',
+				'post_author'   => self::$admin,
+				'post_content'  => $story_content,
+			]
+		);
+
+		self::$private_story_id = $factory->post->create(
+			[
+				'post_type'    => Story_Post_Type::POST_TYPE_SLUG,
+				'post_title'   => 'Private Story',
+				'post_status'  => 'private',
+				'post_author'  => self::$author,
 				'post_content' => $story_content,
 			]
 		);
@@ -364,24 +398,12 @@ class Embed_Controller extends DependencyInjectedRestTestCase {
 	public function test_local_url_draft_without_permission(): void {
 		$this->controller->register();
 
-		$story_content  = (string) file_get_contents( WEB_STORIES_TEST_DATA_DIR . '/story_post_content.html' );
-		$draft_story_id = self::factory()->post->create(
-			[
-				'post_type'    => Story_Post_Type::POST_TYPE_SLUG,
-				'post_title'   => 'Draft Story',
-				'post_status'  => 'draft',
-				'post_author'  => self::$admin,
-				'post_content' => $story_content,
-			]
-		);
-		$this->assertNotWPError( $draft_story_id );
-
 		wp_set_current_user( self::$contributor );
 
 		$url      = add_query_arg(
 			[
 				'post_type' => Story_Post_Type::POST_TYPE_SLUG,
-				'p'         => $draft_story_id,
+				'p'         => self::$draft_story_id,
 			],
 			home_url()
 		);
@@ -393,24 +415,12 @@ class Embed_Controller extends DependencyInjectedRestTestCase {
 	public function test_local_url_draft_with_permission(): void {
 		$this->controller->register();
 
-		$story_content  = (string) file_get_contents( WEB_STORIES_TEST_DATA_DIR . '/story_post_content.html' );
-		$draft_story_id = self::factory()->post->create(
-			[
-				'post_type'    => Story_Post_Type::POST_TYPE_SLUG,
-				'post_title'   => 'Draft Story',
-				'post_status'  => 'draft',
-				'post_author'  => self::$author,
-				'post_content' => $story_content,
-			]
-		);
-		$this->assertNotWPError( $draft_story_id );
-
 		wp_set_current_user( self::$author );
 
 		$url      = add_query_arg(
 			[
 				'post_type' => Story_Post_Type::POST_TYPE_SLUG,
-				'p'         => $draft_story_id,
+				'p'         => self::$draft_story_id,
 			],
 			home_url()
 		);
@@ -431,25 +441,12 @@ class Embed_Controller extends DependencyInjectedRestTestCase {
 	public function test_local_url_password_protected(): void {
 		$this->controller->register();
 
-		$story_content      = (string) file_get_contents( WEB_STORIES_TEST_DATA_DIR . '/story_post_content.html' );
-		$protected_story_id = self::factory()->post->create(
-			[
-				'post_type'     => Story_Post_Type::POST_TYPE_SLUG,
-				'post_title'    => 'Protected Story',
-				'post_status'   => 'publish',
-				'post_password' => 'secret',
-				'post_author'   => self::$admin,
-				'post_content'  => $story_content,
-			]
-		);
-		$this->assertNotWPError( $protected_story_id );
-
 		wp_set_current_user( self::$editor );
 
 		$url      = add_query_arg(
 			[
 				'post_type' => Story_Post_Type::POST_TYPE_SLUG,
-				'p'         => $protected_story_id,
+				'p'         => self::$protected_story_id,
 			],
 			home_url()
 		);
@@ -461,24 +458,12 @@ class Embed_Controller extends DependencyInjectedRestTestCase {
 	public function test_local_url_private_story_without_permission(): void {
 		$this->controller->register();
 
-		$story_content    = (string) file_get_contents( WEB_STORIES_TEST_DATA_DIR . '/story_post_content.html' );
-		$private_story_id = self::factory()->post->create(
-			[
-				'post_type'    => Story_Post_Type::POST_TYPE_SLUG,
-				'post_title'   => 'Private Story',
-				'post_status'  => 'private',
-				'post_author'  => self::$admin,
-				'post_content' => $story_content,
-			]
-		);
-		$this->assertNotWPError( $private_story_id );
-
 		wp_set_current_user( self::$contributor );
 
 		$url      = add_query_arg(
 			[
 				'post_type' => Story_Post_Type::POST_TYPE_SLUG,
-				'p'         => $private_story_id,
+				'p'         => self::$private_story_id,
 			],
 			home_url()
 		);
@@ -490,24 +475,12 @@ class Embed_Controller extends DependencyInjectedRestTestCase {
 	public function test_local_url_private_story_with_permission(): void {
 		$this->controller->register();
 
-		$story_content    = (string) file_get_contents( WEB_STORIES_TEST_DATA_DIR . '/story_post_content.html' );
-		$private_story_id = self::factory()->post->create(
-			[
-				'post_type'    => Story_Post_Type::POST_TYPE_SLUG,
-				'post_title'   => 'Private Story',
-				'post_status'  => 'private',
-				'post_author'  => self::$author,
-				'post_content' => $story_content,
-			]
-		);
-		$this->assertNotWPError( $private_story_id );
-
 		wp_set_current_user( self::$author );
 
 		$url      = add_query_arg(
 			[
 				'post_type' => Story_Post_Type::POST_TYPE_SLUG,
-				'p'         => $private_story_id,
+				'p'         => self::$private_story_id,
 			],
 			home_url()
 		);
@@ -543,6 +516,9 @@ class Embed_Controller extends DependencyInjectedRestTestCase {
 
 		switch_to_blog( $blog_id );
 
+		remove_filter( 'content_save_pre', 'wp_filter_post_kses' );
+		remove_filter( 'content_filtered_save_pre', 'wp_filter_post_kses' );
+
 		$story_content  = (string) file_get_contents( WEB_STORIES_TEST_DATA_DIR . '/story_post_content.html' );
 		$draft_story_id = self::factory()->post->create(
 			[
@@ -554,6 +530,9 @@ class Embed_Controller extends DependencyInjectedRestTestCase {
 			]
 		);
 		$this->assertNotWPError( $draft_story_id );
+
+		add_filter( 'content_save_pre', 'wp_filter_post_kses' );
+		add_filter( 'content_filtered_save_pre', 'wp_filter_post_kses' );
 
 		$permalink = add_query_arg(
 			[

--- a/tests/phpunit/integration/tests/REST_API/Embed_Controller.php
+++ b/tests/phpunit/integration/tests/REST_API/Embed_Controller.php
@@ -39,6 +39,8 @@ class Embed_Controller extends DependencyInjectedRestTestCase {
 
 	protected static int $story_id;
 	protected static int $subscriber;
+	protected static int $contributor;
+	protected static int $author;
 	protected static int $editor;
 	protected static int $admin;
 
@@ -53,18 +55,28 @@ class Embed_Controller extends DependencyInjectedRestTestCase {
 	private \Google\Web_Stories\REST_API\Embed_Controller $controller;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ): void {
-		self::$subscriber = $factory->user->create(
+		self::$subscriber  = $factory->user->create(
 			[
 				'role' => 'subscriber',
 			]
 		);
-		self::$editor     = $factory->user->create(
+		self::$contributor = $factory->user->create(
+			[
+				'role' => 'contributor',
+			]
+		);
+		self::$author      = $factory->user->create(
+			[
+				'role' => 'author',
+			]
+		);
+		self::$editor      = $factory->user->create(
 			[
 				'role'       => 'editor',
 				'user_email' => 'editor@example.com',
 			]
 		);
-		self::$admin      = $factory->user->create(
+		self::$admin       = $factory->user->create(
 			[ 'role' => 'administrator' ]
 		);
 
@@ -347,6 +359,174 @@ class Embed_Controller extends DependencyInjectedRestTestCase {
 		$this->assertIsArray( $data );
 		$this->assertNotEmpty( $data );
 		$this->assertEqualSetsWithIndex( $expected, $data );
+	}
+
+	public function test_local_url_draft_without_permission(): void {
+		$this->controller->register();
+
+		$story_content  = (string) file_get_contents( WEB_STORIES_TEST_DATA_DIR . '/story_post_content.html' );
+		$draft_story_id = self::factory()->post->create(
+			[
+				'post_type'    => Story_Post_Type::POST_TYPE_SLUG,
+				'post_title'   => 'Draft Story',
+				'post_status'  => 'draft',
+				'post_author'  => self::$admin,
+				'post_content' => $story_content,
+			]
+		);
+		$this->assertNotWPError( $draft_story_id );
+
+		wp_set_current_user( self::$contributor );
+
+		$response = $this->dispatch_request( (string) get_permalink( $draft_story_id ) );
+
+		$this->assertErrorResponse( 'rest_invalid_url', $response, 404 );
+	}
+
+	public function test_local_url_draft_with_permission(): void {
+		$this->controller->register();
+
+		$story_content  = (string) file_get_contents( WEB_STORIES_TEST_DATA_DIR . '/story_post_content.html' );
+		$draft_story_id = self::factory()->post->create(
+			[
+				'post_type'    => Story_Post_Type::POST_TYPE_SLUG,
+				'post_title'   => 'Draft Story',
+				'post_status'  => 'draft',
+				'post_author'  => self::$author,
+				'post_content' => $story_content,
+			]
+		);
+		$this->assertNotWPError( $draft_story_id );
+
+		wp_set_current_user( self::$author );
+
+		$response = $this->dispatch_request( (string) get_permalink( $draft_story_id ) );
+		$data     = $response->get_data();
+
+		$expected = [
+			'title'  => '',
+			'poster' => 'https:/example.com/poster.png',
+		];
+
+		$this->assertEquals( 0, $this->request_count );
+		$this->assertIsArray( $data );
+		$this->assertNotEmpty( $data );
+		$this->assertEqualSetsWithIndex( $expected, $data );
+	}
+
+	public function test_local_url_password_protected(): void {
+		$this->controller->register();
+
+		$story_content      = (string) file_get_contents( WEB_STORIES_TEST_DATA_DIR . '/story_post_content.html' );
+		$protected_story_id = self::factory()->post->create(
+			[
+				'post_type'     => Story_Post_Type::POST_TYPE_SLUG,
+				'post_title'    => 'Protected Story',
+				'post_status'   => 'publish',
+				'post_password' => 'secret',
+				'post_author'   => self::$admin,
+				'post_content'  => $story_content,
+			]
+		);
+		$this->assertNotWPError( $protected_story_id );
+
+		wp_set_current_user( self::$editor );
+
+		$response = $this->dispatch_request( (string) get_permalink( $protected_story_id ) );
+
+		$this->assertErrorResponse( 'rest_invalid_url', $response, 404 );
+	}
+
+	public function test_local_url_private_story_without_permission(): void {
+		$this->controller->register();
+
+		$story_content    = (string) file_get_contents( WEB_STORIES_TEST_DATA_DIR . '/story_post_content.html' );
+		$private_story_id = self::factory()->post->create(
+			[
+				'post_type'    => Story_Post_Type::POST_TYPE_SLUG,
+				'post_title'   => 'Private Story',
+				'post_status'  => 'private',
+				'post_author'  => self::$admin,
+				'post_content' => $story_content,
+			]
+		);
+		$this->assertNotWPError( $private_story_id );
+
+		wp_set_current_user( self::$contributor );
+
+		$response = $this->dispatch_request( (string) get_permalink( $private_story_id ) );
+
+		$this->assertErrorResponse( 'rest_invalid_url', $response, 404 );
+	}
+
+	public function test_local_url_private_story_with_permission(): void {
+		$this->controller->register();
+
+		$story_content    = (string) file_get_contents( WEB_STORIES_TEST_DATA_DIR . '/story_post_content.html' );
+		$private_story_id = self::factory()->post->create(
+			[
+				'post_type'    => Story_Post_Type::POST_TYPE_SLUG,
+				'post_title'   => 'Private Story',
+				'post_status'  => 'private',
+				'post_author'  => self::$author,
+				'post_content' => $story_content,
+			]
+		);
+		$this->assertNotWPError( $private_story_id );
+
+		wp_set_current_user( self::$author );
+
+		$response = $this->dispatch_request( (string) get_permalink( $private_story_id ) );
+		$data     = $response->get_data();
+
+		$expected = [
+			'title'  => '',
+			'poster' => 'https:/example.com/poster.png',
+		];
+
+		$this->assertEquals( 0, $this->request_count );
+		$this->assertIsArray( $data );
+		$this->assertNotEmpty( $data );
+		$this->assertEqualSetsWithIndex( $expected, $data );
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_local_url_multisite_draft_without_permission(): void {
+		$this->controller->register();
+
+		$story_post_type = $this->injector->make( Story_Post_Type::class );
+		$story_post_type->register();
+
+		$blog_id = self::factory()->blog->create();
+		$this->assertNotWPError( $blog_id );
+
+		$user_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+		$this->assertNotWPError( $user_id );
+		wp_set_current_user( $user_id );
+
+		switch_to_blog( $blog_id );
+
+		$story_content  = (string) file_get_contents( WEB_STORIES_TEST_DATA_DIR . '/story_post_content.html' );
+		$draft_story_id = self::factory()->post->create(
+			[
+				'post_type'    => Story_Post_Type::POST_TYPE_SLUG,
+				'post_title'   => 'Draft Story',
+				'post_status'  => 'draft',
+				'post_author'  => self::$admin,
+				'post_content' => $story_content,
+			]
+		);
+		$this->assertNotWPError( $draft_story_id );
+
+		$permalink = (string) get_permalink( $draft_story_id );
+
+		restore_current_blog();
+
+		$response = $this->dispatch_request( $permalink );
+
+		$this->assertErrorResponse( 'rest_invalid_url', $response, 404 );
 	}
 
 	protected function dispatch_request( ?string $url = null ): WP_REST_Response {

--- a/tests/phpunit/integration/tests/REST_API/Embed_Controller.php
+++ b/tests/phpunit/integration/tests/REST_API/Embed_Controller.php
@@ -378,7 +378,14 @@ class Embed_Controller extends DependencyInjectedRestTestCase {
 
 		wp_set_current_user( self::$contributor );
 
-		$response = $this->dispatch_request( (string) get_permalink( $draft_story_id ) );
+		$url      = add_query_arg(
+			[
+				'post_type' => Story_Post_Type::POST_TYPE_SLUG,
+				'p'         => $draft_story_id,
+			],
+			home_url()
+		);
+		$response = $this->dispatch_request( $url );
 
 		$this->assertErrorResponse( 'rest_invalid_url', $response, 404 );
 	}
@@ -400,7 +407,14 @@ class Embed_Controller extends DependencyInjectedRestTestCase {
 
 		wp_set_current_user( self::$author );
 
-		$response = $this->dispatch_request( (string) get_permalink( $draft_story_id ) );
+		$url      = add_query_arg(
+			[
+				'post_type' => Story_Post_Type::POST_TYPE_SLUG,
+				'p'         => $draft_story_id,
+			],
+			home_url()
+		);
+		$response = $this->dispatch_request( $url );
 		$data     = $response->get_data();
 
 		$expected = [
@@ -432,7 +446,14 @@ class Embed_Controller extends DependencyInjectedRestTestCase {
 
 		wp_set_current_user( self::$editor );
 
-		$response = $this->dispatch_request( (string) get_permalink( $protected_story_id ) );
+		$url      = add_query_arg(
+			[
+				'post_type' => Story_Post_Type::POST_TYPE_SLUG,
+				'p'         => $protected_story_id,
+			],
+			home_url()
+		);
+		$response = $this->dispatch_request( $url );
 
 		$this->assertErrorResponse( 'rest_invalid_url', $response, 404 );
 	}
@@ -454,7 +475,14 @@ class Embed_Controller extends DependencyInjectedRestTestCase {
 
 		wp_set_current_user( self::$contributor );
 
-		$response = $this->dispatch_request( (string) get_permalink( $private_story_id ) );
+		$url      = add_query_arg(
+			[
+				'post_type' => Story_Post_Type::POST_TYPE_SLUG,
+				'p'         => $private_story_id,
+			],
+			home_url()
+		);
+		$response = $this->dispatch_request( $url );
 
 		$this->assertErrorResponse( 'rest_invalid_url', $response, 404 );
 	}
@@ -476,7 +504,14 @@ class Embed_Controller extends DependencyInjectedRestTestCase {
 
 		wp_set_current_user( self::$author );
 
-		$response = $this->dispatch_request( (string) get_permalink( $private_story_id ) );
+		$url      = add_query_arg(
+			[
+				'post_type' => Story_Post_Type::POST_TYPE_SLUG,
+				'p'         => $private_story_id,
+			],
+			home_url()
+		);
+		$response = $this->dispatch_request( $url );
 		$data     = $response->get_data();
 
 		$expected = [
@@ -520,7 +555,13 @@ class Embed_Controller extends DependencyInjectedRestTestCase {
 		);
 		$this->assertNotWPError( $draft_story_id );
 
-		$permalink = (string) get_permalink( $draft_story_id );
+		$permalink = add_query_arg(
+			[
+				'post_type' => Story_Post_Type::POST_TYPE_SLUG,
+				'p'         => $draft_story_id,
+			],
+			get_home_url( $blog_id )
+		);
 
 		restore_current_blog();
 


### PR DESCRIPTION
## Summary

Checks post read permissions and password protection when resolving local story embeds, and ensures site context is properly switched on multisite installations.

## User-facing changes

None.

## Testing Instructions

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?

Yes, addresses authorization and password protection checks in the REST API embed endpoint.

### Does this PR change what data or activity we track or use?

No.

### Does this PR have a legal-related impact?

No.

## Checklist

- [x] This PR addresses an existing issue and I have linked this PR to it
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

Fixes #14603
